### PR TITLE
Rustfmt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,6 +2558,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/mir-state-analysis/src/free_pcs/impl/local.rs
+++ b/mir-state-analysis/src/free_pcs/impl/local.rs
@@ -42,7 +42,9 @@ impl Default for CapabilityLocal<'_> {
 
 impl<'tcx> CapabilityLocal<'tcx> {
     pub fn get_allocated_mut(&mut self) -> &mut CapabilityProjections<'tcx> {
-        let Self::Allocated(cps) = self else { panic!("Expected allocated local") };
+        let Self::Allocated(cps) = self else {
+            panic!("Expected allocated local")
+        };
         cps
     }
     pub fn new(local: Local, perm: CapabilityKind) -> Self {
@@ -198,8 +200,7 @@ impl<'tcx> CapabilityProjections<'tcx> {
         }
         let mut ops = Vec::new();
         for (to, from, _) in collapsed {
-            let removed_perms: Vec<_> =
-                old_caps.extract_if(|old, _| to.is_prefix(*old)).collect();
+            let removed_perms: Vec<_> = old_caps.extract_if(|old, _| to.is_prefix(*old)).collect();
             let perm = removed_perms
                 .iter()
                 .fold(CapabilityKind::Exclusive, |acc, (_, p)| {

--- a/mir-state-analysis/src/free_pcs/impl/triple.rs
+++ b/mir-state-analysis/src/free_pcs/impl/triple.rs
@@ -58,7 +58,8 @@ impl<'tcx> Visitor<'tcx> for Fpcs<'_, 'tcx> {
                 self.ensures_unalloc(local);
             }
             &Retag(_, box place) => self.requires_exclusive(place),
-            AscribeUserType(..) | PlaceMention(..) | Coverage(..) | Intrinsic(..) | ConstEvalCounter | Nop => (),
+            AscribeUserType(..) | PlaceMention(..) | Coverage(..) | Intrinsic(..)
+            | ConstEvalCounter | Nop => (),
         };
     }
 
@@ -88,11 +89,19 @@ impl<'tcx> Visitor<'tcx> for Fpcs<'_, 'tcx> {
                     }
                 }
             }
