### PR TITLE
Change axiomatization and temporarily fix some triggering issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,6 +2558,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -826,12 +826,12 @@ impl<'vir, 'enc> mir::visit::Visitor<'vir> for EncoderVisitor<'vir, 'enc> {
                 // TODO: dedup with mir_pure
                 let attrs = self.vcx.tcx.get_attrs_unchecked(*func_def_id);
                 let is_pure = attrs.iter()
-                .filter(|attr| !attr.is_doc_comment())
-                .map(|attr| attr.get_normal_item()).any(|item| 
-                    item.path.segments.len() == 2
-                    && item.path.segments[0].ident.as_str() == "prusti"
-                    && item.path.segments[1].ident.as_str() == "pure"
-                );
+                    .filter(|attr| !attr.is_doc_comment())
+                    .map(|attr| attr.get_normal_item()).any(|item| 
+                        item.path.segments.len() == 2
+                        && item.path.segments[0].ident.as_str() == "prusti"
+                        && item.path.segments[1].ident.as_str() == "pure"
+                    );
 
                 let dest = self.encode_place(Place::from(*destination));
                 let call_args = args.iter().map(|op| 
@@ -842,7 +842,6 @@ impl<'vir, 'enc> mir::visit::Visitor<'vir> for EncoderVisitor<'vir, 'enc> {
                         self.encode_operand(op)
                     }
                 );
-                // self.encode_operand(op)
 
                 if is_pure {
                     let func_args = call_args.collect::<Vec<_>>();
@@ -853,7 +852,7 @@ impl<'vir, 'enc> mir::visit::Visitor<'vir> for EncoderVisitor<'vir, 'enc> {
                     let pure_func_app = self.vcx.mk_func_app(pure_func_name, &func_args);
 
                     let method_assign = {
-                        //TODO: can we get the method_assign is a better way? Maybe from the MirFunctionEncoder?
+                        //TODO: Can we get `method_assign` in a better way? Maybe from the MirFunctionEncoder?
                         let body = self.vcx.body.borrow_mut().get_impure_fn_body_identity(func_def_id.expect_local());
                         let return_type = self.deps
                             .require_ref::<crate::encoders::TypeEncoder>(body.return_ty())

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -9,6 +9,7 @@ use task_encoder::{
     TaskEncoderDependencies,
 };
 use std::collections::HashMap;
+use crate::encoders::{ViperTupleEncoder, TypeEncoder};
 
 pub struct MirPureEncoder;
 
@@ -448,9 +449,10 @@ impl<'vir, 'enc> Encoder<'vir, 'enc>
                     TyKind::FnDef(def_id, arg_tys) => {
                         // TODO: this attribute extraction should be done elsewhere?
                         let attrs = self.vcx.tcx.get_attrs_unchecked(*def_id);
-                        attrs.iter()
+                        let normal_attrs = attrs.iter()
                             .filter(|attr| !attr.is_doc_comment())
-                            .map(|attr| attr.get_normal_item())
+                            .map(|attr| attr.get_normal_item()).collect::<Vec<_>>();
+                        normal_attrs.iter()
                             .filter(|item| item.path.segments.len() == 2
                                 && item.path.segments[0].ident.as_str() == "prusti"
                                 && item.path.segments[1].ident.as_str() == "builtin")
@@ -467,6 +469,66 @@ impl<'vir, 'enc> Encoder<'vir, 'enc>
                                 }
                                 _ => panic!("illegal prusti::builtin"),
                             });
