### PR TITLE
Change the triggers for the tuple and struct read axioms

### DIFF
--- a/prusti-encoder/src/encoders/typ.rs
+++ b/prusti-encoder/src/encoders/typ.rs
@@ -557,7 +557,7 @@ impl TaskEncoder for TypeEncoder {
                         expr: vcx.alloc(vir::ExprData::Forall(vcx.alloc(vir::ForallData {
                             qvars: cons_qvars.clone(),
                             triggers: vcx.alloc_slice(&[vcx.alloc_slice(&[
-                                cons_read,
+                                cons_call,
                             ])]),
                             body: vcx.alloc(vir::ExprData::BinOp(vcx.alloc(vir::BinOpData {
                                 kind: vir::BinOpKind::CmpEq,


### PR DESCRIPTION
Change the triggers for the tuple read axioms from `s_Tuple_read_1(s_Tuple_cons(f0, f1))` to `s_Tuple_cons(f0, f1)`

We discussed this change on the 20st of October in chat and you determined that this is the correct trigger.


(This is a part of what used to be #15)