### PR TITLE
Implement function identifiers, use type encoder in more places

### DIFF
--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -6,7 +6,8 @@ use task_encoder::{
     TaskEncoder,
     TaskEncoderDependencies,
 };
-use vir::{BOOL_CONS, vir_snapshot_constructor_name};
+use crate::encoders::typ::BOOL_CONS;
+use vir::{vir_snapshot_constructor_name};
 
 pub struct MirBuiltinEncoder;
 
@@ -106,7 +107,7 @@ impl TaskEncoder for MirBuiltinEncoder {
                             pres: &[],
                             posts: &[],
                             expr: Some(vcx.mk_typed_func_app(
-                                vir::BOOL_CONS,
+                                BOOL_CONS,
                                 vcx.alloc(vir::ExprData::UnOp(vcx.alloc(vir::UnOpData {
                                     kind: vir::UnOpKind::Not,
                                     expr: vcx.mk_func_app(

--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -6,6 +6,7 @@ use task_encoder::{
     TaskEncoder,
     TaskEncoderDependencies,
 };
+use vir::{BOOL_CONS, vir_snapshot_constructor_name};
 
 pub struct MirBuiltinEncoder;
 
@@ -104,15 +105,15 @@ impl TaskEncoder for MirBuiltinEncoder {
                             ret: ty_s,
                             pres: &[],
                             posts: &[],
-                            expr: Some(vcx.mk_func_app(
-                                "s_Bool_cons",
-                                &[vcx.alloc(vir::ExprData::UnOp(vcx.alloc(vir::UnOpData {
+                            expr: Some(vcx.mk_typed_func_app(
+                                vir::BOOL_CONS,
+                                vcx.alloc(vir::ExprData::UnOp(vcx.alloc(vir::UnOpData {
                                     kind: vir::UnOpKind::Not,
                                     expr: vcx.mk_func_app(
                                         "s_Bool_val",
                                         &[vcx.mk_local_ex("arg")],
                                     ),
-                                })))],
+                                }))),
                             )),
                         }),
                     }, ()))
@@ -138,7 +139,7 @@ impl TaskEncoder for MirBuiltinEncoder {
                             pres: &[],
                             posts: &[],
                             expr: Some(vcx.mk_func_app(
-                                vir::vir_format!(vcx, "{}_cons", ty_out.snapshot_name),
+                                vir_snapshot_constructor_name!(vcx, ty_out.snapshot_name),
                                 &[vcx.alloc(vir::ExprData::UnOp(vcx.alloc(vir::UnOpData {
                                     kind: vir::UnOpKind::Neg,
                                     expr: vcx.mk_func_app(
@@ -172,7 +173,7 @@ impl TaskEncoder for MirBuiltinEncoder {
                             pres: &[],
                             posts: &[],
                             expr: Some(vcx.mk_func_app(
-                                vir::vir_format!(vcx, "{}_cons", ty_out.snapshot_name),
+                                vir::vir_snapshot_constructor_name!(vcx,ty_out.snapshot_name),
                                 &[vcx.alloc(vir::ExprData::BinOp(vcx.alloc(vir::BinOpData {
                                     kind: vir::BinOpKind::Add,
                                     lhs: vcx.mk_func_app(
@@ -215,10 +216,10 @@ impl TaskEncoder for MirBuiltinEncoder {
                             pres: &[],
                             posts: &[],
                             expr: Some(vcx.mk_func_app(
-                                vir::vir_format!(vcx, "{}_cons", ty_out.snapshot_name),
+                                vir::vir_snapshot_constructor_name!(vcx,ty_out.snapshot_name),
                                 &[
                                     vcx.mk_func_app(
-                                        vir::vir_format!(vcx, "{}_cons", ty_in.snapshot_name),
+                                        vir::vir_snapshot_constructor_name!(vcx,ty_in.snapshot_name),
                                         &[vcx.alloc(vir::ExprData::BinOp(vcx.alloc(vir::BinOpData {
                                             kind: vir::BinOpKind::Add,
                                             lhs: vcx.mk_func_app(
@@ -232,9 +233,9 @@ impl TaskEncoder for MirBuiltinEncoder {
                                         })))],
                                     ),
                                     // TODO: overflow condition!
-                                    vcx.mk_func_app(
-                                        "s_Bool_cons",
-                                        &[&vir::ExprData::Const(&vir::ConstData::Bool(false))],
+                                    vcx.mk_typed_func_app(
+                                        BOOL_CONS,
+                                        &vir::ExprData::Const(&vir::ConstData::Bool(false))
                                     ),
                                 ],
                             )),

--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -184,7 +184,7 @@ impl TaskEncoder for MirBuiltinEncoder {
                                         vir::vir_format!(vcx, "{}_val", ty_out.snapshot_name),
                                         &[vcx.mk_local_ex("arg2")],
                                     ),
-                                })),)]
+                                })))]
                             )),
                         }),
                     }, ()))

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -13,7 +13,8 @@ use task_encoder::{
     TaskEncoder,
     TaskEncoderDependencies,
 };
-use vir::{Reify, BOOL_CONS};
+use crate::encoders::typ::BOOL_CONS;
+use vir::{Reify};
 
 pub struct MirImpureEncoder;
 

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -8,6 +8,7 @@ use task_encoder::{
     TaskEncoder,
     TaskEncoderDependencies,
 };
+use vir::BOOL_CONS;
 use std::collections::HashMap;
 
 pub struct MirPureEncoder;
@@ -551,14 +552,13 @@ impl<'vir, 'enc> Encoder<'vir, 'enc>
                             ))
                             .lift();
 
-                        // TODO: use type encoder
-                        let forall = self.vcx.mk_func_app(
-                            "s_Bool_cons",
-                            &[self.vcx.alloc(ExprRetData::Forall(self.vcx.alloc(vir::ForallGenData {
+                        let forall = self.vcx.mk_typed_func_app(
+                            BOOL_CONS,
+                            self.vcx.alloc(ExprRetData::Forall(self.vcx.alloc(vir::ForallGenData {
                                 qvars,
                                 triggers: &[], // TODO
                                 body,
-                            })))],
+                            }))),
                         );
 
                         let mut term_update = Update::new();
@@ -620,13 +620,13 @@ impl<'vir, 'enc> Encoder<'vir, 'enc>
             // Cast
             mir::Rvalue::BinaryOp(op, box (l, r)) => {
                 match op {
-                    mir::BinOp::Eq => self.vcx.mk_func_app(
-                        "s_Bool_cons", // TODO: go through type encoder
-                        &[self.vcx.alloc(ExprRetData::BinOp(self.vcx.alloc(vir::BinOpGenData {
+                    mir::BinOp::Eq => self.vcx.mk_typed_func_app(
+                        BOOL_CONS,
+                        self.vcx.alloc(ExprRetData::BinOp(self.vcx.alloc(vir::BinOpGenData {
                             kind: vir::BinOpKind::CmpEq,
                             lhs: self.encode_operand(curr_ver, l),
                             rhs: self.encode_operand(curr_ver, r),
-                        })))],
+                        }))),
                     ),
                     mir::BinOp::Gt => {
                         let ty_l = self.deps.require_ref::<crate::encoders::TypeEncoder>(
@@ -638,9 +638,9 @@ impl<'vir, 'enc> Encoder<'vir, 'enc>
                         ).unwrap();
                         let ty_r = vir::vir_format!(self.vcx, "{}_val", ty_r.snapshot_name); // TODO: get the `_val` function differently
 
-                        self.vcx.mk_func_app(
-                            "s_Bool_cons", // TODO: go through type encoder
-                            &[self.vcx.alloc(ExprRetData::BinOp(self.vcx.alloc(vir::BinOpGenData {
+                        self.vcx.mk_typed_func_app(
+                            BOOL_CONS,
+                            self.vcx.alloc(ExprRetData::BinOp(self.vcx.alloc(vir::BinOpGenData {
                                 kind: vir::BinOpKind::CmpGt,
                                 lhs: self.vcx.mk_func_app(
                                     ty_l,
@@ -650,7 +650,7 @@ impl<'vir, 'enc> Encoder<'vir, 'enc>
                                     ty_r,
                                     &[self.encode_operand(curr_ver, r)],
                                 ),
-                            })))],
+                            }))),
                         )
                     }
                     k => todo!("binop {k:?}"),

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -8,7 +8,7 @@ use task_encoder::{
     TaskEncoder,
     TaskEncoderDependencies,
 };
-use vir::BOOL_CONS;
+use crate::encoders::typ::BOOL_CONS;
 use std::collections::HashMap;
 
 pub struct MirPureEncoder;

--- a/prusti-encoder/src/encoders/typ.rs
+++ b/prusti-encoder/src/encoders/typ.rs
@@ -33,7 +33,7 @@ pub struct TypeEncoderOutputRef<'vir> {
     pub snapshot_name: &'vir str,
     pub predicate_name: &'vir str,
     pub snapshot: vir::Type<'vir>,
-    pub function_unreachable: &'vir str,
+    pub function_unreachable: FunctionIdentifier<'vir, vir::Nullary>,
     pub function_snap: FunctionIdentifier<'vir, vir::Unary>,
     //pub method_refold: &'vir str,
     pub specifics: TypeEncoderOutputRefSub<'vir>,
@@ -60,7 +60,7 @@ macro_rules! builtin_snapshot_constructor {
     }
 }
 
-pub const BOOL_CONS: FunctionIdentifier<'static, vir::Unary> = FunctionIdentifier(builtin_snapshot_constructor!("Bool"), PhantomData);
+pub const BOOL_CONS: FunctionIdentifier<'static, vir::Unary> = FunctionIdentifier::new(builtin_snapshot_constructor!("Bool"));
 
 impl<'vir> TypeEncoderOutputRef<'vir> {
     pub fn expect_structlike(&self) -> &TypeEncoderOutputRefSubStruct<'vir> {
@@ -379,8 +379,8 @@ impl TaskEncoder for TypeEncoder {
                 snapshot_name: name_s,
                 predicate_name: name_p,
                 snapshot: vcx.alloc(vir::TypeData::Domain(name_s)),
-                function_unreachable: vir::vir_format!(vcx, "{name_s}_unreachable"),
-                function_snap: FunctionIdentifier(vir::vir_format!(vcx, "{name_p}_snap"), PhantomData),
+                function_unreachable: FunctionIdentifier::new(vir::vir_format!(vcx, "{name_s}_unreachable")),
+                function_snap: FunctionIdentifier::new(vir::vir_format!(vcx, "{name_p}_snap")),
                 //method_refold: vir::vir_format!(vcx, "refold_{name_p}"),
                 specifics: TypeEncoderOutputRefSub::StructLike(TypeEncoderOutputRefSubStruct {
                     field_read: field_read_names,
@@ -662,8 +662,8 @@ impl TaskEncoder for TypeEncoder {
                     snapshot_name: "s_Bool",
                     predicate_name: "p_Bool",
                     snapshot: ty_s,
-                    function_unreachable: "s_Bool_unreachable",
-                    function_snap: FunctionIdentifier("p_Bool_snap", PhantomData),
+                    function_unreachable: FunctionIdentifier::new("s_Bool_unreachable"),
+                    function_snap: FunctionIdentifier::new("p_Bool_snap"),
                     //method_refold: "refold_p_Bool",
                     specifics: TypeEncoderOutputRefSub::Primitive,
                     method_assign: "assign_p_Bool",
@@ -705,8 +705,8 @@ impl TaskEncoder for TypeEncoder {
                     snapshot_name: name_s,
                     predicate_name: name_p,
                     snapshot: ty_s,
-                    function_unreachable: vir::vir_format!(vcx, "{name_s}_unreachable"),
-                    function_snap: FunctionIdentifier(vir::vir_format!(vcx, "{name_p}_snap"), PhantomData),
+                    function_unreachable: FunctionIdentifier::new(vir::vir_format!(vcx, "{name_s}_unreachable")),
+                    function_snap: FunctionIdentifier::new(vir::vir_format!(vcx, "{name_p}_snap")),
                     //method_refold: vir::vir_format!(vcx, "refold_{name_p}"),
                     specifics: TypeEncoderOutputRefSub::Primitive,
                     method_assign: vir::vir_format!(vcx, "assign_{name_p}"),
@@ -738,8 +738,8 @@ impl TaskEncoder for TypeEncoder {
                     snapshot_name: "s_Tuple0",
                     predicate_name: "p_Tuple0",
                     snapshot: ty_s,
-                    function_unreachable: "s_Tuple0_unreachable",
-                    function_snap: FunctionIdentifier("p_Tuple0_snap", PhantomData),
+                    function_unreachable: FunctionIdentifier::new("s_Tuple0_unreachable"),
+                    function_snap: FunctionIdentifier::new("p_Tuple0_snap"),
                     //method_refold: "refold_p_Tuple0",
                     specifics: TypeEncoderOutputRefSub::Primitive,
                     method_assign: vir::vir_format!(vcx, "assign_p_Tuple0"),
@@ -822,8 +822,8 @@ impl TaskEncoder for TypeEncoder {
                     snapshot_name: param_out.snapshot_param_name,
                     predicate_name: param_out.predicate_param_name,
                     snapshot: ty_s,
-                    function_unreachable: "s_Param_unreachable",
-                    function_snap: FunctionIdentifier("p_Param_snap", PhantomData),
+                    function_unreachable: FunctionIdentifier::new("s_Param_unreachable"),
+                    function_snap: FunctionIdentifier::new("p_Param_snap"),
                     //method_refold: "refold_p_Param",
                     specifics: TypeEncoderOutputRefSub::Primitive,
                     method_assign: vir::vir_format!(vcx, "assign_p_Bool"),
@@ -865,8 +865,8 @@ impl TaskEncoder for TypeEncoder {
                     snapshot_name: "s_Never",
                     predicate_name: "p_Never",
                     snapshot: ty_s,
-                    function_unreachable: "s_Never_unreachable",
-                    function_snap: FunctionIdentifier("p_Never_snap", PhantomData),
+                    function_unreachable: FunctionIdentifier::new("s_Never_unreachable"),
+                    function_snap: FunctionIdentifier::new("p_Never_snap"),
                     //method_refold: "refold_p_Never",
                     specifics: TypeEncoderOutputRefSub::Primitive,
                     method_assign: vir::vir_format!(vcx, "assign_p_Never"),

--- a/prusti-encoder/src/encoders/typ.rs
+++ b/prusti-encoder/src/encoders/typ.rs
@@ -33,9 +33,9 @@ pub struct TypeEncoderOutputRef<'vir> {
     pub snapshot_name: &'vir str,
     pub predicate_name: &'vir str,
     pub snapshot: vir::Type<'vir>,
-    pub snapshot_constructor: FunctionIdentifier<'vir, vir::Unknown>,
-    pub function_unreachable: FunctionIdentifier<'vir, vir::Nullary>,
-    pub function_snap: FunctionIdentifier<'vir, vir::Unary>,
+    pub snapshot_constructor: FunctionIdentifier<'vir, vir::UnknownArgs>,
+    pub function_unreachable: FunctionIdentifier<'vir, vir::NullaryArgs>,
+    pub function_snap: FunctionIdentifier<'vir, vir::UnaryArgs>,
     //pub method_refold: &'vir str,
     pub specifics: TypeEncoderOutputRefSub<'vir>,
     pub method_assign: &'vir str,
@@ -61,7 +61,7 @@ macro_rules! builtin_snapshot_constructor {
     }
 }
 
-pub const BOOL_CONS: FunctionIdentifier<'static, vir::Unary> = FunctionIdentifier::new(builtin_snapshot_constructor!("Bool"));
+pub const BOOL_CONS: FunctionIdentifier<'static, vir::UnaryArgs> = FunctionIdentifier::new(builtin_snapshot_constructor!("Bool"));
 
 impl<'vir> TypeEncoderOutputRef<'vir> {
     pub fn expect_structlike(&self) -> &TypeEncoderOutputRefSubStruct<'vir> {

--- a/prusti-encoder/src/encoders/typ.rs
+++ b/prusti-encoder/src/encoders/typ.rs
@@ -4,7 +4,7 @@ use task_encoder::{
     TaskEncoder,
     TaskEncoderDependencies,
 };
-use vir::{BOOL_CONS, FunctionIdentifier};
+use vir::{FunctionIdentifier};
 
 pub struct TypeEncoder;
 
@@ -41,6 +41,26 @@ pub struct TypeEncoderOutputRef<'vir> {
     pub method_reassign: &'vir str,
 }
 impl<'vir> task_encoder::OutputRefAny<'vir> for TypeEncoderOutputRef<'vir> {}
+
+macro_rules! snapshot_prefix {
+    () => { "s_" }
+}
+
+macro_rules! snapshot_constructor_suffix {
+    () => { "_cons" }
+}
+
+macro_rules! snapshot_val_suffix {
+    () => { "_val" }
+}
+
+macro_rules! builtin_snapshot_constructor {
+    ($s:expr) => {
+        concat!(snapshot_prefix!(), $s, snapshot_constructor_suffix!())
+    }
+}
+
+pub const BOOL_CONS: FunctionIdentifier<'static, vir::Unary> = FunctionIdentifier(builtin_snapshot_constructor!("Bool"), PhantomData);
 
 impl<'vir> TypeEncoderOutputRef<'vir> {
     pub fn expect_structlike(&self) -> &TypeEncoderOutputRefSubStruct<'vir> {

--- a/prusti-encoder/src/encoders/typ.rs
+++ b/prusti-encoder/src/encoders/typ.rs
@@ -33,6 +33,7 @@ pub struct TypeEncoderOutputRef<'vir> {
     pub snapshot_name: &'vir str,
     pub predicate_name: &'vir str,
     pub snapshot: vir::Type<'vir>,
+    pub snapshot_constructor: FunctionIdentifier<'vir, vir::Unknown>,
     pub function_unreachable: FunctionIdentifier<'vir, vir::Nullary>,
     pub function_snap: FunctionIdentifier<'vir, vir::Unary>,
     //pub method_refold: &'vir str,
@@ -379,6 +380,9 @@ impl TaskEncoder for TypeEncoder {
                 snapshot_name: name_s,
                 predicate_name: name_p,
                 snapshot: vcx.alloc(vir::TypeData::Domain(name_s)),
+                snapshot_constructor: FunctionIdentifier::new(
+                    vir::vir_format!(vcx, "{name_s}{}", snapshot_constructor_suffix!())
+                ),
                 function_unreachable: FunctionIdentifier::new(vir::vir_format!(vcx, "{name_s}_unreachable")),
                 function_snap: FunctionIdentifier::new(vir::vir_format!(vcx, "{name_p}_snap")),
                 //method_refold: vir::vir_format!(vcx, "refold_{name_p}"),
@@ -662,6 +666,9 @@ impl TaskEncoder for TypeEncoder {
                     snapshot_name: "s_Bool",
                     predicate_name: "p_Bool",
                     snapshot: ty_s,
+                    snapshot_constructor: FunctionIdentifier::new(
+                        vir::vir_format!(vcx, "s_Bool{}", snapshot_constructor_suffix!())
+                    ),
                     function_unreachable: FunctionIdentifier::new("s_Bool_unreachable"),
                     function_snap: FunctionIdentifier::new("p_Bool_snap"),
                     //method_refold: "refold_p_Bool",
@@ -705,6 +712,9 @@ impl TaskEncoder for TypeEncoder {
                     snapshot_name: name_s,
                     predicate_name: name_p,
                     snapshot: ty_s,
+                    snapshot_constructor: FunctionIdentifier::new(
+                        vir::vir_format!(vcx, "{name_s}{}", snapshot_constructor_suffix!())
+                    ),
                     function_unreachable: FunctionIdentifier::new(vir::vir_format!(vcx, "{name_s}_unreachable")),
                     function_snap: FunctionIdentifier::new(vir::vir_format!(vcx, "{name_p}_snap")),
                     //method_refold: vir::vir_format!(vcx, "refold_{name_p}"),
@@ -738,6 +748,9 @@ impl TaskEncoder for TypeEncoder {
                     snapshot_name: "s_Tuple0",
                     predicate_name: "p_Tuple0",
                     snapshot: ty_s,
+                    snapshot_constructor: FunctionIdentifier::new(
+                        vir::vir_format!(vcx, "s_Tuple0{}", snapshot_constructor_suffix!())
+                    ),
                     function_unreachable: FunctionIdentifier::new("s_Tuple0_unreachable"),
                     function_snap: FunctionIdentifier::new("p_Tuple0_snap"),
                     //method_refold: "refold_p_Tuple0",
@@ -822,6 +835,9 @@ impl TaskEncoder for TypeEncoder {
                     snapshot_name: param_out.snapshot_param_name,
                     predicate_name: param_out.predicate_param_name,
                     snapshot: ty_s,
+                    snapshot_constructor: FunctionIdentifier::new(
+                        vir::vir_format!(vcx, "{}{}", param_out.snapshot_param_name, snapshot_constructor_suffix!())
+                    ),
                     function_unreachable: FunctionIdentifier::new("s_Param_unreachable"),
                     function_snap: FunctionIdentifier::new("p_Param_snap"),
                     //method_refold: "refold_p_Param",
@@ -865,6 +881,9 @@ impl TaskEncoder for TypeEncoder {
                     snapshot_name: "s_Never",
                     predicate_name: "p_Never",
                     snapshot: ty_s,
+                    snapshot_constructor: FunctionIdentifier::new(
+                        vir::vir_format!(vcx, "s_Never{}", snapshot_constructor_suffix!())
+                    ),
                     function_unreachable: FunctionIdentifier::new("s_Never_unreachable"),
                     function_snap: FunctionIdentifier::new("p_Never_snap"),
                     //method_refold: "refold_p_Never",

--- a/vir/src/context.rs
+++ b/vir/src/context.rs
@@ -5,7 +5,7 @@ use crate::data::*;
 use crate::gendata::*;
 use crate::genrefs::*;
 use crate::refs::*;
-use crate::functionidentifier::{Args, Unary, FunctionIdentifier};
+use crate::functionidentifier::{Args, FunctionIdentifier};
 
 /// The VIR context is a data structure used throughout the encoding process.
 pub struct VirCtxt<'tcx> {

--- a/vir/src/context.rs
+++ b/vir/src/context.rs
@@ -5,6 +5,7 @@ use crate::data::*;
 use crate::gendata::*;
 use crate::genrefs::*;
 use crate::refs::*;
+use crate::functionidentifier::{Args, Unary, FunctionIdentifier};
 
 /// The VIR context is a data structure used throughout the encoding process.
 pub struct VirCtxt<'tcx> {
@@ -64,6 +65,16 @@ impl<'tcx> VirCtxt<'tcx> {
     pub fn mk_local_ex<Curr, Next>(&'tcx self, name: &'tcx str) -> ExprGen<'tcx, Curr, Next> {
         self.arena.alloc(ExprGenData::Local(self.mk_local(name)))
     }
+
+    pub fn mk_typed_func_app<T: Args, Curr, Next>(
+        &'tcx self,
+        target: FunctionIdentifier<'tcx, T>,
+        src_arg: T::ArgType<'tcx, Curr, Next>,
+    ) -> ExprGen<'tcx, Curr, Next> {
+        self.mk_func_app(target.0, &T::to_vec(src_arg))
+    }
+
+
     pub fn mk_func_app<Curr, Next>(
         &'tcx self,
         target: &'tcx str,

--- a/vir/src/functionidentifier.rs
+++ b/vir/src/functionidentifier.rs
@@ -1,54 +1,55 @@
 use std::marker::PhantomData;
 
-use crate::{ExprGen, ExprGenData};
+use crate::ExprGen;
 
 #[derive(Debug, Clone, Copy)]
-pub struct FunctionIdentifier<'a, ArgType>(pub &'a str, PhantomData<ArgType>);
+pub struct FunctionIdentifier<'a, Args>(pub &'a str, PhantomData<Args>);
 
-impl <'a, T> FunctionIdentifier<'a, T> {
+impl<'a, Args> FunctionIdentifier<'a, Args> {
     pub const fn new(name: &'a str) -> Self {
         FunctionIdentifier(name, PhantomData)
     }
 }
-#[derive(Debug, Clone, Copy)]
-pub struct Nullary;
-
-impl Args for Nullary {
-    type ArgType<'tcx, Curr: 'tcx, Next: 'tcx> = ();
-    fn to_vec<'tcx, Curr: 'tcx, Next: 'tcx>(
-            _arg: ()
-        ) -> Vec<ExprGen<'tcx, Curr, Next>> {
-        vec![]
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct Unary;
-struct Binary;
-
-#[derive(Debug, Clone, Copy)]
-pub struct Unknown;
-
-impl Args for Unary {
-    type ArgType<'tcx, Curr: 'tcx, Next: 'tcx> = ExprGen<'tcx, Curr, Next> where Self: 'tcx;
-    fn to_vec<'tcx, Curr: 'tcx, Next: 'tcx>(
-            arg: Self::ArgType<'tcx, Curr, Next>,
-        ) -> Vec<ExprGen<'tcx, Curr, Next>> {
-        vec![arg]
-    }
-}
-
-impl Args for Unknown {
-    type ArgType<'tcx, Curr: 'tcx, Next: 'tcx> = Vec<ExprGen<'tcx, Curr, Next>> where Self: 'tcx;
-    fn to_vec<'tcx, Curr: 'tcx, Next: 'tcx>(
-            arg: Self::ArgType<'tcx, Curr, Next>,
-        ) -> Vec<ExprGen<'tcx, Curr, Next>> { arg }
-}
-
 pub trait Args {
-    type ArgType<'tcx, Curr: 'tcx, Next: 'tcx> where Self: 'tcx;
+    type ArgType<'tcx, Curr: 'tcx, Next: 'tcx>
+    where
+        Self: 'tcx;
 
     fn to_vec<'tcx, Curr: 'tcx, Next: 'tcx>(
         arg: Self::ArgType<'tcx, Curr, Next>,
     ) -> Vec<ExprGen<'tcx, Curr, Next>>;
 }
+
+#[derive(Debug, Clone, Copy)]
+pub struct NullaryArgs;
+
+impl Args for NullaryArgs {
+    type ArgType<'tcx, Curr: 'tcx, Next: 'tcx> = ();
+    fn to_vec<'tcx, Curr: 'tcx, Next: 'tcx>(_arg: ()) -> Vec<ExprGen<'tcx, Curr, Next>> {
+        vec![]
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct UnaryArgs;
+
+impl Args for UnaryArgs {
+    type ArgType<'tcx, Curr: 'tcx, Next: 'tcx> = ExprGen<'tcx, Curr, Next> where Self: 'tcx;
+    fn to_vec<'tcx, Curr: 'tcx, Next: 'tcx>(
+        arg: Self::ArgType<'tcx, Curr, Next>,
+    ) -> Vec<ExprGen<'tcx, Curr, Next>> {
+        vec![arg]
+    }
+}
+#[derive(Debug, Clone, Copy)]
+pub struct UnknownArgs;
+
+impl Args for UnknownArgs {
+    type ArgType<'tcx, Curr: 'tcx, Next: 'tcx> = Vec<ExprGen<'tcx, Curr, Next>> where Self: 'tcx;
+    fn to_vec<'tcx, Curr: 'tcx, Next: 'tcx>(
+        arg: Self::ArgType<'tcx, Curr, Next>,
+    ) -> Vec<ExprGen<'tcx, Curr, Next>> {
+        arg
+    }
+}
+

--- a/vir/src/functionidentifier.rs
+++ b/vir/src/functionidentifier.rs
@@ -1,0 +1,41 @@
+use std::marker::PhantomData;
+
+use crate::{ExprGen, ExprGenData};
+use crate::builtin_snapshot_constructor;
+
+#[derive(Debug, Clone, Copy)]
+pub struct FunctionIdentifier<'tcx, ArgType>(pub &'tcx str, pub PhantomData<ArgType>);
+struct Nullary;
+
+#[derive(Debug, Clone, Copy)]
+pub struct Unary;
+struct Binary;
+
+pub struct Unknown;
+
+impl Args for Unary {
+    type ArgType<'tcx, Curr: 'tcx, Next: 'tcx> = ExprGen<'tcx, Curr, Next> where Self: 'tcx;
+    fn to_vec<'tcx, Curr: 'tcx, Next: 'tcx>(
+            arg: Self::ArgType<'tcx, Curr, Next>,
+        ) -> Vec<ExprGen<'tcx, Curr, Next>> {
+        vec![arg]
+    }
+}
+
+impl Args for Unknown {
+    type ArgType<'tcx, Curr: 'tcx, Next: 'tcx> = Vec<ExprGen<'tcx, Curr, Next>> where Self: 'tcx;
+    fn to_vec<'tcx, Curr: 'tcx, Next: 'tcx>(
+            arg: Self::ArgType<'tcx, Curr, Next>,
+        ) -> Vec<ExprGen<'tcx, Curr, Next>> { arg }
+}
+
+pub trait Args {
+    type ArgType<'tcx, Curr: 'tcx, Next: 'tcx> where Self: 'tcx;
+
+    fn to_vec<'tcx, Curr: 'tcx, Next: 'tcx>(
+        arg: Self::ArgType<'tcx, Curr, Next>,
+    ) -> Vec<ExprGen<'tcx, Curr, Next>>;
+}
+
+
+pub const BOOL_CONS: FunctionIdentifier<'static, Unary> = FunctionIdentifier(builtin_snapshot_constructor!("Bool"), PhantomData);

--- a/vir/src/functionidentifier.rs
+++ b/vir/src/functionidentifier.rs
@@ -26,6 +26,7 @@ impl Args for Nullary {
 pub struct Unary;
 struct Binary;
 
+#[derive(Debug, Clone, Copy)]
 pub struct Unknown;
 
 impl Args for Unary {

--- a/vir/src/functionidentifier.rs
+++ b/vir/src/functionidentifier.rs
@@ -1,11 +1,26 @@
 use std::marker::PhantomData;
 
 use crate::{ExprGen, ExprGenData};
-use crate::builtin_snapshot_constructor;
 
 #[derive(Debug, Clone, Copy)]
-pub struct FunctionIdentifier<'tcx, ArgType>(pub &'tcx str, pub PhantomData<ArgType>);
-struct Nullary;
+pub struct FunctionIdentifier<'a, ArgType>(pub &'a str, PhantomData<ArgType>);
+
+impl <'a, T> FunctionIdentifier<'a, T> {
+    pub const fn new(name: &'a str) -> Self {
+        FunctionIdentifier(name, PhantomData)
+    }
+}
+#[derive(Debug, Clone, Copy)]
+pub struct Nullary;
+
+impl Args for Nullary {
+    type ArgType<'tcx, Curr: 'tcx, Next: 'tcx> = ();
+    fn to_vec<'tcx, Curr: 'tcx, Next: 'tcx>(
+            _arg: ()
+        ) -> Vec<ExprGen<'tcx, Curr, Next>> {
+        vec![]
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 pub struct Unary;
@@ -36,6 +51,3 @@ pub trait Args {
         arg: Self::ArgType<'tcx, Curr, Next>,
     ) -> Vec<ExprGen<'tcx, Curr, Next>>;
 }
-
-
-pub const BOOL_CONS: FunctionIdentifier<'static, Unary> = FunctionIdentifier(builtin_snapshot_constructor!("Bool"), PhantomData);

--- a/vir/src/lib.rs
+++ b/vir/src/lib.rs
@@ -11,6 +11,7 @@ mod genrefs; // TODO: explain gen...
 mod macros;
 mod refs;
 mod reify;
+mod functionidentifier;
 
 pub use context::*;
 pub use data::*;
@@ -18,6 +19,7 @@ pub use gendata::*;
 pub use genrefs::*;
 pub use refs::*;
 pub use reify::*;
+pub use functionidentifier::*;
 
 // for all arena-allocated types, there are two type definitions: one with
 // a `Data` suffix, containing the actual data; and one without the suffix,

--- a/vir/src/macros.rs
+++ b/vir/src/macros.rs
@@ -269,6 +269,10 @@ macro_rules! vir_predicate {
     }};
 }
 
+const SNAPSHOT_PREFIX: &'static str = "s_";
+const SNAPSHOT_CONSTRUCTOR_SUFFIX: &'static str = "_val";
+const SNAPSHOT_VAL_SUFFIX: &'static str = "_cons";
+
 #[macro_export]
 macro_rules! snapshot_constructor_suffix {
     () => {
@@ -283,13 +287,6 @@ macro_rules! snapshot_val_suffix {
     };
 }
 
-
-#[macro_export]
-macro_rules! builtin_snapshot_constructor {
-    ($s:expr) => {
-        concat!("S_", $s, crate::snapshot_constructor_suffix!())
-    }
-}
 
 #[macro_export]
 macro_rules! vir_snapshot_constructor_name {

--- a/vir/src/macros.rs
+++ b/vir/src/macros.rs
@@ -268,36 +268,3 @@ macro_rules! vir_predicate {
         })
     }};
 }
-
-const SNAPSHOT_PREFIX: &'static str = "s_";
-const SNAPSHOT_CONSTRUCTOR_SUFFIX: &'static str = "_val";
-const SNAPSHOT_VAL_SUFFIX: &'static str = "_cons";
-
-#[macro_export]
-macro_rules! snapshot_constructor_suffix {
-    () => {
-        "_cons"
-    };
-}
-
-#[macro_export]
-macro_rules! snapshot_val_suffix {
-    () => {
-        "_val"
-    };
-}
-
-
-#[macro_export]
-macro_rules! vir_snapshot_constructor_name {
-    ($vcx:expr, $snapshot_name:expr) => { 
-        vir::vir_format!($vcx, "{}{}", $snapshot_name, vir::snapshot_constructor_suffix!())
-    };
-}
-
-#[macro_export]
-macro_rules! vir_snapshot_val_name {
-    ($vcx:expr, $snapshot_name:expr) => { 
-        vir::vir_format!($vcx, "{}{}", $snapshot_name, vir::snapshot_val_suffix!())
-    };
-}

--- a/vir/src/macros.rs
+++ b/vir/src/macros.rs
@@ -268,3 +268,39 @@ macro_rules! vir_predicate {
         })
     }};
 }
+
+#[macro_export]
+macro_rules! snapshot_constructor_suffix {
+    () => {
+        "_cons"
+    };
+}
+
+#[macro_export]
+macro_rules! snapshot_val_suffix {
+    () => {
+        "_val"
+    };
+}
+
+
+#[macro_export]
+macro_rules! builtin_snapshot_constructor {
+    ($s:expr) => {
+        concat!("S_", $s, crate::snapshot_constructor_suffix!())
+    }
+}
+
+#[macro_export]
+macro_rules! vir_snapshot_constructor_name {
+    ($vcx:expr, $snapshot_name:expr) => { 
+        vir::vir_format!($vcx, "{}{}", $snapshot_name, vir::snapshot_constructor_suffix!())
+    };
+}
+
+#[macro_export]
+macro_rules! vir_snapshot_val_name {
+    ($vcx:expr, $snapshot_name:expr) => { 
+        vir::vir_format!($vcx, "{}{}", $snapshot_name, vir::snapshot_val_suffix!())
+    };
+}


### PR DESCRIPTION
This PR introduces the `FunctionIdentifier` struct, which is used to represent the identifier of an encoded Viper function. To demonstrate its use, some code has been refactored to use it instead of string literals.

`FunctionIdentifier` wraps a borrowed string, and includes a type parameter `A` that characterizes its input parameters.
```rust
pub struct FunctionIdentifier<'a, A>(pub &'a str, PhantomData<A>);
```

However, the type `A` does correspond directly to the parameters; rather, it should be any type with an implementation for the trait:

```rust
pub trait Args {
    type ArgType<'tcx, Curr: 'tcx, Next: 'tcx>
    where
        Self: 'tcx;

    fn to_vec<'tcx, Curr: 'tcx, Next: 'tcx>(
        arg: Self::ArgType<'tcx, Curr, Next>,
    ) -> Vec<ExprGen<'tcx, Curr, Next>>;
}
```

This indirection is necessary to define arguments that are generic over parameters `'tcx`, `Curr`, and `Next`. 

---

Function applications are encoded using the function:

```rust
pub fn mk_typed_func_app<A: Args, Curr, Next>(
        &'tcx self,
        target: FunctionIdentifier<'tcx, A>,
        src_arg: A::ArgType<'tcx, Curr, Next>,
    ) -> ExprGen<'tcx, Curr, Next> {
        self.mk_func_app(target.0, &T::to_vec(src_arg))
    }
```

For example, we can define a `FunctionIdentifier` for a unary function by using the type `UnaryArgs`.

```rust
#[derive(Debug, Clone, Copy)]
pub struct UnaryArgs;

impl Args for UnaryArgs {
    type ArgType<'tcx, Curr: 'tcx, Next: 'tcx> = ExprGen<'tcx, Curr, Next> where Self: 'tcx;
    fn to_vec<'tcx, Curr: 'tcx, Next: 'tcx>(
        arg: Self::ArgType<'tcx, Curr, Next>,
    ) -> Vec<ExprGen<'tcx, Curr, Next>> {
        vec![arg]
    }
}
```

Therefore, values of type `FunctionIdentifier<'_, UnaryArgs>` correspond to identifiers of single-argument functions.
 