+
+
+                        let is_pure = normal_attrs.iter().any(|item| 
+                            item.path.segments.len() == 2
+                            && item.path.segments[0].ident.as_str() == "prusti"
+                            && item.path.segments[1].ident.as_str() == "pure"
+                        );
+
+                         // TODO: detect snapshot_equality properly
+                         let is_snapshot_eq = self.vcx.tcx.opt_item_name(*def_id).map(|e| e.as_str() == "snapshot_equality") == Some(true)
+                            && self.vcx.tcx.crate_name(def_id.krate).as_str() == "prusti_contracts";
+
+                        let func_call = if is_pure {
+                            assert!(builtin.is_none(), "Function is pure and builtin?");
+                            let pure_func = self.deps.require_ref::<crate::encoders::MirFunctionEncoder>(*def_id).unwrap().function_name;
+
+                            let encoded_args = args.iter()
+                                .map(|oper| self.encode_operand(&new_curr_ver, oper))
+                                .collect::<Vec<_>>();
+                            
+                            let func_call = self.vcx.mk_func_app(pure_func, &encoded_args);
+
+                           Some(func_call)
+                        }
+
+                        else if is_snapshot_eq {
+                            assert!(builtin.is_none(), "Function is snapshot_equality and builtin?");
+                            let encoded_args = args.iter()
+                                .map(|oper| self.encode_operand(&new_curr_ver, oper))
+                                .collect::<Vec<_>>();
+
+                            assert_eq!(encoded_args.len(), 2);
+
+
+                            let eq_expr  = self.vcx.alloc(vir::ExprGenData::BinOp(self.vcx.alloc(vir::BinOpGenData {
+                                kind: vir::BinOpKind::CmpEq,
+                                lhs: encoded_args[0],
+                                rhs: encoded_args[1],
+                            })));
+
+
+                            // TODO: type encoder
+                            Some(self.vcx.mk_func_app("s_Bool_cons", &[eq_expr]))
+                        }
+                        else {
+                            None
+                        };
+
+
+                        if let Some(func_call) = func_call {
+                            let mut term_update = Update::new();
+                            assert!(destination.projection.is_empty());
+                            self.bump_version(&mut term_update, destination.local, func_call);
+                            term_update.add_to_map(&mut new_curr_ver);
+    
+                            // walk rest of CFG
+                            let end_update = self.encode_cfg(&new_curr_ver, target.unwrap(), end);
+    
+                            return stmt_update.merge(term_update).merge(end_update);
+                        }
                     }
                     _ => todo!(),
                 }
@@ -769,24 +831,48 @@ impl<'vir, 'enc> Encoder<'vir, 'enc>
         }
 
         let local = self.mk_local_ex(place.local, curr_ver[&place.local]);
-        if !place.projection.is_empty() {
-            // TODO: for now, assume this is a closure argument
-            assert_eq!(place.projection[0], mir::ProjectionElem::Deref);
-            assert!(matches!(place.projection[1], mir::ProjectionElem::Field(..)));
-            assert_eq!(place.projection[2], mir::ProjectionElem::Deref);
-            assert_eq!(place.projection.len(), 3);
-            let upvars = match self.body.local_decls[place.local].ty.peel_refs().kind() {
-                TyKind::Closure(_def_id, args) => args.as_closure().upvar_tys().collect::<Vec<_>>().len(),
-                _ => unreachable!(),
-            };
-            let tuple_ref = self.deps.require_ref::<crate::encoders::ViperTupleEncoder>(
-                upvars,
-            ).unwrap();
-            return match place.projection[1] {
-                mir::ProjectionElem::Field(idx, _) => tuple_ref.mk_elem(self.vcx, local, idx.as_usize()),
-                _ => todo!(),
-            };
+        let mut partent_ty =  self.body.local_decls[place.local].ty;
+        let mut expr = local;
+
+        for elem in place.projection {
+            (partent_ty, expr) = self.encode_place_element(partent_ty, elem, expr);
         }
-        local
+
+        expr
+    }
+
+
+    fn encode_place_element(&mut self, parent_ty: ty::Ty<'vir>, elem: mir::PlaceElem<'vir>, expr: ExprRet<'vir>) -> (ty::Ty<'vir>, ExprRet<'vir>) {
+        let parent_ty = parent_ty.peel_refs();
+
+         match elem {
+            mir::ProjectionElem::Deref => {
+                (parent_ty, expr)
+            }
+            mir::ProjectionElem::Field(field_idx, field_ty) => {
+                let field_idx= field_idx.as_usize();
+                match parent_ty.kind() {
+                    TyKind::Closure(_def_id, args) => {
+                        let upvars = args.as_closure().upvar_tys().collect::<Vec<_>>().len();
+                        let tuple_ref = self.deps.require_ref::<ViperTupleEncoder>(
+                            upvars,
+                        ).unwrap();
+                        let tup  = tuple_ref.mk_elem(self.vcx, expr, field_idx);
+
+                        (field_ty, tup)
+                    }
+                    _ => {
+                        let local_encoded_ty = self.deps.require_ref::<TypeEncoder>(parent_ty).unwrap();
+                        let struct_like = local_encoded_ty.expect_structlike();
+                        let proj = struct_like.field_read[field_idx];
+                
+                        let app = self.vcx.mk_func_app(proj, self.vcx.alloc_slice(&[expr]));
+
+                        (field_ty, app)
+                    }
+                }
+            }   
+            _ => todo!("Unsupported ProjectionElem {:?}", elem),
+        }
     }
 }

