### PR TITLE
Fix bug in `encode_constant` and simplify integers

### DIFF
--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -75,18 +75,8 @@ impl TaskEncoder for MirBuiltinEncoder {
         // TODO: this function is also useful for the type encoder, extract?
         fn int_name<'tcx>(ty: ty::Ty<'tcx>) -> &'static str {
             match ty.kind() {
-                ty::TyKind::Int(ty::IntTy::Isize) => "isize",
-                ty::TyKind::Int(ty::IntTy::I8) => "i8",
-                ty::TyKind::Int(ty::IntTy::I16) => "i16",
-                ty::TyKind::Int(ty::IntTy::I32) => "i32",
-                ty::TyKind::Int(ty::IntTy::I64) => "i64",
-                ty::TyKind::Int(ty::IntTy::I128) => "i128",
-                ty::TyKind::Uint(ty::UintTy::Usize) => "usize",
-                ty::TyKind::Uint(ty::UintTy::U8) => "u8",
-                ty::TyKind::Uint(ty::UintTy::U16) => "u16",
-                ty::TyKind::Uint(ty::UintTy::U32) => "u32",
-                ty::TyKind::Uint(ty::UintTy::U64) => "u64",
-                ty::TyKind::Uint(ty::UintTy::U128) => "u128",
+                ty::TyKind::Int(kind) => kind.name_str(),
+                ty::TyKind::Uint(kind) => kind.name_str(),
                 _ => unreachable!("non-integer type"),
             }
         }

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -501,7 +501,7 @@ impl<'vir, 'enc> EncoderVisitor<'vir, 'enc> {
                     ty::TyKind::Uint(uint_ty) => {
                         let scalar_val = const_val.try_to_scalar_int().unwrap();
                         self.vcx.alloc(vir::ExprData::Todo(
-                            vir::vir_format!(self.vcx, "s_Int_{}_cons({})", uint_ty.name_str(), scalar_val.try_to_uint(scalar_val.size()).unwrap()),
+                            vir::vir_format!(self.vcx, "s_Uint_{}_cons({})", uint_ty.name_str(), scalar_val.try_to_uint(scalar_val.size()).unwrap()),
                         ))
                     }
                     ty::TyKind::Bool => self.vcx.alloc(vir::ExprData::Todo(

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -492,9 +492,18 @@ impl<'vir, 'enc> EncoderVisitor<'vir, 'enc> {
                     ty::TyKind::Tuple(tys) if tys.len() == 0 => self.vcx.alloc(vir::ExprData::Todo(
                         vir::vir_format!(self.vcx, "s_Tuple0_cons()"),
                     )),
-                    ty::TyKind::Int(ty::IntTy::I32) => self.vcx.alloc(vir::ExprData::Todo(
-                        vir::vir_format!(self.vcx, "s_Int_i32_cons({})", const_val.try_to_scalar_int().unwrap()),
-                    )),
+                    ty::TyKind::Int(int_ty) => {
+                        let scalar_val = const_val.try_to_scalar_int().unwrap();
+                        self.vcx.alloc(vir::ExprData::Todo(
+                            vir::vir_format!(self.vcx, "s_Int_{}_cons({})", int_ty.name_str(), scalar_val.try_to_int(scalar_val.size()).unwrap()),
+                        ))
+                    }
+                    ty::TyKind::Uint(uint_ty) => {
+                        let scalar_val = const_val.try_to_scalar_int().unwrap();
+                        self.vcx.alloc(vir::ExprData::Todo(
+                            vir::vir_format!(self.vcx, "s_Int_{}_cons({})", uint_ty.name_str(), scalar_val.try_to_uint(scalar_val.size()).unwrap()),
+                        ))
+                    }
                     ty::TyKind::Bool => self.vcx.alloc(vir::ExprData::Todo(
                         vir::vir_format!(self.vcx, "s_Bool_cons({})", const_val.try_to_bool().unwrap()),
                     )),

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -696,9 +696,18 @@ impl<'vir, 'enc> Encoder<'vir, 'enc>
                             ty::TyKind::Tuple(tys) if tys.len() == 0 => self.vcx.alloc(ExprRetData::Todo(
                                 vir::vir_format!(self.vcx, "s_Tuple0_cons()"),
                             )),
-                            ty::TyKind::Int(ty::IntTy::I32) => self.vcx.alloc(ExprRetData::Todo(
-                                vir::vir_format!(self.vcx, "s_Int_i32_cons({})", const_val.try_to_scalar_int().unwrap()),
-                            )),
+                            ty::TyKind::Int(int_ty) => {
+                                let scalar_val = const_val.try_to_scalar_int().unwrap();
+                                self.vcx.alloc(ExprRetData::Todo(
+                                    vir::vir_format!(self.vcx, "s_Int_{}_cons({})", int_ty.name_str(), scalar_val.try_to_int(scalar_val.size()).unwrap()),
+                                ))
+                            }
+                            ty::TyKind::Uint(uint_ty) => {
+                                let scalar_val = const_val.try_to_scalar_int().unwrap();
+                                self.vcx.alloc(ExprRetData::Todo(
+                                    vir::vir_format!(self.vcx, "s_Int_{}_cons({})", uint_ty.name_str(), scalar_val.try_to_uint(scalar_val.size()).unwrap()),
+                                ))
+                            }
                             ty::TyKind::Bool => self.vcx.alloc(ExprRetData::Todo(
                                 vir::vir_format!(self.vcx, "s_Bool_cons({})", const_val.try_to_bool().unwrap()),
                             )),

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -628,20 +628,31 @@ impl<'vir, 'enc> Encoder<'vir, 'enc>
                             rhs: self.encode_operand(curr_ver, r),
                         })))],
                     ),