-            &Drop { place, replace: false, .. } => {
+            &Drop {
+                place,
+                replace: false,
+                ..
+            } => {
                 self.requires_write(place);
                 self.ensures_write(place);
             }
-            &Drop { place, replace: true, .. } => {
+            &Drop {
+                place,
+                replace: true,
+                ..
+            } => {
                 self.requires_write(place);
                 self.ensures_exclusive(place);
             }

--- a/mir-state-analysis/src/utils/repacker.rs
+++ b/mir-state-analysis/src/utils/repacker.rs
@@ -11,8 +11,7 @@ use prusti_rustc_interface::{
     index::bit_set::BitSet,
     middle::{
         mir::{
-            tcx::PlaceTy, Body, HasLocalDecls, Local, Mutability, Place as MirPlace,
-            ProjectionElem,
+            tcx::PlaceTy, Body, HasLocalDecls, Local, Mutability, Place as MirPlace, ProjectionElem,
         },
         ty::{TyCtxt, TyKind},
     },

--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -342,7 +342,7 @@ pub fn old<T>(arg: T) -> T {
 /// Universal quantifier.
 ///
 /// This is a Prusti-internal representation of the `forall` syntax.
-#[prusti::builtin="forall"]
+#[prusti::builtin = "forall"]
 pub fn forall<T, F>(_trigger_set: T, _closure: F) -> bool {
     true
 }

--- a/prusti-contracts/prusti-specs/src/lib.rs
+++ b/prusti-contracts/prusti-specs/src/lib.rs
@@ -77,7 +77,9 @@ fn extract_prusti_attributes(
                         // tokens identical to the ones passed by the native procedural
                         // macro call.
                         let mut iter = attr.tokens.into_iter();
-                        let TokenTree::Group(group) = iter.next().unwrap() else { unreachable!() };
+                        let TokenTree::Group(group) = iter.next().unwrap() else {
+                            unreachable!()
+                        };
                         assert!(iter.next().is_none(), "Unexpected shape of an attribute.");
                         group.stream()
                     }
@@ -596,10 +598,14 @@ pub fn refine_trait_spec(_attr: TokenStream, tokens: TokenStream) -> TokenStream
                 let parsed_predicate =
                     handle_result!(predicate::parse_predicate_in_impl(makro.mac.tokens.clone()));
 
-                let ParsedPredicate::Impl(predicate) = parsed_predicate else { unreachable!() };
+                let ParsedPredicate::Impl(predicate) = parsed_predicate else {
+                    unreachable!()
+                };
 
                 // Patch spec function: Rewrite self with _self: <SpecStruct>
-                let syn::Item::Fn(spec_function) = predicate.spec_function else { unreachable!() };
+                let syn::Item::Fn(spec_function) = predicate.spec_function else {
+                    unreachable!()
+                };
                 generated_spec_items.push(spec_function);
 
                 // Add patched predicate function to new items
@@ -872,7 +878,9 @@ fn extract_prusti_attributes_for_types(
                         // tokens identical to the ones passed by the native procedural
                         // macro call.
                         let mut iter = attr.tokens.into_iter();
-                        let TokenTree::Group(group) = iter.next().unwrap() else { unreachable!() };
+                        let TokenTree::Group(group) = iter.next().unwrap() else {
+                            unreachable!()
+                        };
                         group.stream()
                     }
                 };

--- a/prusti-encoder/src/encoders/generic.rs
+++ b/prusti-encoder/src/encoders/generic.rs
@@ -1,7 +1,4 @@
-use task_encoder::{
-    TaskEncoder,
-    TaskEncoderDependencies,
-};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies};
 
 pub struct GenericEncoder;
 
@@ -39,7 +36,8 @@ impl TaskEncoder for GenericEncoder {
     type EncodingError = GenericEncoderError;
 
     fn with_cache<'vir, F, R>(f: F) -> R
-        where F: FnOnce(&'vir task_encoder::CacheRef<'vir, GenericEncoder>) -> R,
+    where
+        F: FnOnce(&'vir task_encoder::CacheRef<'vir, GenericEncoder>) -> R,
     {
         CACHE.with(|cache| {
             // SAFETY: the 'vir and 'tcx given to this function will always be
@@ -57,38 +55,49 @@ impl TaskEncoder for GenericEncoder {
     fn do_encode_full<'vir>(
         task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<(
-        Self::OutputFullLocal<'vir>,
-        Self::OutputFullDependency<'vir>,
-    ), (
-        Self::EncodingError,
-        Option<Self::OutputFullDependency<'vir>>,
-    )> {
-        deps.emit_output_ref::<Self>(*task_key, GenericEncoderOutputRef {
-            snapshot_param_name: "s_Param",
-            predicate_param_name: "p_Param",
-            domain_type_name: "s_Type",
-        });
-        vir::with_vcx(|vcx| Ok((GenericEncoderOutput {
-            snapshot_param: vir::vir_domain! { vcx; domain s_Param {} },
-            predicate_param: vir::vir_predicate! { vcx; predicate p_Param(self_p: Ref/*, self_s: s_Param*/) },
-            domain_type: vir::vir_domain! { vcx; domain s_Type {
-                // TODO: only emit these when the types are actually used?
-                //       emit instead from type encoder, to be consistent with the ADT case?
-                unique function s_Type_Bool(): s_Type;
-                unique function s_Type_Int_isize(): s_Type;
-                unique function s_Type_Int_i8(): s_Type;
-                unique function s_Type_Int_i16(): s_Type;
-                unique function s_Type_Int_i32(): s_Type;
-                unique function s_Type_Int_i64(): s_Type;
-                unique function s_Type_Int_i128(): s_Type;
-                unique function s_Type_Uint_usize(): s_Type;
-                unique function s_Type_Uint_u8(): s_Type;
-                unique function s_Type_Uint_u16(): s_Type;
-                unique function s_Type_Uint_u32(): s_Type;
-                unique function s_Type_Uint_u64(): s_Type;
-                unique function s_Type_Uint_u128(): s_Type;
-            } },
-        }, ())))
+    ) -> Result<
+        (
+            Self::OutputFullLocal<'vir>,
+            Self::OutputFullDependency<'vir>,
+        ),
+        (
+            Self::EncodingError,
+            Option<Self::OutputFullDependency<'vir>>,
+        ),
+    > {
+        deps.emit_output_ref::<Self>(
+            *task_key,
+            GenericEncoderOutputRef {
+                snapshot_param_name: "s_Param",
+                predicate_param_name: "p_Param",
+                domain_type_name: "s_Type",
+            },
+        );
+        vir::with_vcx(|vcx| {
+            Ok((
+                GenericEncoderOutput {
+                    snapshot_param: vir::vir_domain! { vcx; domain s_Param {} },
+                    predicate_param: vir::vir_predicate! { vcx; predicate p_Param(self_p: Ref/*, self_s: s_Param*/) },
+                    domain_type: vir::vir_domain! { vcx; domain s_Type {
+                        // TODO: only emit these when the types are actually used?
+                        //       emit instead from type encoder, to be consistent with the ADT case?
+                        unique function s_Type_Bool(): s_Type;
+                        unique function s_Type_Int_isize(): s_Type;
+                        unique function s_Type_Int_i8(): s_Type;
+                        unique function s_Type_Int_i16(): s_Type;
+                        unique function s_Type_Int_i32(): s_Type;
+                        unique function s_Type_Int_i64(): s_Type;
+                        unique function s_Type_Int_i128(): s_Type;
+                        unique function s_Type_Uint_usize(): s_Type;
+                        unique function s_Type_Uint_u8(): s_Type;
+                        unique function s_Type_Uint_u16(): s_Type;
+                        unique function s_Type_Uint_u32(): s_Type;
+                        unique function s_Type_Uint_u64(): s_Type;
+                        unique function s_Type_Uint_u128(): s_Type;
+                    } },
+                },
+                (),
+            ))
+        })
     }
 }

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -826,12 +826,12 @@ impl<'vir, 'enc> mir::visit::Visitor<'vir> for EncoderVisitor<'vir, 'enc> {
                 // TODO: dedup with mir_pure
                 let attrs = self.vcx.tcx.get_attrs_unchecked(*func_def_id);
                 let is_pure = attrs.iter()
-                .filter(|attr| !attr.is_doc_comment())
-                .map(|attr| attr.get_normal_item()).any(|item| 
-                    item.path.segments.len() == 2
-                    && item.path.segments[0].ident.as_str() == "prusti"
-                    && item.path.segments[1].ident.as_str() == "pure"
-                );
+                    .filter(|attr| !attr.is_doc_comment())
+                    .map(|attr| attr.get_normal_item()).any(|item| 
+                        item.path.segments.len() == 2
+                        && item.path.segments[0].ident.as_str() == "prusti"
+                        && item.path.segments[1].ident.as_str() == "pure"
+                    );
 
                 let dest = self.encode_place(Place::from(*destination));
                 let call_args = args.iter().map(|op| 
@@ -842,7 +842,6 @@ impl<'vir, 'enc> mir::visit::Visitor<'vir> for EncoderVisitor<'vir, 'enc> {
                         self.encode_operand(op)
                     }
                 );
-                // self.encode_operand(op)
 
                 if is_pure {
                     let func_args = call_args.collect::<Vec<_>>();
@@ -853,7 +852,7 @@ impl<'vir, 'enc> mir::visit::Visitor<'vir> for EncoderVisitor<'vir, 'enc> {
                     let pure_func_app = self.vcx.mk_func_app(pure_func_name, &func_args);
 
                     let method_assign = {
-                        //TODO: can we get the method_assign is a better way? Maybe from the MirFunctionEncoder?
+                        //TODO: Can we get `method_assign` in a better way? Maybe from the MirFunctionEncoder?
                         let body = self.vcx.body.borrow_mut().get_impure_fn_body_identity(func_def_id.expect_local());
                         let return_type = self.deps
                             .require_ref::<crate::encoders::TypeEncoder>(body.return_ty())

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -9,6 +9,7 @@ use task_encoder::{
     TaskEncoderDependencies,
 };
 use std::collections::HashMap;
+use crate::encoders::{ViperTupleEncoder, TypeEncoder};
 
 pub struct MirPureEncoder;
 
@@ -448,9 +449,10 @@ impl<'vir, 'enc> Encoder<'vir, 'enc>
                     TyKind::FnDef(def_id, arg_tys) => {
                         // TODO: this attribute extraction should be done elsewhere?
                         let attrs = self.vcx.tcx.get_attrs_unchecked(*def_id);
-                        attrs.iter()
+                        let normal_attrs = attrs.iter()
                             .filter(|attr| !attr.is_doc_comment())
-                            .map(|attr| attr.get_normal_item())
+                            .map(|attr| attr.get_normal_item()).collect::<Vec<_>>();
+                        normal_attrs.iter()
                             .filter(|item| item.path.segments.len() == 2
                                 && item.path.segments[0].ident.as_str() == "prusti"
                                 && item.path.segments[1].ident.as_str() == "builtin")
@@ -467,6 +469,66 @@ impl<'vir, 'enc> Encoder<'vir, 'enc>
                                 }
                                 _ => panic!("illegal prusti::builtin"),
                             });
+
+
+                        let is_pure = normal_attrs.iter().any(|item| 
+                            item.path.segments.len() == 2
+                            && item.path.segments[0].ident.as_str() == "prusti"
+                            && item.path.segments[1].ident.as_str() == "pure"
+                        );
+
+                         // TODO: detect snapshot_equality properly
+                         let is_snapshot_eq = self.vcx.tcx.opt_item_name(*def_id).map(|e| e.as_str() == "snapshot_equality") == Some(true)
+                            && self.vcx.tcx.crate_name(def_id.krate).as_str() == "prusti_contracts";
+
+                        let func_call = if is_pure {
+                            assert!(builtin.is_none(), "Function is pure and builtin?");
+                            let pure_func = self.deps.require_ref::<crate::encoders::MirFunctionEncoder>(*def_id).unwrap().function_name;
+
+                            let encoded_args = args.iter()
+                                .map(|oper| self.encode_operand(&new_curr_ver, oper))
+                                .collect::<Vec<_>>();
+                            
+                            let func_call = self.vcx.mk_func_app(pure_func, &encoded_args);
+
+                           Some(func_call)
+                        }
+
+                        else if is_snapshot_eq {
+                            assert!(builtin.is_none(), "Function is snapshot_equality and builtin?");
+                            let encoded_args = args.iter()
+                                .map(|oper| self.encode_operand(&new_curr_ver, oper))
+                                .collect::<Vec<_>>();
+
+                            assert_eq!(encoded_args.len(), 2);
+
+
+                            let eq_expr  = self.vcx.alloc(vir::ExprGenData::BinOp(self.vcx.alloc(vir::BinOpGenData {
+                                kind: vir::BinOpKind::CmpEq,
+                                lhs: encoded_args[0],
+                                rhs: encoded_args[1],
+                            })));
+
+
+                            // TODO: type encoder
+                            Some(self.vcx.mk_func_app("s_Bool_cons", &[eq_expr]))
+                        }
+                        else {
+                            None
+                        };
+
+
+                        if let Some(func_call) = func_call {
+                            let mut term_update = Update::new();
+                            assert!(destination.projection.is_empty());
+                            self.bump_version(&mut term_update, destination.local, func_call);
+                            term_update.add_to_map(&mut new_curr_ver);
+    
+                            // walk rest of CFG
+                            let end_update = self.encode_cfg(&new_curr_ver, target.unwrap(), end);
+    
+                            return stmt_update.merge(term_update).merge(end_update);
+                        }
                     }
                     _ => todo!(),
                 }
@@ -769,24 +831,48 @@ impl<'vir, 'enc> Encoder<'vir, 'enc>
         }
 
         let local = self.mk_local_ex(place.local, curr_ver[&place.local]);
-        if !place.projection.is_empty() {
-            // TODO: for now, assume this is a closure argument
-            assert_eq!(place.projection[0], mir::ProjectionElem::Deref);
-            assert!(matches!(place.projection[1], mir::ProjectionElem::Field(..)));
-            assert_eq!(place.projection[2], mir::ProjectionElem::Deref);
-            assert_eq!(place.projection.len(), 3);
-            let upvars = match self.body.local_decls[place.local].ty.peel_refs().kind() {
-                TyKind::Closure(_def_id, args) => args.as_closure().upvar_tys().collect::<Vec<_>>().len(),
-                _ => unreachable!(),
-            };
-            let tuple_ref = self.deps.require_ref::<crate::encoders::ViperTupleEncoder>(
-                upvars,
-            ).unwrap();
-            return match place.projection[1] {
-                mir::ProjectionElem::Field(idx, _) => tuple_ref.mk_elem(self.vcx, local, idx.as_usize()),
-                _ => todo!(),
-            };
+        let mut partent_ty =  self.body.local_decls[place.local].ty;
+        let mut expr = local;
+
+        for elem in place.projection {
+            (partent_ty, expr) = self.encode_place_element(partent_ty, elem, expr);
         }
-        local
+
+        expr
+    }
+
+
+    fn encode_place_element(&mut self, parent_ty: ty::Ty<'vir>, elem: mir::PlaceElem<'vir>, expr: ExprRet<'vir>) -> (ty::Ty<'vir>, ExprRet<'vir>) {
+        let parent_ty = parent_ty.peel_refs();
+
+         match elem {
+            mir::ProjectionElem::Deref => {
+                (parent_ty, expr)
+            }
+            mir::ProjectionElem::Field(field_idx, field_ty) => {
+                let field_idx= field_idx.as_usize();
+                match parent_ty.kind() {
+                    TyKind::Closure(_def_id, args) => {
+                        let upvars = args.as_closure().upvar_tys().collect::<Vec<_>>().len();
+                        let tuple_ref = self.deps.require_ref::<ViperTupleEncoder>(
+                            upvars,
+                        ).unwrap();
+                        let tup  = tuple_ref.mk_elem(self.vcx, expr, field_idx);
+
+                        (field_ty, tup)
+                    }
+                    _ => {
+                        let local_encoded_ty = self.deps.require_ref::<TypeEncoder>(parent_ty).unwrap();
+                        let struct_like = local_encoded_ty.expect_structlike();
+                        let proj = struct_like.field_read[field_idx];
+                
+                        let app = self.vcx.mk_func_app(proj, self.vcx.alloc_slice(&[expr]));
+
+                        (field_ty, app)
+                    }
+                }
+            }   
+            _ => todo!("Unsupported ProjectionElem {:?}", elem),
+        }
     }
 }

--- a/prusti-encoder/src/encoders/mir_pure_function.rs
+++ b/prusti-encoder/src/encoders/mir_pure_function.rs
@@ -1,8 +1,11 @@
-use prusti_rustc_interface::{middle::{mir, ty}, span::def_id::DefId};
+use prusti_rustc_interface::{
+    middle::{mir, ty},
+    span::def_id::DefId,
+};
 
+use std::cell::RefCell;
 use task_encoder::{TaskEncoder, TaskEncoderDependencies};
 use vir::Reify;
-use std::cell::RefCell;
 
 use crate::encoders::{
     MirPureEncoder, MirPureEncoderTask, SpecEncoder, SpecEncoderTask, TypeEncoder,
@@ -76,11 +79,14 @@ impl TaskEncoder for MirFunctionEncoder {
             deps.emit_output_ref::<Self>(*task_key, MirFunctionEncoderOutputRef { function_name });
 
             let local_def_id = def_id.expect_local();
-            let body = vcx.body.borrow_mut().get_impure_fn_body_identity(local_def_id);
+            let body = vcx
+                .body
+                .borrow_mut()
+                .get_impure_fn_body_identity(local_def_id);
 
-            let spec = deps.require_local::<crate::encoders::pure::spec::MirSpecEncoder>(
-                (def_id, true)
-            ).unwrap();
+            let spec = deps
+                .require_local::<crate::encoders::pure::spec::MirSpecEncoder>((def_id, true))
+                .unwrap();
 
             let mut func_args = Vec::with_capacity(body.arg_count);
 

--- a/prusti-encoder/src/encoders/mir_pure_function.rs
+++ b/prusti-encoder/src/encoders/mir_pure_function.rs
@@ -73,32 +73,65 @@ impl TaskEncoder for MirFunctionEncoder {
             tracing::debug!("encoding {def_id:?}");
 
             let function_name = vir::vir_format!(vcx, "f_{}", vcx.tcx.item_name(def_id));
-            deps.emit_output_ref::<Self>(def_id, MirFunctionEncoderOutputRef { function_name });
+            deps.emit_output_ref::<Self>(*task_key, MirFunctionEncoderOutputRef { function_name });
 
-            let local_defs = deps.require_local::<crate::encoders::local_def::MirLocalDefEncoder>(
-                def_id,
-            ).unwrap();
+            let local_def_id = def_id.expect_local();
+            let body = vcx.body.borrow_mut().get_impure_fn_body_identity(local_def_id);
+
             let spec = deps.require_local::<crate::encoders::pure::spec::MirSpecEncoder>(
                 (def_id, true)
             ).unwrap();
 
-            let func_args: Vec<_> = (1..=local_defs.arg_count).map(mir::Local::from).map(|arg| vcx.alloc(vir::LocalDeclData {
-                name: local_defs.locals[arg].local.name,
-                ty: local_defs.locals[arg].snapshot,
-            })).collect();
+            let mut func_args = Vec::with_capacity(body.arg_count);
 
-            // Encode the body of the function
-            let expr = deps
-                .require_local::<MirPureEncoder>(MirPureEncoderTask {
-                    encoding_depth: 0,
-                    parent_def_id: def_id,
-                    promoted: None,
-                    param_env: vcx.tcx.param_env(def_id),
-                    substs: ty::List::identity_for_item(vcx.tcx, def_id),
-                })
+            for (arg_idx0, arg_local) in body.args_iter().enumerate() {
+                let arg_idx = arg_idx0 + 1; // enumerate is 0 based but we want to start at 1
+
+                let arg_decl = body.local_decls.get(arg_local).unwrap();
+                let arg_type_ref = deps.require_ref::<TypeEncoder>(arg_decl.ty).unwrap();
+
+                let name_p = vir::vir_format!(vcx, "_{arg_idx}p");
+                func_args.push(vcx.alloc(vir::LocalDeclData {
+                    name: name_p,
+                    ty: arg_type_ref.snapshot,
+                }));
+            }
+
+            // TODO: dedup with mir_pure
+            let attrs = vcx.tcx.get_attrs_unchecked(def_id);
+            let is_trusted = attrs
+                .iter()
+                .filter(|attr| !attr.is_doc_comment())
+                .map(|attr| attr.get_normal_item())
+                .any(|item| {
+                    item.path.segments.len() == 2
+                        && item.path.segments[0].ident.as_str() == "prusti"
+                        && item.path.segments[1].ident.as_str() == "trusted"
+                });
+
+            let expr = if is_trusted {
+                None
+            } else {
+                // Encode the body of the function
+                let expr = deps
+                    .require_local::<MirPureEncoder>(MirPureEncoderTask {
+                        encoding_depth: 0,
+                        parent_def_id: def_id,
+                        promoted: None,
+                        param_env: vcx.tcx.param_env(def_id),
+                        substs: ty::List::identity_for_item(vcx.tcx, def_id),
+                    })
+                    .unwrap()
+                    .expr;
+
+                Some(expr.reify(vcx, (def_id, &spec.pre_args.split_last().unwrap().1)))
+            };
+
+            // Snapshot type of the return type
+            let ret = deps
+                .require_ref::<TypeEncoder>(body.return_ty())
                 .unwrap()
-                .expr;
-            let expr = expr.reify(vcx, (def_id, &spec.pre_args[1..]));
+                .snapshot;
 
             tracing::debug!("finished {def_id:?}");
 
@@ -107,10 +140,10 @@ impl TaskEncoder for MirFunctionEncoder {
                     function: vcx.alloc(vir::FunctionData {
                         name: function_name,
                         args: vcx.alloc_slice(&func_args),
-                        ret: local_defs.locals[mir::RETURN_PLACE].snapshot,
+                        ret,
                         pres: vcx.alloc_slice(&spec.pres),
                         posts: vcx.alloc_slice(&spec.posts),
-                        expr: Some(expr),
+                        expr,
                     }),
                 },
                 (),

--- a/prusti-encoder/src/encoders/mir_pure_function.rs
+++ b/prusti-encoder/src/encoders/mir_pure_function.rs
@@ -16,13 +16,13 @@ pub enum MirFunctionEncoderError {
 
 #[derive(Clone, Debug)]
 pub struct MirFunctionEncoderOutputRef<'vir> {
-    pub method_name: &'vir str,
+    pub function_name: &'vir str,
 }
 impl<'vir> task_encoder::OutputRefAny<'vir> for MirFunctionEncoderOutputRef<'vir> {}
 
 #[derive(Clone, Debug)]
 pub struct MirFunctionEncoderOutput<'vir> {
-    pub method: vir::Function<'vir>,
+    pub function: vir::Function<'vir>,
 }
 
 thread_local! {
@@ -72,8 +72,8 @@ impl TaskEncoder for MirFunctionEncoder {
 
             tracing::debug!("encoding {def_id:?}");
 
-            let method_name = vir::vir_format!(vcx, "f_{}", vcx.tcx.item_name(def_id));
-            deps.emit_output_ref::<Self>(def_id, MirFunctionEncoderOutputRef { method_name });
+            let function_name = vir::vir_format!(vcx, "f_{}", vcx.tcx.item_name(def_id));
+            deps.emit_output_ref::<Self>(def_id, MirFunctionEncoderOutputRef { function_name });
 
             let local_defs = deps.require_local::<crate::encoders::local_def::MirLocalDefEncoder>(
                 def_id,
@@ -104,8 +104,8 @@ impl TaskEncoder for MirFunctionEncoder {
 
             Ok((
                 MirFunctionEncoderOutput {
-                    method: vcx.alloc(vir::FunctionData {
-                        name: method_name,
+                    function: vcx.alloc(vir::FunctionData {
+                        name: function_name,
                         args: vcx.alloc_slice(&func_args),
                         ret: local_defs.locals[mir::RETURN_PLACE].snapshot,
                         pres: vcx.alloc_slice(&spec.pres),

--- a/prusti-encoder/src/encoders/mod.rs
+++ b/prusti-encoder/src/encoders/mod.rs
@@ -9,33 +9,13 @@ mod mir_pure_function;
 pub mod pure;
 pub mod local_def;
 
-pub use generic::{
-    GenericEncoder,
-};
-pub use mir_builtin::{
-    MirBuiltinEncoder,
-    MirBuiltinEncoderTask,
-};
+pub use generic::GenericEncoder;
+pub use mir_builtin::{MirBuiltinEncoder, MirBuiltinEncoderTask};
 pub use mir_impure::MirImpureEncoder;
-pub use mir_pure::{
-    MirPureEncoder,
-    MirPureEncoderTask,
-};
-pub use spec::{
-    SpecEncoder,
-    SpecEncoderOutput,
-    SpecEncoderTask,
-};
+pub use mir_pure::{MirPureEncoder, MirPureEncoderTask};
 pub(super) use spec::{init_def_spec, with_def_spec};
-pub use typ::{
-    TypeEncoder,
-    TypeEncoderOutputRef,
-    TypeEncoderOutput,
-};
-pub use viper_tuple::{
-    ViperTupleEncoder,
-    ViperTupleEncoderOutputRef,
-    ViperTupleEncoderOutput,
-};
+pub use spec::{SpecEncoder, SpecEncoderOutput, SpecEncoderTask};
+pub use typ::{TypeEncoder, TypeEncoderOutput, TypeEncoderOutputRef};
+pub use viper_tuple::{ViperTupleEncoder, ViperTupleEncoderOutput, ViperTupleEncoderOutputRef};
 
 pub use mir_pure_function::MirFunctionEncoder;

--- a/prusti-encoder/src/encoders/spec.rs
+++ b/prusti-encoder/src/encoders/spec.rs
@@ -1,12 +1,6 @@
-use prusti_rustc_interface::{
-    //middle::{mir, ty},
-    span::def_id::DefId,
-};
 use prusti_interface::specs::typed::DefSpecificationMap;
-use task_encoder::{
-    TaskEncoder,
-    TaskEncoderDependencies,
-};
+use prusti_rustc_interface::span::def_id::DefId;
+use task_encoder::{TaskEncoder, TaskEncoderDependencies};
 
 pub struct SpecEncoder;
 
@@ -42,7 +36,7 @@ pub fn init_def_spec(def_spec: DefSpecificationMap) {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SpecEncoderTask {
     pub def_id: DefId, // ID of the function
-    // TODO: substs here?
+                       // TODO: substs here?
 }
 
 impl TaskEncoder for SpecEncoder {
@@ -57,7 +51,8 @@ impl TaskEncoder for SpecEncoder {
     type EncodingError = SpecEncoderError;
 
     fn with_cache<'vir, F, R>(f: F) -> R
-       where F: FnOnce(&'vir task_encoder::CacheRef<'vir, SpecEncoder>) -> R,
+    where
+        F: FnOnce(&'vir task_encoder::CacheRef<'vir, SpecEncoder>) -> R,
     {
         CACHE.with(|cache| {
             // SAFETY: the 'vir and 'tcx given to this function will always be
@@ -78,13 +73,16 @@ impl TaskEncoder for SpecEncoder {
     fn do_encode_full<'vir>(
         task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<(
-        Self::OutputFullLocal<'vir>,
-        Self::OutputFullDependency<'vir>,
-    ), (
-        Self::EncodingError,
-        Option<Self::OutputFullDependency<'vir>>,
-    )> {
+    ) -> Result<
+        (
+            Self::OutputFullLocal<'vir>,
+            Self::OutputFullDependency<'vir>,
+        ),
+        (
+            Self::EncodingError,
+            Option<Self::OutputFullDependency<'vir>>,
+        ),
+    > {
         deps.emit_output_ref::<Self>(task_key.clone(), ());
         vir::with_vcx(|vcx| {
             with_def_spec(|def_spec| {
@@ -98,7 +96,7 @@ impl TaskEncoder for SpecEncoder {
                     .and_then(|specs| specs.base_spec.posts.expect_empty_or_inherent())
                     .map(|specs| vcx.alloc_slice(specs))
                     .unwrap_or_default();
-                Ok((SpecEncoderOutput { pres, posts, }, () ))
+                Ok((SpecEncoderOutput { pres, posts }, ()))
             })
         })
     }

--- a/prusti-encoder/src/encoders/typ.rs
+++ b/prusti-encoder/src/encoders/typ.rs
@@ -468,12 +468,7 @@ impl TaskEncoder for TypeEncoder {
                         name: vir::vir_format!(vcx, "ax_{name_s}_cons_read_{read_idx}"),
                         expr: vcx.alloc(vir::ExprData::Forall(vcx.alloc(vir::ForallData {
                             qvars: cons_qvars.clone(),
-                            triggers: vcx.alloc_slice(&[vcx.alloc_slice(&[
-                                vcx.mk_func_app(
-                                    vir::vir_format!(vcx, "{name_s}_read_{read_idx}"),
-                                    &[cons_call],
-                                ),
-                            ])]),
+                            triggers: vcx.alloc_slice(&[vcx.alloc_slice(&[cons_call])]),
                             body: vcx.alloc(vir::ExprData::BinOp(vcx.alloc(vir::BinOpData {
                                 kind: vir::BinOpKind::CmpEq,
                                 lhs: vcx.mk_func_app(
@@ -620,6 +615,7 @@ impl TaskEncoder for TypeEncoder {
                         function s_Bool_cons(Bool): s_Bool;
                         function s_Bool_val(s_Bool): Bool;
                         axiom_inverse(s_Bool_val, s_Bool_cons, Bool);
+                        axiom_inverse(s_Bool_cons, s_Bool_val, s_Bool);
                     } },
                     predicate: mk_simple_predicate(vcx, "p_Bool", "f_Bool"),
                     function_unreachable: mk_unreachable(vcx, "s_Bool", ty_s),
@@ -663,6 +659,7 @@ impl TaskEncoder for TypeEncoder {
                         function [name_cons](Int): [ty_s];
                         function [name_val]([ty_s]): Int;
                         axiom_inverse([name_val], [name_cons], Int);
+                        axiom_inverse([name_cons], [name_val], [ty_s]);
                     } },
                     predicate: mk_simple_predicate(vcx, name_p, name_field),
                     function_unreachable: mk_unreachable(vcx, name_s, ty_s),

--- a/prusti-encoder/src/encoders/viper_tuple.rs
+++ b/prusti-encoder/src/encoders/viper_tuple.rs
@@ -150,7 +150,7 @@ impl TaskEncoder for ViperTupleEncoder {
                 domain: Some(vcx.alloc(vir::DomainData {
                     name: domain_name,
                     typarams: vcx.alloc_slice(&typaram_names),
-                    axioms: vcx.alloc_slice(&[axiom]),
+                    axioms: if task_key == &0 {&[]} else {vcx.alloc_slice(&[axiom])},
                     functions: vcx.alloc_slice(&functions),
                 })),
             }, ()))

--- a/prusti-encoder/src/encoders/viper_tuple.rs
+++ b/prusti-encoder/src/encoders/viper_tuple.rs
@@ -1,8 +1,5 @@
-use task_encoder::{
-    TaskEncoder,
-    TaskEncoderDependencies,
-};
 use std::cell::RefCell;
+use task_encoder::{TaskEncoder, TaskEncoderDependencies};
 
 pub struct ViperTupleEncoder;
 
@@ -19,7 +16,7 @@ impl<'vir> ViperTupleEncoderOutputRef<'vir> {
     pub fn mk_cons<Curr, Next>(
         &self,
         vcx: &'vir vir::VirCtxt<'vir>,
-        elems: &[vir::ExprGen<'vir, Curr, Next>]
+        elems: &[vir::ExprGen<'vir, Curr, Next>],
     ) -> vir::ExprGen<'vir, Curr, Next> {
         if self.elem_count == 1 {
             return elems[0];
@@ -58,7 +55,8 @@ impl TaskEncoder for ViperTupleEncoder {
     type EncodingError = ();
 
     fn with_cache<'vir, F, R>(f: F) -> R
-       where F: FnOnce(&'vir task_encoder::CacheRef<'vir, ViperTupleEncoder>) -> R,
+    where
+        F: FnOnce(&'vir task_encoder::CacheRef<'vir, ViperTupleEncoder>) -> R,
     {
         CACHE.with(|cache| {
             // SAFETY: the 'vir and 'tcx given to this function will always be
@@ -76,69 +74,89 @@ impl TaskEncoder for ViperTupleEncoder {
     fn do_encode_full<'vir>(
         task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<(
-        Self::OutputFullLocal<'vir>,
-        Self::OutputFullDependency<'vir>,
-    ), (
-        Self::EncodingError,
-        Option<Self::OutputFullDependency<'vir>>,
-    )> {
+    ) -> Result<
+        (
+            Self::OutputFullLocal<'vir>,
+            Self::OutputFullDependency<'vir>,
+        ),
+        (
+            Self::EncodingError,
+            Option<Self::OutputFullDependency<'vir>>,
+        ),
+    > {
         vir::with_vcx(|vcx| {
             let domain_name = vir::vir_format!(vcx, "Tuple_{task_key}");
             let cons_name = vir::vir_format!(vcx, "Tuple_{task_key}_cons");
             let elem_names = (0..*task_key)
                 .map(|idx| vir::vir_format!(vcx, "Tuple_{task_key}_elem_{idx}"))
                 .collect::<Vec<_>>();
-            deps.emit_output_ref::<Self>(*task_key, ViperTupleEncoderOutputRef {
-                elem_count: *task_key,
-                domain_name,
-                cons_name,
-                elem_names: vcx.alloc_slice(&elem_names),
-            });
+            deps.emit_output_ref::<Self>(
+                *task_key,
+                ViperTupleEncoderOutputRef {
+                    elem_count: *task_key,
+                    domain_name,
+                    cons_name,
+                    elem_names: vcx.alloc_slice(&elem_names),
+                },
+            );
             let typaram_names = (0..*task_key)
                 .map(|idx| vir::vir_format!(vcx, "T{idx}"))
                 .collect::<Vec<_>>();
-            let typaram_tys = vcx.alloc_slice(&typaram_names.iter()
-                .map(|name| vcx.alloc(vir::TypeData::Domain(name)))
-                .collect::<Vec<_>>());
+            let typaram_tys = vcx.alloc_slice(
+                &typaram_names
+                    .iter()
+                    .map(|name| vcx.alloc(vir::TypeData::Domain(name)))
+                    .collect::<Vec<_>>(),
+            );
             let domain_ty = vcx.alloc(vir::TypeData::DomainParams(domain_name, typaram_tys));
             let qvars_names = (0..*task_key)
                 .map(|idx| vir::vir_format!(vcx, "elem{idx}"))
                 .collect::<Vec<_>>();
-            let qvars_decl = vcx.alloc_slice(&(0..*task_key)
-                .map(|idx| vcx.mk_local_decl(qvars_names[idx], typaram_tys[idx]))
-                .collect::<Vec<_>>());
+            let qvars_decl = vcx.alloc_slice(
+                &(0..*task_key)
+                    .map(|idx| vcx.mk_local_decl(qvars_names[idx], typaram_tys[idx]))
+                    .collect::<Vec<_>>(),
+            );
             let qvars_ex = (0..*task_key)
                 .map(|idx| vcx.mk_local_ex(qvars_names[idx]))
                 .collect::<Vec<_>>();
             let cons_call = vcx.mk_func_app(
                 cons_name,
-                &qvars_names.iter()
+                &qvars_names
+                    .iter()
                     .map(|qvar| vcx.mk_local_ex(qvar))
                     .collect::<Vec<_>>(),
             );
             let axiom = vcx.alloc(vir::DomainAxiomData {
                 name: vir::vir_format!(vcx, "ax_Tuple_{task_key}_elem"),
-                expr: vcx.alloc(vir::ExprData::Forall(vcx.alloc(vir::ForallData {
-                    qvars: qvars_decl,
-                    triggers: vcx.alloc_slice(&[vcx.alloc_slice(&[cons_call])]),
-                    body: vcx.mk_conj(&(0..*task_key)
-                        .map(|idx| vcx.alloc(vir::ExprData::BinOp(vcx.alloc(vir::BinOpData {
-                            kind: vir::BinOpKind::CmpEq,
-                            lhs: vcx.mk_func_app(elem_names[idx], &[cons_call]),
-                            rhs: qvars_ex[idx],
-                        }))))
-                        .collect::<Vec<_>>()),
-                }))),
+                expr: vcx.alloc(vir::ExprData::Forall(
+                    vcx.alloc(vir::ForallData {
+                        qvars: qvars_decl,
+                        triggers: vcx.alloc_slice(&[vcx.alloc_slice(&[cons_call])]),
+                        body: vcx.mk_conj(
+                            &(0..*task_key)
+                                .map(|idx| {
+                                    vcx.alloc(vir::ExprData::BinOp(vcx.alloc(vir::BinOpData {
+                                        kind: vir::BinOpKind::CmpEq,
+                                        lhs: vcx.mk_func_app(elem_names[idx], &[cons_call]),
+                                        rhs: qvars_ex[idx],
+                                    })))
+                                })
+                                .collect::<Vec<_>>(),
+                        ),
+                    }),
+                )),
             });
             let elem_args = vcx.alloc_slice(&[domain_ty]);
             let mut functions = (0..*task_key)
-                .map(|idx| vcx.alloc(vir::DomainFunctionData {
-                    unique: false,
-                    name: elem_names[idx],
-                    args: elem_args,
-                    ret: typaram_tys[idx],
-                }))
+                .map(|idx| {
+                    vcx.alloc(vir::DomainFunctionData {
+                        unique: false,
+                        name: elem_names[idx],
+                        args: elem_args,
+                        ret: typaram_tys[idx],
+                    })
+                })
                 .collect::<Vec<_>>();
             functions.push(vcx.alloc(vir::DomainFunctionData {
                 unique: false,
@@ -146,14 +164,21 @@ impl TaskEncoder for ViperTupleEncoder {
                 args: typaram_tys,
                 ret: domain_ty,
             }));
-            Ok((ViperTupleEncoderOutput {
-                domain: Some(vcx.alloc(vir::DomainData {
-                    name: domain_name,
-                    typarams: vcx.alloc_slice(&typaram_names),
-                    axioms: if task_key == &0 {&[]} else {vcx.alloc_slice(&[axiom])},
-                    functions: vcx.alloc_slice(&functions),
-                })),
-            }, ()))
+            Ok((
+                ViperTupleEncoderOutput {
+                    domain: Some(vcx.alloc(vir::DomainData {
+                        name: domain_name,
+                        typarams: vcx.alloc_slice(&typaram_names),
+                        axioms: if task_key == &0 {
+                            &[]
+                        } else {
+                            vcx.alloc_slice(&[axiom])
+                        },
+                        functions: vcx.alloc_slice(&functions),
+                    })),
+                },
+                (),
+            ))
         })
     }
 }

--- a/prusti-encoder/src/lib.rs
+++ b/prusti-encoder/src/lib.rs
@@ -9,7 +9,7 @@ extern crate rustc_type_ir;
 
 mod encoders;
 
-use prusti_interface::environment::EnvBody;
+use prusti_interface::{environment::EnvBody, specs::typed::SpecificationItem};
 use prusti_rustc_interface::{
     middle::ty,
     hir,
@@ -127,7 +127,7 @@ pub fn test_entrypoint<'tcx>(
     // TODO: this should be a "crate" encoder, which will deps.require all the methods in the crate
 
     for def_id in tcx.hir_crate_items(()).definitions() {
-        //println!("item: {def_id:?}");
+        tracing::debug!("test_entrypoint item: {def_id:?}");
         let kind = tcx.def_kind(def_id);
         //println!("  kind: {:?}", kind);
         /*if !format!("{def_id:?}").contains("foo") {
@@ -162,7 +162,7 @@ pub fn test_entrypoint<'tcx>(
                 }*/
             }
             unsupported_item_kind => {
-                println!("another item: {unsupported_item_kind:?}");
+                tracing::debug!("unsupported item: {unsupported_item_kind:?}");
             }
         }
     }
@@ -182,7 +182,7 @@ pub fn test_entrypoint<'tcx>(
 
     header(&mut viper_code, "functions");
     for output in crate::encoders::MirFunctionEncoder::all_outputs() {
-        viper_code.push_str(&format!("{:?}\n", output.method));
+        viper_code.push_str(&format!("{:?}\n", output.function));
     }
 
     header(&mut viper_code, "MIR builtins");

--- a/prusti-encoder/src/lib.rs
+++ b/prusti-encoder/src/lib.rs
@@ -10,10 +10,7 @@ extern crate rustc_type_ir;
 mod encoders;
 
 use prusti_interface::{environment::EnvBody, specs::typed::SpecificationItem};
-use prusti_rustc_interface::{
-    middle::ty,
-    hir,
-};
+use prusti_rustc_interface::{hir, middle::ty};
 
 /*
 struct MirBodyPureEncoder;
@@ -100,7 +97,7 @@ impl<'vir, 'tcx> TaskEncoder<'vir, 'tcx> for MirBodyImpureEncoder<'vir, 'tcx> {
     );
     // TaskKey, OutputRef same as above
     type OutputFull = vir::Method<'vir>;
-} 
+}
 
 struct MirTyEncoder<'vir, 'tcx>(PhantomData<&'vir ()>, PhantomData<&'tcx ()>);
 impl<'vir, 'tcx> TaskEncoder<'vir, 'tcx> for MirTyEncoder<'vir, 'tcx> {
@@ -147,27 +144,29 @@ pub fn test_entrypoint<'tcx>(
                         .get_proc_spec(&def_id.to_def_id())
                         .map(|e| &e.base_spec);
 
-                        let is_pure = base_spec.and_then(|kind| kind.kind.is_pure().ok()).unwrap_or_default();
-                        let is_trusted = matches!(base_spec.map(|spec| spec.trusted), Some(SpecificationItem::Inherent(
-                            true,
-                        )));
-                        (is_pure, is_trusted)
-                    }
-                );
+                    let is_pure = base_spec
+                        .and_then(|kind| kind.kind.is_pure().ok())
+                        .unwrap_or_default();
+                    let is_trusted = matches!(
+                        base_spec.map(|spec| spec.trusted),
+                        Some(SpecificationItem::Inherent(true,))
+                    );
+                    (is_pure, is_trusted)
+                });
 
-                if ! (is_trusted && is_pure) {
+                if !(is_trusted && is_pure) {
                     let res = crate::encoders::MirImpureEncoder::encode(def_id.to_def_id());
                     assert!(res.is_ok());
                 }
-               
 
                 if is_pure {
-                    tracing::debug!("Encoding {def_id:?} as a pure function because it is labeled as pure");
+                    tracing::debug!(
+                        "Encoding {def_id:?} as a pure function because it is labeled as pure"
+                    );
                     let res = crate::encoders::MirFunctionEncoder::encode(def_id.to_def_id());
                     assert!(res.is_ok());
                 }
 
-            
                 /*
                 match res {
                     Ok(res) => println!("ok: {:?}", res),
@@ -235,20 +234,20 @@ pub fn test_entrypoint<'tcx>(
 
     std::fs::write("local-testing/simple.vpr", viper_code).unwrap();
 
-    vir::with_vcx(|vcx| vcx.alloc(vir::ProgramData {
-        fields: &[],
-        domains: &[],
-        predicates: &[],
-        functions: vcx.alloc_slice(&[
-            vcx.alloc(vir::FunctionData {
+    vir::with_vcx(|vcx| {
+        vcx.alloc(vir::ProgramData {
+            fields: &[],
+            domains: &[],
+            predicates: &[],
+            functions: vcx.alloc_slice(&[vcx.alloc(vir::FunctionData {
                 name: "test_function",
                 args: &[],
                 ret: &vir::TypeData::Bool,
                 pres: &[],
                 posts: &[],
                 expr: None,
-            }),
-        ]),
-        methods: &[],
-    }))
+            })]),
+            methods: &[],
+        })
+    })
 }

--- a/prusti-interface/src/environment/body.rs
+++ b/prusti-interface/src/environment/body.rs
@@ -136,7 +136,7 @@ impl<'tcx> EnvBody<'tcx> {
 
         BodyWithBorrowckFacts {
             body: MirBody(Rc::new(body_with_facts.body)),
-           // borrowck_facts: Rc::new(facts),
+            // borrowck_facts: Rc::new(facts),
         }
     }
 
@@ -174,12 +174,18 @@ impl<'tcx> EnvBody<'tcx> {
         {
             let monomorphised = if let Some(caller_def_id) = caller_def_id {
                 let param_env = self.tcx.param_env(caller_def_id);
-                self.tcx
-                    .subst_and_normalize_erasing_regions(substs, param_env, ty::EarlyBinder::bind(body.0))
+                self.tcx.subst_and_normalize_erasing_regions(
+                    substs,
+                    param_env,
+                    ty::EarlyBinder::bind(body.0),
+                )
             } else {
                 let param_env = self.tcx.param_env(def_id);
-                self.tcx
-                    .subst_and_normalize_erasing_regions(substs, param_env, ty::EarlyBinder::bind(body.0))
+                self.tcx.subst_and_normalize_erasing_regions(
+                    substs,
+                    param_env,
+                    ty::EarlyBinder::bind(body.0),
+                )
             };
             v.insert(MirBody(monomorphised)).clone()
         } else {
@@ -201,7 +207,11 @@ impl<'tcx> EnvBody<'tcx> {
     /// with the given type substitutions.
     ///
     /// FIXME: This function is called only in pure contexts???
-    pub fn get_impure_fn_body(&self, def_id: LocalDefId, substs: GenericArgsRef<'tcx>) -> MirBody<'tcx> {
+    pub fn get_impure_fn_body(
+        &self,
+        def_id: LocalDefId,
+        substs: GenericArgsRef<'tcx>,
+    ) -> MirBody<'tcx> {
         if let Some(body) = self.get_monomorphised(def_id.to_def_id(), substs, None) {
             return body;
         }
@@ -328,7 +338,7 @@ impl<'tcx> EnvBody<'tcx> {
 
     pub(crate) fn load_pure_fn_body(&mut self, def_id: LocalDefId) {
         assert!(!self.pure_fns.local.contains_key(&def_id));
-        let body = Self::load_local_mir( self.tcx, def_id);
+        let body = Self::load_local_mir(self.tcx, def_id);
         self.pure_fns.local.insert(def_id, body);
         let bwbf = Self::load_local_mir_with_facts(self.tcx, def_id);
         // Also add to `impure_fns` since we'll also be encoding this as impure

--- a/prusti-interface/src/specs/encoder.rs
+++ b/prusti-interface/src/specs/encoder.rs
@@ -18,10 +18,7 @@ pub struct DefSpecsEncoder<'tcx> {
 }
 
 impl<'tcx> DefSpecsEncoder<'tcx> {
-    pub fn new(
-        tcx: TyCtxt<'tcx>,
-        path: &std::path::PathBuf,
-    ) -> std::io::Result<Self> {
+    pub fn new(tcx: TyCtxt<'tcx>, path: &std::path::PathBuf) -> std::io::Result<Self> {
         Ok(DefSpecsEncoder {
             tcx,
             opaque: opaque::FileEncoder::new(path)?,

--- a/prusti-interface/src/specs/external.rs
+++ b/prusti-interface/src/specs/external.rs
@@ -4,10 +4,7 @@ use prusti_rustc_interface::{
         def_id::{DefId, LocalDefId},
         intravisit::{self, Visitor},
     },
-    middle::{
-        hir::map::Map,
-        ty::GenericArgsRef,
-    },
+    middle::{hir::map::Map, ty::GenericArgsRef},
     span::Span,
 };
 

--- a/prusti-interface/src/utils.rs
+++ b/prusti-interface/src/utils.rs
@@ -10,7 +10,10 @@ use prusti_rustc_interface::{
     abi::FieldIdx,
     ast::ast,
     data_structures::fx::FxHashSet,
-    middle::{mir, ty::{self, TyCtxt}},
+    middle::{
+        mir,
+        ty::{self, TyCtxt},
+    },
 };
 use std::borrow::Borrow;
 
@@ -95,8 +98,7 @@ pub fn expand_struct_place<'tcx>(
             for (index, field_def) in variant.fields.iter().enumerate() {
                 if Some(index) != without_field {
                     let field = FieldIdx::from_usize(index);
-                    let field_place =
-                        tcx.mk_place_field(place, field, field_def.ty(tcx, substs));
+                    let field_place = tcx.mk_place_field(place, field, field_def.ty(tcx, substs));
                     places.push(field_place);
                 }
             }
@@ -132,7 +134,6 @@ pub fn expand_struct_place<'tcx>(
     }
     places
 }
-
 
 /// Pop the last projection from the place and return the new place with the popped element.
 pub fn try_pop_one_level<'tcx>(

--- a/prusti/src/callbacks.rs
+++ b/prusti/src/callbacks.rs
@@ -9,16 +9,12 @@ use prusti_rustc_interface::{
     borrowck::consumers,
     data_structures::steal::Steal,
     driver::Compilation,
+    hir::{def::DefKind, def_id::LocalDefId},
     index::IndexVec,
     interface::{interface::Compiler, Config, Queries},
-    hir::{def::DefKind, def_id::LocalDefId},
     middle::{
         mir,
-        query::{
-            queries::mir_borrowck::ProvidedValue as MirBorrowck,
-            ExternProviders,
-            Providers
-        },
+        query::{queries::mir_borrowck::ProvidedValue as MirBorrowck, ExternProviders, Providers},
         ty::TyCtxt,
     },
     session::{EarlyErrorHandler, Session},
@@ -174,7 +170,7 @@ impl prusti_rustc_interface::driver::Callbacks for PrustiCompilerCalls {
                         test_free_pcs(&mir, tcx);
                     }
                 } else {*/
-                    verify(env, def_spec);
+                verify(env, def_spec);
                 //}
             }
         });

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -56,18 +56,20 @@ fn report_prusti_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
         prusti_rustc_interface::driver::DEFAULT_LOCALE_RESOURCES.to_vec(),
         false,
     );
-    let emitter = Box::new(prusti_rustc_interface::errors::emitter::EmitterWriter::stderr(
-        prusti_rustc_interface::errors::ColorConfig::Auto,
-        None,
-        None,
-        fallback_bundle,
-        false,
-        false,
-        None,
-        false,
-        false,
-        prusti_rustc_interface::errors::TerminalUrl::Auto,
-    ));
+    let emitter = Box::new(
+        prusti_rustc_interface::errors::emitter::EmitterWriter::stderr(
+            prusti_rustc_interface::errors::ColorConfig::Auto,
+            None,
+            None,
+            fallback_bundle,
+            false,
+            false,
+            None,
+            false,
+            false,
+            prusti_rustc_interface::errors::TerminalUrl::Auto,
+        ),
+    );
     let handler = prusti_rustc_interface::errors::Handler::with_emitter(true, None, emitter);
 
     // a .span_bug or .bug call has already printed what it wants to print.

--- a/prusti/src/verifier.rs
+++ b/prusti/src/verifier.rs
@@ -14,40 +14,36 @@ pub fn verify(env: Environment<'_>, def_spec: typed::DefSpecificationMap) {
     if env.diagnostic.has_errors() {
         warn!("The compiler reported an error, so the program will not be verified.");
     } else {
-        debug!("Prepare verification task...");/*
-        // TODO: can we replace `get_annotated_procedures` with information
-        // that is already in `def_spec`?
-        let (annotated_procedures, types) = env.get_annotated_procedures_and_types();
-        let verification_task = VerificationTask {
-            procedures: annotated_procedures,
-            types,
-        };
-        debug!("Verification task: {:?}", &verification_task);
+        debug!("Prepare verification task..."); /*
+                                                // TODO: can we replace `get_annotated_procedures` with information
+                                                // that is already in `def_spec`?
+                                                let (annotated_procedures, types) = env.get_annotated_procedures_and_types();
+                                                let verification_task = VerificationTask {
+                                                    procedures: annotated_procedures,
+                                                    types,
+                                                };
+                                                debug!("Verification task: {:?}", &verification_task);
 
-        user::message(format!(
-            "Verification of {} items...",
-            verification_task.procedures.len()
-        ));
+                                                user::message(format!(
+                                                    "Verification of {} items...",
+                                                    verification_task.procedures.len()
+                                                ));
 
-        if config::print_collected_verification_items() {
-            println!(
-                "Collected verification items {}:",
-                verification_task.procedures.len()
-            );
-            for procedure in &verification_task.procedures {
-                println!(
-                    "procedure: {} at {:?}",
-                    env.name.get_item_def_path(*procedure),
-                    env.query.get_def_span(procedure)
-                );
-            }
-        }*/
+                                                if config::print_collected_verification_items() {
+                                                    println!(
+                                                        "Collected verification items {}:",
+                                                        verification_task.procedures.len()
+                                                    );
+                                                    for procedure in &verification_task.procedures {
+                                                        println!(
+                                                            "procedure: {} at {:?}",
+                                                            env.name.get_item_def_path(*procedure),
+                                                            env.query.get_def_span(procedure)
+                                                        );
+                                                    }
+                                                }*/
 
-        let program = prusti_encoder::test_entrypoint(
-            env.tcx(),
-            env.body,
-            def_spec,
-        );
+        let program = prusti_encoder::test_entrypoint(env.tcx(), env.body, def_spec);
         //viper::verify(program);
 
         //let verification_result =

--- a/test-crates/src/main.rs
+++ b/test-crates/src/main.rs
@@ -4,6 +4,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use clap::Parser;
+use log::{error, info, warn, LevelFilter};
+use rustwide::{cmd, logging, logging::LogStorage, Crate, Toolchain, Workspace, WorkspaceBuilder};
+use serde::Deserialize;
 use std::{
     env,
     error::Error,
@@ -11,10 +15,6 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use log::{error, info, warn, LevelFilter};
-use rustwide::{cmd, logging, logging::LogStorage, Crate, Toolchain, Workspace, WorkspaceBuilder};
-use serde::Deserialize;
-use clap::Parser;
 
 /// How a crate should be tested. All tests use `check_panics=false`, `check_overflows=false` and
 /// `skip_unsupported_features=true`.
@@ -145,17 +145,21 @@ struct Args {
     shard_index: usize,
 }
 
-fn attempt_fetch(krate: &Crate, workspace: &Workspace, num_retries: u8) -> Result<(), failure::Error> {
+fn attempt_fetch(
+    krate: &Crate,
+    workspace: &Workspace,
+    num_retries: u8,
+) -> Result<(), failure::Error> {
     let mut i = 0;
     while i < num_retries + 1 {
         if let Err(err) = krate.fetch(workspace) {
             warn!("Error fetching crate {}: {}", krate, err);
             if i == num_retries {
                 // Last attempt failed, return the error
-                return Err(err)
+                return Err(err);
             }
         } else {
-            return Ok(())
+            return Ok(());
         }
         i += 1;
     }
@@ -228,7 +232,12 @@ fn main() -> Result<(), Box<dyn Error>> {
             .collect::<Result<Vec<CrateRecord>, _>>()?
             .into_iter()
             .filter(|record| record.name.contains(&args.filter_crate_name))
-            .map(|record| (Crate::crates_io(&record.name, &record.version), record.test_kind))
+            .map(|record| {
+                (
+                    Crate::crates_io(&record.name, &record.version),
+                    record.test_kind,
+                )
+            })
             .collect();
     info!("There are {} crates in total.", crates_list.len());
 
@@ -239,8 +248,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     // List of crates on which Prusti succeed.
     let mut successful_crates = vec![];
 
-    let shard_crates_list: Vec<&(Crate, TestKind)> = crates_list.iter().skip(args.shard_index)
-        .step_by(args.num_shards).collect();
+    let shard_crates_list: Vec<&(Crate, TestKind)> = crates_list
+        .iter()
+        .skip(args.shard_index)
+        .step_by(args.num_shards)
+        .collect();
     info!(
         "Iterate over the {} crates of the shard {}/{}...",
         shard_crates_list.len(),
@@ -248,7 +260,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         args.num_shards,
     );
     for (index, (krate, test_kind)) in shard_crates_list.iter().enumerate() {
-        info!("Crate {}/{}: {}, test kind: {:?}", index, shard_crates_list.len(), krate, test_kind);
+        info!(
+            "Crate {}/{}: {}, test kind: {:?}",
+            index,
+            shard_crates_list.len(),
+            krate,
+            test_kind
+        );
 
         if let TestKind::Skip = test_kind {
             info!("Skip crate");
@@ -300,11 +318,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     guest_prusti_home,
                     cmd::MountKind::ReadOnly,
                 )
-                .mount(
-                    host_viper_home,
-                    guest_viper_home,
-                    cmd::MountKind::ReadOnly,
-                )
+                .mount(host_viper_home, guest_viper_home, cmd::MountKind::ReadOnly)
                 .mount(host_z3_home, guest_z3_home, cmd::MountKind::ReadOnly)
                 .mount(&host_java_home, &guest_java_home, cmd::MountKind::ReadOnly);
             for java_policy_path in &host_java_policies {
@@ -317,7 +331,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             let verification_status = build_dir.build(&toolchain, krate, sandbox).run(|build| {
                 logging::capture(&storage, || {
-                    let mut command = build.cmd(&cargo_prusti)
+                    let mut command = build
+                        .cmd(&cargo_prusti)
                         .env("RUST_BACKTRACE", "1")
                         .env("PRUSTI_ASSERT_TIMEOUT", "60000")
                         .env("PRUSTI_LOG_DIR", "/tmp/prusti_log")
@@ -328,13 +343,14 @@ fn main() -> Result<(), Box<dyn Error>> {
                         .env("PRUSTI_SKIP_UNSUPPORTED_FEATURES", "true");
                     match test_kind {
                         TestKind::NoErrorsWithUnreachableUnsupportedCode => {
-                            command = command.env("PRUSTI_ALLOW_UNREACHABLE_UNSUPPORTED_CODE", "true");
+                            command =
+                                command.env("PRUSTI_ALLOW_UNREACHABLE_UNSUPPORTED_CODE", "true");
                         }
-                        TestKind::NoErrors => {},
+                        TestKind::NoErrors => {}
                         TestKind::NoCrash => {
                             // Report internal errors as warnings
                             command = command.env("PRUSTI_INTERNAL_ERRORS_AS_WARNINGS", "true");
-                        },
+                        }
                         TestKind::Skip => {
                             unreachable!();
                         }
@@ -383,7 +399,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // Panic
-    assert!(failed_crates.is_empty(), "Failed to verify {} crates", failed_crates.len());
+    assert!(
+        failed_crates.is_empty(),
+        "Failed to verify {} crates",
+        failed_crates.len()
+    );
 
     Ok(())
 }

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-tracing = "0.1"
+tracing = { version = "0.1", features = ["log"] }
 proc-macro-tracing = { path = "proc-macro-tracing" }

--- a/tracing/proc-macro-tracing/src/lib.rs
+++ b/tracing/proc-macro-tracing/src/lib.rs
@@ -9,7 +9,7 @@
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{ItemFn, ReturnType, token::Paren, Type, TypeParen};
+use syn::{token::Paren, ItemFn, ReturnType, Type, TypeParen};
 
 // Using `tracing::instrument` without this crate (from the vanilla tracing crate)
 // causes RA to not pick up the return type properly atm - it colours wrong and
@@ -21,17 +21,22 @@ pub fn instrument(attr: TokenStream, tokens: TokenStream) -> TokenStream {
     let (attr, tokens): (TokenStream2, TokenStream2) = (attr.into(), tokens.into());
     if let Ok(mut item) = syn::parse2::<ItemFn>(tokens.clone()) {
         if let ReturnType::Type(a, ty) = item.sig.output {
-            let new_ty = Type::Paren(TypeParen { paren_token: Paren::default(), elem: ty });
+            let new_ty = Type::Paren(TypeParen {
+                paren_token: Paren::default(),
+                elem: ty,
+            });
             item.sig.output = ReturnType::Type(a, Box::new(new_ty));
         }
         quote! {
             #[tracing::tracing_instrument(#attr)]
             #item
-        }.into()
+        }
+        .into()
     } else {
         quote! {
             #[tracing::tracing_instrument(#attr)]
             #tokens
-        }.into()
+        }
+        .into()
     }
 }

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -4,5 +4,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-pub use tracing::{*, instrument as tracing_instrument};
 pub use proc_macro_tracing::instrument;
+pub use tracing::{instrument as tracing_instrument, *};

--- a/vir-proc-macro/src/lib.rs
+++ b/vir-proc-macro/src/lib.rs
@@ -3,7 +3,9 @@ use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
 fn is_reify_copy(field: &syn::Field) -> bool {
-    field.attrs.iter()
+    field
+        .attrs
+        .iter()
         .filter_map(|attr| match &attr.meta {
             syn::Meta::Path(p) => Some(&p.segments),
             _ => None,
@@ -29,13 +31,11 @@ pub fn derive_reify(input: TokenStream) -> TokenStream {
     };
     TokenStream::from(match input.data {
         syn::Data::Struct(syn::DataStruct {
-            fields: syn::Fields::Named(syn::FieldsNamed {
-                named,
-                ..
-            }),
+            fields: syn::Fields::Named(syn::FieldsNamed { named, .. }),
             ..
         }) => {
-            let compute_fields = named.iter()
+            let compute_fields = named
+                .iter()
                 .filter_map(|field| {
                     let name = field.ident.as_ref().unwrap();
                     if is_reify_copy(field) {
@@ -47,7 +47,8 @@ pub fn derive_reify(input: TokenStream) -> TokenStream {
                     }
                 })
                 .collect::<Vec<_>>();
-            let fields = named.iter()
+            let fields = named
+                .iter()
                 .map(|field| {
                     let name = field.ident.as_ref().unwrap();
                     if is_reify_copy(field) {
@@ -70,25 +71,21 @@ pub fn derive_reify(input: TokenStream) -> TokenStream {
                 #slice_impl
             }
         }
-        syn::Data::Enum(syn::DataEnum {
-            variants,
-            ..
-        }) => {
-            let variants = variants.iter()
+        syn::Data::Enum(syn::DataEnum { variants, .. }) => {
+            let variants = variants
+                .iter()
                 .map(|variant| {
                     let variant_name = &variant.ident;
                     match &variant.fields {
-                        syn::Fields::Unnamed(syn::FieldsUnnamed {
-                            unnamed,
-                            ..
-                        }) => {
+                        syn::Fields::Unnamed(syn::FieldsUnnamed { unnamed, .. }) => {
                             let vbinds = (0..unnamed.len())
                                 .map(|idx| quote::format_ident!("v{idx}"))
                                 .collect::<Vec<_>>();
                             let obinds = (0..unnamed.len())
                                 .map(|idx| quote::format_ident!("opt{idx}"))
                                 .collect::<Vec<_>>();
-                            let compute_fields = unnamed.iter()
+                            let compute_fields = unnamed
+                                .iter()
                                 .enumerate()
                                 .filter_map(|(idx, field)| {
                                     if is_reify_copy(field) {
@@ -102,7 +99,8 @@ pub fn derive_reify(input: TokenStream) -> TokenStream {
                                     }
                                 })
                                 .collect::<Vec<_>>();
-                            let fields = unnamed.iter()
+                            let fields = unnamed
+                                .iter()
                                 .enumerate()
                                 .map(|(idx, field)| {
                                     let vbind = &vbinds[idx];
@@ -120,7 +118,7 @@ pub fn derive_reify(input: TokenStream) -> TokenStream {
                                     vcx.alloc(#name::#variant_name(#(#fields),*))
                                 }
                             }
-                        },
+                        }
                         syn::Fields::Unit => quote! {
                             #name::#variant_name => &#name::#variant_name
                         },

--- a/vir/src/context.rs
+++ b/vir/src/context.rs
@@ -1,11 +1,8 @@
-use std::cell::RefCell;
 use prusti_interface::environment::EnvBody;
 use prusti_rustc_interface::middle::ty;
+use std::cell::RefCell;
 
-use crate::data::*;
-use crate::gendata::*;
-use crate::genrefs::*;
-use crate::refs::*;
+use crate::{data::*, gendata::*, genrefs::*, refs::*};
 
 /// The VIR context is a data structure used throughout the encoding process.
 pub struct VirCtxt<'tcx> {
@@ -20,13 +17,11 @@ pub struct VirCtxt<'tcx> {
     pub span_stack: Vec<i32>,
     // TODO: span stack
     // TODO: error positions?
-
     /// The compiler's typing context. This allows convenient access to most
     /// of the compiler's APIs.
     pub tcx: ty::TyCtxt<'tcx>,
 
     pub body: RefCell<EnvBody<'tcx>>,
-    
 }
 
 impl<'tcx> VirCtxt<'tcx> {
@@ -48,25 +43,23 @@ impl<'tcx> VirCtxt<'tcx> {
         &*self.arena.alloc_str(val)
     }
 
-/*    pub fn alloc_slice<'a, T: Copy>(&'tcx self, val: &'a [T]) -> &'tcx [T] {
-        &*self.arena.alloc_slice_copy(val)
-        }*/
+    /*    pub fn alloc_slice<'a, T: Copy>(&'tcx self, val: &'a [T]) -> &'tcx [T] {
+    &*self.arena.alloc_slice_copy(val)
+    }*/
     pub fn alloc_slice<T: Copy>(&self, val: &[T]) -> &[T] {
         &*self.arena.alloc_slice_copy(val)
     }
 
     pub fn mk_local<'vir>(&'vir self, name: &'vir str) -> Local<'vir> {
-        self.arena.alloc(LocalData {
-            name,
-        })
+        self.arena.alloc(LocalData { name })
     }
     pub fn mk_local_decl(&'tcx self, name: &'tcx str, ty: Type<'tcx>) -> LocalDecl<'tcx> {
-        self.arena.alloc(LocalDeclData {
-            name,
-            ty,
-        })
+        self.arena.alloc(LocalDeclData { name, ty })
     }
-    pub fn mk_local_ex_local<Curr, Next>(&'tcx self, local: Local<'tcx>) -> ExprGen<'tcx, Curr, Next> {
+    pub fn mk_local_ex_local<Curr, Next>(
+        &'tcx self,
+        local: Local<'tcx>,
+    ) -> ExprGen<'tcx, Curr, Next> {
         self.arena.alloc(ExprGenData::Local(local))
     }
     pub fn mk_local_ex<Curr, Next>(&'tcx self, name: &'tcx str) -> ExprGen<'tcx, Curr, Next> {
@@ -77,16 +70,18 @@ impl<'tcx> VirCtxt<'tcx> {
         target: &'tcx str,
         src_args: &[ExprGen<'tcx, Curr, Next>],
     ) -> ExprGen<'tcx, Curr, Next> {
-        self.arena.alloc(ExprGenData::FuncApp(self.arena.alloc(FuncAppGenData {
-            target,
-            args: self.alloc_slice(src_args),
-        })))
+        self.arena
+            .alloc(ExprGenData::FuncApp(self.arena.alloc(FuncAppGenData {
+                target,
+                args: self.alloc_slice(src_args),
+            })))
     }
     pub fn mk_pred_app(&'tcx self, target: &'tcx str, src_args: &[Expr<'tcx>]) -> Expr<'tcx> {
-        self.arena.alloc(ExprData::PredicateApp(self.arena.alloc(PredicateAppData {
-            target,
-            args: self.alloc_slice(src_args),
-        })))
+        self.arena
+            .alloc(ExprData::PredicateApp(self.arena.alloc(PredicateAppData {
+                target,
+                args: self.alloc_slice(src_args),
+            })))
     }
 
     pub fn mk_true(&'tcx self) -> Expr<'tcx> {

--- a/vir/src/data.rs
+++ b/vir/src/data.rs
@@ -41,6 +41,7 @@ pub enum BinOpKind {
     CmpLe,
     And,
     Add,
+    Sub,
     // ...
 }
 impl From<mir::BinOp> for BinOpKind {

--- a/vir/src/data.rs
+++ b/vir/src/data.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
-use prusti_rustc_interface::middle::mir;
 use crate::refs::*;
+use prusti_rustc_interface::middle::mir;
 
 pub struct LocalData<'vir> {
     pub name: &'vir str, // TODO: identifiers

--- a/vir/src/debug.rs
+++ b/vir/src/debug.rs
@@ -57,6 +57,7 @@ impl<'vir, Curr, Next> Debug for BinOpGenData<'vir, Curr, Next> {
             BinOpKind::CmpLe => "<=",
             BinOpKind::And => "&&",
             BinOpKind::Add => "+",
+            BinOpKind::Sub => "-",
         })?;
         self.rhs.fmt(f)?;
         write!(f, ")")

--- a/vir/src/debug.rs
+++ b/vir/src/debug.rs
@@ -1,13 +1,14 @@
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 
-use crate::data::*;
-use crate::gendata::*;
+use crate::{data::*, gendata::*};
 
 fn fmt_comma_sep_display<T: Display>(f: &mut Formatter<'_>, els: &[T]) -> FmtResult {
     els.iter()
         .enumerate()
         .map(|(idx, el)| {
-            if idx > 0 { write!(f, ", ")? }
+            if idx > 0 {
+                write!(f, ", ")?
+            }
             el.fmt(f)
         })
         .collect::<FmtResult>()
@@ -16,7 +17,9 @@ fn fmt_comma_sep<T: Debug>(f: &mut Formatter<'_>, els: &[T]) -> FmtResult {
     els.iter()
         .enumerate()
         .map(|(idx, el)| {
-            if idx > 0 { write!(f, ", ")? }
+            if idx > 0 {
+                write!(f, ", ")?
+            }
             el.fmt(f)
         })
         .collect::<FmtResult>()
@@ -32,10 +35,7 @@ fn fmt_comma_sep_lines<T: Debug>(f: &mut Formatter<'_>, els: &[T]) -> FmtResult 
     Ok(())
 }
 fn indent(s: String) -> String {
-    s
-        .split("\n")
-        .intersperse("\n  ")
-        .collect::<String>()
+    s.split("\n").intersperse("\n  ").collect::<String>()
 }
 
 impl<'vir, Curr, Next> Debug for AccFieldGenData<'vir, Curr, Next> {
@@ -48,17 +48,21 @@ impl<'vir, Curr, Next> Debug for BinOpGenData<'vir, Curr, Next> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "(")?;
         self.lhs.fmt(f)?;
-        write!(f, ") {} (", match self.kind {
-            BinOpKind::CmpEq => "==",
-            BinOpKind::CmpNe => "!=",
-            BinOpKind::CmpGt => ">",
-            BinOpKind::CmpGe => ">=",
-            BinOpKind::CmpLt => "<",
-            BinOpKind::CmpLe => "<=",
-            BinOpKind::And => "&&",
-            BinOpKind::Add => "+",
-            BinOpKind::Sub => "-",
-        })?;
+        write!(
+            f,
+            ") {} (",
+            match self.kind {
+                BinOpKind::CmpEq => "==",
+                BinOpKind::CmpNe => "!=",
+                BinOpKind::CmpGt => ">",
+                BinOpKind::CmpGe => ">=",
+                BinOpKind::CmpLt => "<",
+                BinOpKind::CmpLe => "<=",
+                BinOpKind::And => "&&",
+                BinOpKind::Add => "+",
+                BinOpKind::Sub => "-",
+            }
+        )?;
         self.rhs.fmt(f)?;
         write!(f, ")")
     }
@@ -93,8 +97,14 @@ impl<'vir, Curr, Next> Debug for DomainGenData<'vir, Curr, Next> {
             write!(f, "]")?;
         }
         writeln!(f, " {{")?;
-        self.axioms.iter().map(|el| el.fmt(f)).collect::<FmtResult>()?;
-        self.functions.iter().map(|el| el.fmt(f)).collect::<FmtResult>()?;
+        self.axioms
+            .iter()
+            .map(|el| el.fmt(f))
+            .collect::<FmtResult>()?;
+        self.functions
+            .iter()
+            .map(|el| el.fmt(f))
+            .collect::<FmtResult>()?;
         writeln!(f, "}}")
     }
 }
@@ -174,8 +184,14 @@ impl<'vir, Curr, Next> Debug for FunctionGenData<'vir, Curr, Next> {
         writeln!(f, "function {}(", self.name)?;
         fmt_comma_sep_lines(f, &self.args)?;
         writeln!(f, "): {:?}", self.ret)?;
-        self.pres.iter().map(|el| writeln!(f, "  requires {:?}", el)).collect::<FmtResult>()?;
-        self.posts.iter().map(|el| writeln!(f, "  ensures {:?}", el)).collect::<FmtResult>()?;
+        self.pres
+            .iter()
+            .map(|el| writeln!(f, "  requires {:?}", el))
+            .collect::<FmtResult>()?;
+        self.posts
+            .iter()
+            .map(|el| writeln!(f, "  ensures {:?}", el))
+            .collect::<FmtResult>()?;
         if let Some(expr) = self.expr {
             write!(f, "{{\n  ")?;
             expr.fmt(f)?;
@@ -222,8 +238,14 @@ impl<'vir, Curr, Next> Debug for MethodGenData<'vir, Curr, Next> {
         } else {
             writeln!(f, ")")?;
         }
-        self.pres.iter().map(|el| writeln!(f, "  requires {:?}", el)).collect::<FmtResult>()?;
-        self.posts.iter().map(|el| writeln!(f, "  ensures {:?}", el)).collect::<FmtResult>()?;
+        self.pres
+            .iter()
+            .map(|el| writeln!(f, "  requires {:?}", el))
+            .collect::<FmtResult>()?;
+        self.posts
+            .iter()
+            .map(|el| writeln!(f, "  ensures {:?}", el))
+            .collect::<FmtResult>()?;
         if let Some(blocks) = self.blocks.as_ref() {
             writeln!(f, "{{")?;
             for block in blocks.iter() {
@@ -302,7 +324,11 @@ impl<'vir, Curr, Next> Debug for TerminatorStmtGenData<'vir, Curr, Next> {
                     write!(f, "goto {:?}", data.otherwise)
                 } else {
                     for target in data.targets {
-                        write!(f, "if ({:?} == {:?}) {{ goto {:?} }}\n  else", data.value, target.0, target.1)?;
+                        write!(
+                            f,
+                            "if ({:?} == {:?}) {{ goto {:?} }}\n  else",
+                            data.value, target.0, target.1
+                        )?;
                     }
                     write!(f, " {{ goto {:?} }}", data.otherwise)
                 }
@@ -343,10 +369,15 @@ impl<'vir> Debug for TypeData<'vir> {
 
 impl<'vir, Curr, Next> Debug for UnOpGenData<'vir, Curr, Next> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{}({:?})", match self.kind {
-            UnOpKind::Neg => "-",
-            UnOpKind::Not => "!",
-        }, self.expr)
+        write!(
+            f,
+            "{}({:?})",
+            match self.kind {
+                UnOpKind::Neg => "-",
+                UnOpKind::Not => "!",
+            },
+            self.expr
+        )
     }
 }
 

--- a/vir/src/gendata.rs
+++ b/vir/src/gendata.rs
@@ -1,20 +1,20 @@
 use std::fmt::Debug;
 
-use crate::data::*;
-use crate::genrefs::*;
-use crate::refs::*;
+use crate::{data::*, genrefs::*, refs::*};
 
 use vir_proc_macro::*;
 
 #[derive(Reify)]
 pub struct UnOpGenData<'vir, Curr, Next> {
-    #[reify_copy] pub kind: UnOpKind,
+    #[reify_copy]
+    pub kind: UnOpKind,
     pub expr: ExprGen<'vir, Curr, Next>,
 }
 
 #[derive(Reify)]
 pub struct BinOpGenData<'vir, Curr, Next> {
-    #[reify_copy] pub kind: BinOpKind,
+    #[reify_copy]
+    pub kind: BinOpKind,
     pub lhs: ExprGen<'vir, Curr, Next>,
     pub rhs: ExprGen<'vir, Curr, Next>,
 }
@@ -28,20 +28,23 @@ pub struct TernaryGenData<'vir, Curr, Next> {
 
 #[derive(Reify)]
 pub struct ForallGenData<'vir, Curr, Next> {
-    #[reify_copy] pub qvars: &'vir [LocalDecl<'vir>],
+    #[reify_copy]
+    pub qvars: &'vir [LocalDecl<'vir>],
     pub triggers: &'vir [&'vir [ExprGen<'vir, Curr, Next>]],
     pub body: ExprGen<'vir, Curr, Next>,
 }
 
 #[derive(Reify)]
 pub struct FuncAppGenData<'vir, Curr, Next> {
-    #[reify_copy] pub target: &'vir str, // TODO: identifiers
+    #[reify_copy]
+    pub target: &'vir str, // TODO: identifiers
     pub args: &'vir [ExprGen<'vir, Curr, Next>],
 }
 
 #[derive(Reify)]
 pub struct PredicateAppGenData<'vir, Curr, Next> {
-    #[reify_copy] pub target: &'vir str, // TODO: identifiers
+    #[reify_copy]
+    pub target: &'vir str, // TODO: identifiers
     pub args: &'vir [ExprGen<'vir, Curr, Next>],
 }
 
@@ -54,13 +57,15 @@ pub struct UnfoldingGenData<'vir, Curr, Next> {
 #[derive(Reify)]
 pub struct AccFieldGenData<'vir, Curr, Next> {
     pub recv: ExprGen<'vir, Curr, Next>,
-    #[reify_copy] pub field: &'vir str, // TODO: identifiers
-    // TODO: permission amount
+    #[reify_copy]
+    pub field: &'vir str, // TODO: identifiers
+                          // TODO: permission amount
 }
 
 #[derive(Reify)]
 pub struct LetGenData<'vir, Curr, Next> {
-    #[reify_copy] pub name: &'vir str,
+    #[reify_copy]
+    pub name: &'vir str,
     pub val: ExprGen<'vir, Curr, Next>,
     pub expr: ExprGen<'vir, Curr, Next>,
 }
@@ -103,8 +108,10 @@ pub enum ExprGenData<'vir, Curr: 'vir, Next: 'vir> {
     PredicateApp(PredicateAppGen<'vir, Curr, Next>), // TODO: this should not be used instead of acc?
     // domain func app
     // inhale/exhale
-
-    Lazy(&'vir str, Box<dyn Fn(&'vir crate::VirCtxt<'vir>, Curr) -> Next + 'vir>),
+    Lazy(
+        &'vir str,
+        Box<dyn Fn(&'vir crate::VirCtxt<'vir>, Curr) -> Next + 'vir>,
+    ),
 
     Todo(&'vir str),
 }
@@ -120,30 +127,39 @@ impl<'vir, Curr, Next> ExprGenData<'vir, Curr, Next> {
 
 #[derive(Reify)]
 pub struct DomainAxiomGenData<'vir, Curr, Next> {
-    #[reify_copy] pub name: &'vir str, // ? or comment, then auto-gen the names?
+    #[reify_copy]
+    pub name: &'vir str, // ? or comment, then auto-gen the names?
     pub expr: ExprGen<'vir, Curr, Next>,
 }
 
 #[derive(Reify)]
 pub struct DomainGenData<'vir, Curr, Next> {
-    #[reify_copy] pub name: &'vir str, // TODO: identifiers
-    #[reify_copy] pub typarams: &'vir [&'vir str],
+    #[reify_copy]
+    pub name: &'vir str, // TODO: identifiers
+    #[reify_copy]
+    pub typarams: &'vir [&'vir str],
     pub axioms: &'vir [DomainAxiomGen<'vir, Curr, Next>],
-    #[reify_copy] pub functions: &'vir [DomainFunction<'vir>],
+    #[reify_copy]
+    pub functions: &'vir [DomainFunction<'vir>],
 }
 
 #[derive(Reify)]
 pub struct PredicateGenData<'vir, Curr, Next> {
-    #[reify_copy] pub name: &'vir str, // TODO: identifiers
-    #[reify_copy] pub args: &'vir [LocalDecl<'vir>],
+    #[reify_copy]
+    pub name: &'vir str, // TODO: identifiers
+    #[reify_copy]
+    pub args: &'vir [LocalDecl<'vir>],
     pub expr: Option<ExprGen<'vir, Curr, Next>>,
 }
 
 #[derive(Reify)]
 pub struct FunctionGenData<'vir, Curr, Next> {
-    #[reify_copy] pub name: &'vir str, // TODO: identifiers
-    #[reify_copy] pub args: &'vir [LocalDecl<'vir>],
-    #[reify_copy] pub ret: Type<'vir>,
+    #[reify_copy]
+    pub name: &'vir str, // TODO: identifiers
+    #[reify_copy]
+    pub args: &'vir [LocalDecl<'vir>],
+    #[reify_copy]
+    pub ret: Type<'vir>,
     pub pres: &'vir [ExprGen<'vir, Curr, Next>],
     pub posts: &'vir [ExprGen<'vir, Curr, Next>],
     pub expr: Option<ExprGen<'vir, Curr, Next>>,
@@ -160,14 +176,19 @@ pub struct PureAssignGenData<'vir, Curr, Next> {
 
 #[derive(Reify)]
 pub struct MethodCallGenData<'vir, Curr, Next> {
-    #[reify_copy] pub targets: &'vir [Local<'vir>],
-    #[reify_copy] pub method: &'vir str,
+    #[reify_copy]
+    pub targets: &'vir [Local<'vir>],
+    #[reify_copy]
+    pub method: &'vir str,
     pub args: &'vir [ExprGen<'vir, Curr, Next>],
 }
 
 #[derive(Reify)]
 pub enum StmtGenData<'vir, Curr, Next> {
-    LocalDecl(#[reify_copy] LocalDecl<'vir>, Option<ExprGen<'vir, Curr, Next>>),
+    LocalDecl(
+        #[reify_copy] LocalDecl<'vir>,
+        Option<ExprGen<'vir, Curr, Next>>,
+    ),
     PureAssign(PureAssignGen<'vir, Curr, Next>),
     Inhale(ExprGen<'vir, Curr, Next>),
     Exhale(ExprGen<'vir, Curr, Next>),
@@ -182,7 +203,8 @@ pub enum StmtGenData<'vir, Curr, Next> {
 pub struct GotoIfGenData<'vir, Curr, Next> {
     pub value: ExprGen<'vir, Curr, Next>,
     pub targets: &'vir [(ExprGen<'vir, Curr, Next>, CfgBlockLabel<'vir>)],
-    #[reify_copy] pub otherwise: CfgBlockLabel<'vir>,
+    #[reify_copy]
+    pub otherwise: CfgBlockLabel<'vir>,
 }
 
 #[derive(Reify)]
@@ -196,16 +218,20 @@ pub enum TerminatorStmtGenData<'vir, Curr, Next> {
 
 #[derive(Debug, Reify)]
 pub struct CfgBlockGenData<'vir, Curr, Next> {
-    #[reify_copy] pub label: CfgBlockLabel<'vir>,
+    #[reify_copy]
+    pub label: CfgBlockLabel<'vir>,
     pub stmts: &'vir [StmtGen<'vir, Curr, Next>],
     pub terminator: TerminatorStmtGen<'vir, Curr, Next>,
 }
 
 #[derive(Reify)]
 pub struct MethodGenData<'vir, Curr, Next> {
-    #[reify_copy] pub name: &'vir str, // TODO: identifiers
-    #[reify_copy] pub args: &'vir [LocalDecl<'vir>],
-    #[reify_copy] pub rets: &'vir [LocalDecl<'vir>],
+    #[reify_copy]
+    pub name: &'vir str, // TODO: identifiers
+    #[reify_copy]
+    pub args: &'vir [LocalDecl<'vir>],
+    #[reify_copy]
+    pub rets: &'vir [LocalDecl<'vir>],
     // TODO: pre/post - add a comment variant
     pub pres: &'vir [ExprGen<'vir, Curr, Next>],
     pub posts: &'vir [ExprGen<'vir, Curr, Next>],
@@ -214,7 +240,8 @@ pub struct MethodGenData<'vir, Curr, Next> {
 
 #[derive(Debug, Reify)]
 pub struct ProgramGenData<'vir, Curr, Next> {
-    #[reify_copy] pub fields: &'vir [Field<'vir>],
+    #[reify_copy]
+    pub fields: &'vir [Field<'vir>],
     pub domains: &'vir [DomainGen<'vir, Curr, Next>],
     pub predicates: &'vir [PredicateGen<'vir, Curr, Next>],
     pub functions: &'vir [FunctionGen<'vir, Curr, Next>],

--- a/vir/src/genrefs.rs
+++ b/vir/src/genrefs.rs
@@ -1,7 +1,8 @@
 pub type AccFieldGen<'vir, Curr, Next> = &'vir crate::gendata::AccFieldGenData<'vir, Curr, Next>;
 pub type BinOpGen<'vir, Curr, Next> = &'vir crate::gendata::BinOpGenData<'vir, Curr, Next>;
 pub type CfgBlockGen<'vir, Curr, Next> = &'vir crate::gendata::CfgBlockGenData<'vir, Curr, Next>;
-pub type DomainAxiomGen<'vir, Curr, Next> = &'vir crate::gendata::DomainAxiomGenData<'vir, Curr, Next>;
+pub type DomainAxiomGen<'vir, Curr, Next> =
+    &'vir crate::gendata::DomainAxiomGenData<'vir, Curr, Next>;
 pub type DomainGen<'vir, Curr, Next> = &'vir crate::gendata::DomainGenData<'vir, Curr, Next>;
 pub type ExprGen<'vir, Curr, Next> = &'vir crate::gendata::ExprGenData<'vir, Curr, Next>;
 pub type ForallGen<'vir, Curr, Next> = &'vir crate::gendata::ForallGenData<'vir, Curr, Next>;
@@ -10,13 +11,17 @@ pub type FunctionGen<'vir, Curr, Next> = &'vir crate::gendata::FunctionGenData<'
 pub type GotoIfGen<'vir, Curr, Next> = &'vir crate::gendata::GotoIfGenData<'vir, Curr, Next>;
 pub type LetGen<'vir, Curr, Next> = &'vir crate::gendata::LetGenData<'vir, Curr, Next>;
 pub type MethodGen<'vir, Curr, Next> = &'vir crate::gendata::MethodGenData<'vir, Curr, Next>;
-pub type MethodCallGen<'vir, Curr, Next> = &'vir crate::gendata::MethodCallGenData<'vir, Curr, Next>;
+pub type MethodCallGen<'vir, Curr, Next> =
+    &'vir crate::gendata::MethodCallGenData<'vir, Curr, Next>;
 pub type PredicateGen<'vir, Curr, Next> = &'vir crate::gendata::PredicateGenData<'vir, Curr, Next>;
-pub type PredicateAppGen<'vir, Curr, Next> = &'vir crate::gendata::PredicateAppGenData<'vir, Curr, Next>;
+pub type PredicateAppGen<'vir, Curr, Next> =
+    &'vir crate::gendata::PredicateAppGenData<'vir, Curr, Next>;
 pub type ProgramGen<'vir, Curr, Next> = &'vir crate::gendata::ProgramGenData<'vir, Curr, Next>;
-pub type PureAssignGen<'vir, Curr, Next> = &'vir crate::gendata::PureAssignGenData<'vir, Curr, Next>;
+pub type PureAssignGen<'vir, Curr, Next> =
+    &'vir crate::gendata::PureAssignGenData<'vir, Curr, Next>;
 pub type StmtGen<'vir, Curr, Next> = &'vir crate::gendata::StmtGenData<'vir, Curr, Next>;
-pub type TerminatorStmtGen<'vir, Curr, Next> = &'vir crate::gendata::TerminatorStmtGenData<'vir, Curr, Next>;
+pub type TerminatorStmtGen<'vir, Curr, Next> =
+    &'vir crate::gendata::TerminatorStmtGenData<'vir, Curr, Next>;
 pub type TernaryGen<'vir, Curr, Next> = &'vir crate::gendata::TernaryGenData<'vir, Curr, Next>;
 pub type UnOpGen<'vir, Curr, Next> = &'vir crate::gendata::UnOpGenData<'vir, Curr, Next>;
 pub type UnfoldingGen<'vir, Curr, Next> = &'vir crate::gendata::UnfoldingGenData<'vir, Curr, Next>;

--- a/vir/src/macros.rs
+++ b/vir/src/macros.rs
@@ -1,6 +1,6 @@
 //#[macro_export]
 //macro_rules! vir_expr_nopos {
-//    
+//
 //}
 
 //#[macro_export]
@@ -112,8 +112,12 @@ macro_rules! vir_expr {
 
 #[macro_export]
 macro_rules! vir_ident {
-    ($vcx:expr; [ $name:expr ]) => { $name };
-    ($vcx:expr; $name:ident ) => { $vcx.alloc_str(stringify!($name)) };
+    ($vcx:expr; [ $name:expr ]) => {
+        $name
+    };
+    ($vcx:expr; $name:ident ) => {
+        $vcx.alloc_str(stringify!($name))
+    };
 }
 
 #[macro_export]
@@ -123,10 +127,18 @@ macro_rules! vir_format {
 
 #[macro_export]
 macro_rules! vir_type {
-    ($vcx:expr; Int) => { $vcx.alloc($crate::TypeData::Int) };
-    ($vcx:expr; Bool) => { $vcx.alloc($crate::TypeData::Bool) };
-    ($vcx:expr; Ref) => { $vcx.alloc($crate::TypeData::Ref) };
-    ($vcx:expr; [ $ty:expr ]) => { $ty };
+    ($vcx:expr; Int) => {
+        $vcx.alloc($crate::TypeData::Int)
+    };
+    ($vcx:expr; Bool) => {
+        $vcx.alloc($crate::TypeData::Bool)
+    };
+    ($vcx:expr; Ref) => {
+        $vcx.alloc($crate::TypeData::Ref)
+    };
+    ($vcx:expr; [ $ty:expr ]) => {
+        $ty
+    };
     ($vcx:expr; $name:ident) => {
         $vcx.alloc($crate::TypeData::Domain($vcx.alloc_str(stringify!($name))))
     };


### PR DESCRIPTION
Builds on top of #15. To see what changed since #15 see https://github.com/tillarnold/prusti-dev/compare/till_rebuilt_3..tillarnold:prusti-dev:rustfmt


Run rustfmt on the entire project.

I did this by running `cargo fmt` in the repo root as well as in `prusti-contracts` as that appears to be a different workspace. Running `./x.py fmt-all` resulted in an error.  Old prusti recently merged a PR that changed how the formatting in `x.py` works https://github.com/viperproject/prusti-dev/pull/1456. Maybe that fix could be relevant here too?