--- a/prusti-encoder/src/encoders/mir_pure_function.rs
+++ b/prusti-encoder/src/encoders/mir_pure_function.rs
@@ -73,32 +73,65 @@ impl TaskEncoder for MirFunctionEncoder {
             tracing::debug!("encoding {def_id:?}");
 
             let function_name = vir::vir_format!(vcx, "f_{}", vcx.tcx.item_name(def_id));
-            deps.emit_output_ref::<Self>(def_id, MirFunctionEncoderOutputRef { function_name });
+            deps.emit_output_ref::<Self>(*task_key, MirFunctionEncoderOutputRef { function_name });
 
-            let local_defs = deps.require_local::<crate::encoders::local_def::MirLocalDefEncoder>(
-                def_id,
-            ).unwrap();
+            let local_def_id = def_id.expect_local();
+            let body = vcx.body.borrow_mut().get_impure_fn_body_identity(local_def_id);
+
             let spec = deps.require_local::<crate::encoders::pure::spec::MirSpecEncoder>(
                 (def_id, true)
             ).unwrap();
 
-            let func_args: Vec<_> = (1..=local_defs.arg_count).map(mir::Local::from).map(|arg| vcx.alloc(vir::LocalDeclData {
-                name: local_defs.locals[arg].local.name,
-                ty: local_defs.locals[arg].snapshot,
-            })).collect();
+            let mut func_args = Vec::with_capacity(body.arg_count);
 
-            // Encode the body of the function
-            let expr = deps
-                .require_local::<MirPureEncoder>(MirPureEncoderTask {
-                    encoding_depth: 0,
-                    parent_def_id: def_id,
-                    promoted: None,
-                    param_env: vcx.tcx.param_env(def_id),
-                    substs: ty::List::identity_for_item(vcx.tcx, def_id),
-                })
+            for (arg_idx0, arg_local) in body.args_iter().enumerate() {
+                let arg_idx = arg_idx0 + 1; // enumerate is 0 based but we want to start at 1
+
+                let arg_decl = body.local_decls.get(arg_local).unwrap();
+                let arg_type_ref = deps.require_ref::<TypeEncoder>(arg_decl.ty).unwrap();
+
+                let name_p = vir::vir_format!(vcx, "_{arg_idx}p");
+                func_args.push(vcx.alloc(vir::LocalDeclData {
+                    name: name_p,
+                    ty: arg_type_ref.snapshot,
+                }));
+            }
+
+            // TODO: dedup with mir_pure
+            let attrs = vcx.tcx.get_attrs_unchecked(def_id);
+            let is_trusted = attrs
+                .iter()
+                .filter(|attr| !attr.is_doc_comment())
+                .map(|attr| attr.get_normal_item())
+                .any(|item| {
+                    item.path.segments.len() == 2
+                        && item.path.segments[0].ident.as_str() == "prusti"
+                        && item.path.segments[1].ident.as_str() == "trusted"
+                });
+
+            let expr = if is_trusted {
+                None
+            } else {
+                // Encode the body of the function
+                let expr = deps
+                    .require_local::<MirPureEncoder>(MirPureEncoderTask {
+                        encoding_depth: 0,
+                        parent_def_id: def_id,
+                        promoted: None,
+                        param_env: vcx.tcx.param_env(def_id),
+                        substs: ty::List::identity_for_item(vcx.tcx, def_id),
+                    })
+                    .unwrap()
+                    .expr;
+
+                Some(expr.reify(vcx, (def_id, &spec.pre_args.split_last().unwrap().1)))
+            };
+
+            // Snapshot type of the return type
+            let ret = deps
+                .require_ref::<TypeEncoder>(body.return_ty())
                 .unwrap()
-                .expr;
-            let expr = expr.reify(vcx, (def_id, &spec.pre_args[1..]));
+                .snapshot;
 
             tracing::debug!("finished {def_id:?}");
 
@@ -107,10 +140,10 @@ impl TaskEncoder for MirFunctionEncoder {
                     function: vcx.alloc(vir::FunctionData {
                         name: function_name,
                         args: vcx.alloc_slice(&func_args),
-                        ret: local_defs.locals[mir::RETURN_PLACE].snapshot,
+                        ret,
                         pres: vcx.alloc_slice(&spec.pres),
                         posts: vcx.alloc_slice(&spec.posts),
-                        expr: Some(expr),
+                        expr,
                     }),
                 },
                 (),

--- a/prusti-encoder/src/encoders/mir_pure_function.rs
+++ b/prusti-encoder/src/encoders/mir_pure_function.rs
@@ -16,13 +16,13 @@ pub enum MirFunctionEncoderError {
 
 #[derive(Clone, Debug)]
 pub struct MirFunctionEncoderOutputRef<'vir> {
-    pub method_name: &'vir str,
+    pub function_name: &'vir str,
 }
 impl<'vir> task_encoder::OutputRefAny<'vir> for MirFunctionEncoderOutputRef<'vir> {}
 
 #[derive(Clone, Debug)]
 pub struct MirFunctionEncoderOutput<'vir> {
-    pub method: vir::Function<'vir>,
+    pub function: vir::Function<'vir>,
 }
 
 thread_local! {
@@ -72,8 +72,8 @@ impl TaskEncoder for MirFunctionEncoder {
 
             tracing::debug!("encoding {def_id:?}");
 
-            let method_name = vir::vir_format!(vcx, "f_{}", vcx.tcx.item_name(def_id));
-            deps.emit_output_ref::<Self>(def_id, MirFunctionEncoderOutputRef { method_name });
+            let function_name = vir::vir_format!(vcx, "f_{}", vcx.tcx.item_name(def_id));
+            deps.emit_output_ref::<Self>(def_id, MirFunctionEncoderOutputRef { function_name });
 
             let local_defs = deps.require_local::<crate::encoders::local_def::MirLocalDefEncoder>(
                 def_id,
@@ -104,8 +104,8 @@ impl TaskEncoder for MirFunctionEncoder {
 
             Ok((
                 MirFunctionEncoderOutput {
-                    method: vcx.alloc(vir::FunctionData {
-                        name: method_name,
+                    function: vcx.alloc(vir::FunctionData {
+                        name: function_name,
                         args: vcx.alloc_slice(&func_args),
                         ret: local_defs.locals[mir::RETURN_PLACE].snapshot,
                         pres: vcx.alloc_slice(&spec.pres),

--- a/prusti-encoder/src/encoders/typ.rs
+++ b/prusti-encoder/src/encoders/typ.rs
@@ -468,12 +468,7 @@ impl TaskEncoder for TypeEncoder {
                         name: vir::vir_format!(vcx, "ax_{name_s}_cons_read_{read_idx}"),
                         expr: vcx.alloc(vir::ExprData::Forall(vcx.alloc(vir::ForallData {
                             qvars: cons_qvars.clone(),
-                            triggers: vcx.alloc_slice(&[vcx.alloc_slice(&[
-                                vcx.mk_func_app(
-                                    vir::vir_format!(vcx, "{name_s}_read_{read_idx}"),
-                                    &[cons_call],
-                                ),
-                            ])]),
+                            triggers: vcx.alloc_slice(&[vcx.alloc_slice(&[cons_call])]),
                             body: vcx.alloc(vir::ExprData::BinOp(vcx.alloc(vir::BinOpData {
                                 kind: vir::BinOpKind::CmpEq,
                                 lhs: vcx.mk_func_app(
@@ -620,6 +615,7 @@ impl TaskEncoder for TypeEncoder {
                         function s_Bool_cons(Bool): s_Bool;
                         function s_Bool_val(s_Bool): Bool;
                         axiom_inverse(s_Bool_val, s_Bool_cons, Bool);
+                        axiom_inverse(s_Bool_cons, s_Bool_val, s_Bool);
                     } },
                     predicate: mk_simple_predicate(vcx, "p_Bool", "f_Bool"),
                     function_unreachable: mk_unreachable(vcx, "s_Bool", ty_s),
@@ -663,6 +659,7 @@ impl TaskEncoder for TypeEncoder {
                         function [name_cons](Int): [ty_s];
                         function [name_val]([ty_s]): Int;
                         axiom_inverse([name_val], [name_cons], Int);
+                        axiom_inverse([name_cons], [name_val], [ty_s]);
                     } },
                     predicate: mk_simple_predicate(vcx, name_p, name_field),
                     function_unreachable: mk_unreachable(vcx, name_s, ty_s),

--- a/prusti-encoder/src/encoders/viper_tuple.rs
+++ b/prusti-encoder/src/encoders/viper_tuple.rs
@@ -150,7 +150,7 @@ impl TaskEncoder for ViperTupleEncoder {
                 domain: Some(vcx.alloc(vir::DomainData {
                     name: domain_name,
                     typarams: vcx.alloc_slice(&typaram_names),
-                    axioms: vcx.alloc_slice(&[axiom]),
+                    axioms: if task_key == &0 {&[]} else {vcx.alloc_slice(&[axiom])},
                     functions: vcx.alloc_slice(&functions),
                 })),
             }, ()))

--- a/prusti-encoder/src/lib.rs
+++ b/prusti-encoder/src/lib.rs
@@ -9,7 +9,7 @@ extern crate rustc_type_ir;
 
 mod encoders;
 
-use prusti_interface::environment::EnvBody;
+use prusti_interface::{environment::EnvBody, specs::typed::SpecificationItem};
 use prusti_rustc_interface::{
     middle::ty,
     hir,
@@ -127,7 +127,7 @@ pub fn test_entrypoint<'tcx>(
     // TODO: this should be a "crate" encoder, which will deps.require all the methods in the crate
 
     for def_id in tcx.hir_crate_items(()).definitions() {
-        //println!("item: {def_id:?}");
+        tracing::debug!("test_entrypoint item: {def_id:?}");
         let kind = tcx.def_kind(def_id);
         //println!("  kind: {:?}", kind);
         /*if !format!("{def_id:?}").contains("foo") {
@@ -162,7 +162,7 @@ pub fn test_entrypoint<'tcx>(
                 }*/
             }
             unsupported_item_kind => {
-                println!("another item: {unsupported_item_kind:?}");
+                tracing::debug!("unsupported item: {unsupported_item_kind:?}");
             }
         }
     }
@@ -182,7 +182,7 @@ pub fn test_entrypoint<'tcx>(
 
     header(&mut viper_code, "functions");
     for output in crate::encoders::MirFunctionEncoder::all_outputs() {
-        viper_code.push_str(&format!("{:?}\n", output.method));
+        viper_code.push_str(&format!("{:?}\n", output.function));
     }
 
     header(&mut viper_code, "MIR builtins");

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-tracing = "0.1"
+tracing = { version = "0.1", features = ["log"] }
 proc-macro-tracing = { path = "proc-macro-tracing" }

--- a/vir/src/data.rs
+++ b/vir/src/data.rs
@@ -41,6 +41,7 @@ pub enum BinOpKind {
     CmpLe,
     And,
     Add,
+    Sub,
     // ...
 }
 impl From<mir::BinOp> for BinOpKind {

--- a/vir/src/debug.rs
+++ b/vir/src/debug.rs
@@ -57,6 +57,7 @@ impl<'vir, Curr, Next> Debug for BinOpGenData<'vir, Curr, Next> {
             BinOpKind::CmpLe => "<=",
             BinOpKind::And => "&&",
             BinOpKind::Add => "+",
+            BinOpKind::Sub => "-",
         })?;
         self.rhs.fmt(f)?;
         write!(f, ")")


### PR DESCRIPTION
- Builds on top of #14.
- To see what changed since PR 14 see [this](https://github.com/tillarnold/prusti-dev/compare/till_rebuilt_2..tillarnold:prusti-dev:till_rebuilt_3).
- To see what the changes were intended to be before other changes were merged into the PR 14 see [this](https://github.com/tillarnold/prusti-dev/compare/fa4aa23074ba6712abfe8bc7f0715fc509be5bc0..tillarnold:prusti-dev:722be36d74c3d8cbee716dc765bf770694fcdf53). This diff could be helpful to determine if everything went correctly once this PR is made mergeable.

These changes here are necessary to make my example clamp program verify.
- There was an issue where the variables that a `forall` quantifies over were stored in let bindings which somehow prevented triggering correctly. This PR contains a hacky workaround in the form of an "optimization" function that removes let bindings if they are of the form `let var1 = var2 in ...`. I doubt that this is what we want in the long run but i wanted to get my example to verify. This was reported to upstream Viper in https://github.com/viperproject/silver/issues/751. That issue as been resolved. We might still need this temporary fix depending on which viper version we use.
- Change the triggers for the tuple read axioms from `s_Tuple_read_1(s_Tuple_cons(f0, f1))` to `s_Tuple_cons(f0, f1)` 
- For the primitive types Currently this axiom exists `forall val: Int :: {s_Int_i32_cons(val)} (s_Int_i32_val(s_Int_i32_cons(val))) == (val)`. This PR additionally also adds the inverse of it `forall val: s_Int_i32 :: {s_Int_i32_val(val)} (s_Int_i32_cons(s_Int_i32_val(val))) == (val)`. This might be dangerous but for the few cases i tested it improved/allowed verification to complete.
The necessity of the new additional inverse axiom is shown by this example 
  ```rust
  extern crate prusti_contracts;
  use prusti_contracts::*;
  
  #[requires(a >= 0)]
  fn f(a: i32)  {
      if a < 1 {
          assert_true(a == 0);
      }
     
  }
  
  #[requires(b)]
  fn assert_true(b: bool) {}
  
  fn main() {
      
  }
  ```
  
  This works with the new axiom but not without it. This also serves as an example why the trigger cannot be `s_Int_i32_cons(s_Int_i32_val(val))` instead of `s_Int_i32_val(val)`: if one manually changes the trigger in the resulting viper code the verification fails.

(Replaces #12)