-                    mir::BinOp::Gt => self.vcx.mk_func_app(
-                        "s_Bool_cons", // TODO: go through type encoder
-                        &[self.vcx.alloc(ExprRetData::BinOp(self.vcx.alloc(vir::BinOpGenData {
-                            kind: vir::BinOpKind::CmpGt,
-                            lhs: self.vcx.mk_func_app(
-                                "s_Int_i32_val",
-                                &[self.encode_operand(curr_ver, l)],
-                            ),
-                            rhs: self.vcx.mk_func_app(
-                                "s_Int_i32_val",
-                                &[self.encode_operand(curr_ver, r)],
-                            ),
-                        })))],
-                    ),
+                    mir::BinOp::Gt => {
+                        let ty_l = self.deps.require_ref::<crate::encoders::TypeEncoder>(
+                            l.ty(self.body, self.vcx.tcx),
+                        ).unwrap();
+                        let ty_l = vir::vir_format!(self.vcx, "{}_val", ty_l.snapshot_name); // TODO: get the `_val` function differently
+                        let ty_r = self.deps.require_ref::<crate::encoders::TypeEncoder>(
+                            r.ty(self.body, self.vcx.tcx),
+                        ).unwrap();
+                        let ty_r = vir::vir_format!(self.vcx, "{}_val", ty_r.snapshot_name); // TODO: get the `_val` function differently
+
+                        self.vcx.mk_func_app(
+                            "s_Bool_cons", // TODO: go through type encoder
+                            &[self.vcx.alloc(ExprRetData::BinOp(self.vcx.alloc(vir::BinOpGenData {
+                                kind: vir::BinOpKind::CmpGt,
+                                lhs: self.vcx.mk_func_app(
+                                    ty_l,
+                                    &[self.encode_operand(curr_ver, l)],
+                                ),
+                                rhs: self.vcx.mk_func_app(
+                                    ty_r,
+                                    &[self.encode_operand(curr_ver, r)],
+                                ),
+                            })))],
+                        )
+                    }
                     k => todo!("binop {k:?}"),
                 }
             }

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -705,7 +705,7 @@ impl<'vir, 'enc> Encoder<'vir, 'enc>
                             ty::TyKind::Uint(uint_ty) => {
                                 let scalar_val = const_val.try_to_scalar_int().unwrap();
                                 self.vcx.alloc(ExprRetData::Todo(
-                                    vir::vir_format!(self.vcx, "s_Int_{}_cons({})", uint_ty.name_str(), scalar_val.try_to_uint(scalar_val.size()).unwrap()),
+                                    vir::vir_format!(self.vcx, "s_Uint_{}_cons({})", uint_ty.name_str(), scalar_val.try_to_uint(scalar_val.size()).unwrap()),
                                 ))
                             }
                             ty::TyKind::Bool => self.vcx.alloc(ExprRetData::Todo(

--- a/prusti-encoder/src/encoders/typ.rs
+++ b/prusti-encoder/src/encoders/typ.rs
@@ -64,18 +64,7 @@ impl<'vir> TypeEncoderOutputRef<'vir> {
                 //    vcx.alloc(vir::ConstData::Bool(val != 0)),
                 //)));
             }
-            "s_Uint_usize" => "s_Uint_usize_cons",
-            "s_Uint_u8" => "s_Uint_u8_cons",
-            "s_Uint_u16" => "s_Uint_u16_cons",
-            "s_Uint_u32" => "s_Uint_u32_cons",
-            "s_Uint_u64" => "s_Uint_u64_cons",
-            "s_Uint_u128" => "s_Uint_u128_cons",
-            "s_Int_isize" => "s_Int_isize_cons",
-            "s_Int_i8" => "s_Int_i8_cons",
-            "s_Int_i16" => "s_Int_i16_cons",
-            "s_Int_i32" => "s_Int_i32_cons",
-            "s_Int_i64" => "s_Int_i64_cons",
-            "s_Int_i128" => "s_Int_i128_cons",
+            name if name.starts_with("s_Int_") => vir::with_vcx(|vcx| vir::vir_format!(vcx, "{name}_cons")),
             k => todo!("unsupported type in expr_from_u128 {k:?}"),
         };
         vir::with_vcx(|vcx| vcx.mk_func_app(
@@ -681,15 +670,15 @@ impl TaskEncoder for TypeEncoder {
                     method_reassign: mk_reassign(vcx, "p_Bool", ty_s),
                 }, ()))
             }
-            TyKind::Int(int_kind) => {
-                let (name_s, name_p) = match int_kind {
-                    ty::IntTy::Isize => ("s_Int_isize", "p_Int_isize"),
-                    ty::IntTy::I8 => ("s_Int_i8", "p_Int_i8"),
-                    ty::IntTy::I16 => ("s_Int_i16", "p_Int_i16"),
-                    ty::IntTy::I32 => ("s_Int_i32", "p_Int_i32"),
-                    ty::IntTy::I64 => ("s_Int_i64", "p_Int_i64"),
-                    ty::IntTy::I128 => ("s_Int_i128", "p_Int_i128"),
+            TyKind::Int(_) |
+            TyKind::Uint(_) => {
+                let name_str = match task_key.kind() {
+                    TyKind::Int(kind) => kind.name_str(),
+                    TyKind::Uint(kind) => kind.name_str(),
+                    _ => unreachable!(),
                 };
+                let name_s = vir::vir_format!(vcx, "s_Int_{name_str}");
+                let name_p = vir::vir_format!(vcx, "p_Int_{name_str}");
                 let name_cons = vir::vir_format!(vcx, "{name_s}_cons");
                 let name_val = vir::vir_format!(vcx, "{name_s}_val");
                 let name_field = vir::vir_format!(vcx, "f_{name_s}");
@@ -714,48 +703,6 @@ impl TaskEncoder for TypeEncoder {
                         function [name_cons](Int): [ty_s];
                         function [name_val]([ty_s]): Int;
                         axiom_inverse([name_val], [name_cons], Int);
-                    } },
-                    predicate: mk_simple_predicate(vcx, name_p, name_field),
-                    function_unreachable: mk_unreachable(vcx, name_s, ty_s),
-                    function_snap: mk_snap(vcx, name_p, name_s, Some(name_field), ty_s),
-                    //method_refold: mk_refold(vcx, name_p, ty_s),
-                    field_projection_p: &[],
-                    method_assign: mk_assign(vcx, name_p, ty_s),
-                    method_reassign: mk_reassign(vcx, name_p, ty_s),
-                }, ()))
-            }
-            TyKind::Uint(int_kind) => {
-                let (name_s, name_p) = match int_kind {
-                    ty::UintTy::Usize => ("s_Uint_usize", "p_Uint_usize"),
-                    ty::UintTy::U8 => ("s_Uint_u8", "p_Uint_u8"),
-                    ty::UintTy::U16 => ("s_Uint_u16", "p_Uint_u16"),
-                    ty::UintTy::U32 => ("s_Uint_u32", "p_Uint_u32"),
-                    ty::UintTy::U64 => ("s_Uint_u64", "p_Uint_u64"),
-                    ty::UintTy::U128 => ("s_Uint_u128", "p_Uint_u128"),
-                };
-                let name_cons = vir::vir_format!(vcx, "{name_s}_cons");
-                let name_val = vir::vir_format!(vcx, "{name_s}_val");
-                let name_field = vir::vir_format!(vcx, "f_{name_s}");
-                let ty_s = vcx.alloc(vir::TypeData::Domain(name_s));
-                deps.emit_output_ref::<Self>(*task_key, TypeEncoderOutputRef {
-                    snapshot_name: name_s,
-                    predicate_name: name_p,
-                    snapshot: ty_s,
-                    function_unreachable: vir::vir_format!(vcx, "{name_s}_unreachable"),
-                    function_snap: vir::vir_format!(vcx, "{name_p}_snap"),
-                    //method_refold: vir::vir_format!(vcx, "refold_{name_p}"),
-                    specifics: TypeEncoderOutputRefSub::Primitive,
-                    method_assign: vir::vir_format!(vcx, "assign_{name_p}"),
-                    method_reassign: vir::vir_format!(vcx, "reassign_{name_p}"),
-                });
-                Ok((TypeEncoderOutput {
-                    fields: vcx.alloc_slice(&[vcx.alloc(vir::FieldData {
-                        name: vir::vir_format!(vcx, "f_{name_s}"),
-                        ty: ty_s,
-                    })]),
-                    snapshot: vir::vir_domain! { vcx; domain [name_s] {
-                        function [name_cons](Int): [ty_s];
-                        function [name_val]([ty_s]): Int;
                     } },
                     predicate: mk_simple_predicate(vcx, name_p, name_field),
                     function_unreachable: mk_unreachable(vcx, name_s, ty_s),

--- a/prusti-encoder/src/encoders/typ.rs
+++ b/prusti-encoder/src/encoders/typ.rs
@@ -64,7 +64,8 @@ impl<'vir> TypeEncoderOutputRef<'vir> {
                 //    vcx.alloc(vir::ConstData::Bool(val != 0)),
                 //)));
             }
-            name if name.starts_with("s_Int_") => vir::with_vcx(|vcx| vir::vir_format!(vcx, "{name}_cons")),
+            name if name.starts_with("s_Int_") || name.starts_with("s_Uint_") =>
+                vir::with_vcx(|vcx| vir::vir_format!(vcx, "{name}_cons")),
             k => todo!("unsupported type in expr_from_u128 {k:?}"),
         };
         vir::with_vcx(|vcx| vcx.mk_func_app(
@@ -672,13 +673,13 @@ impl TaskEncoder for TypeEncoder {
             }
             TyKind::Int(_) |
             TyKind::Uint(_) => {
-                let name_str = match task_key.kind() {
-                    TyKind::Int(kind) => kind.name_str(),
-                    TyKind::Uint(kind) => kind.name_str(),
+                let (sign, name_str) = match task_key.kind() {
+                    TyKind::Int(kind) => ("Int", kind.name_str()),
+                    TyKind::Uint(kind) => ("Uint", kind.name_str()),
                     _ => unreachable!(),
                 };
-                let name_s = vir::vir_format!(vcx, "s_Int_{name_str}");
-                let name_p = vir::vir_format!(vcx, "p_Int_{name_str}");
+                let name_s = vir::vir_format!(vcx, "s_{sign}_{name_str}");
+                let name_p = vir::vir_format!(vcx, "p_{sign}_{name_str}");
                 let name_cons = vir::vir_format!(vcx, "{name_s}_cons");
                 let name_val = vir::vir_format!(vcx, "{name_s}_val");
                 let name_field = vir::vir_format!(vcx, "f_{name_s}");


### PR DESCRIPTION
@Aurel300 
The bug is that `-1` is printed as `4294967295`, caused by directly printing the results of `try_to_scalar_int` which just represents the bytes of the number, for integers we still need to turn this `u128` to a `i128` (done here by `try_to_int`).