### PR TITLE
Add cons val axiom to primitives

### DIFF
--- a/prusti-encoder/src/encoders/typ.rs
+++ b/prusti-encoder/src/encoders/typ.rs
@@ -747,7 +747,7 @@ impl TaskEncoder for TypeEncoder {
                         function prim_to_snap(Int): [ty_s];
                         function snap_to_prim([ty_s]): Int;
                         axiom_inverse(snap_to_prim, prim_to_snap, Int);
-                        axiom_inverse(prim_to_snap, snap_to_prim, ty_s);
+                        axiom_inverse(prim_to_snap, snap_to_prim, [ty_s]);
                     } },
                     predicate: mk_simple_predicate(vcx, name_p, name_field),
                     unreachable_to_snap: mk_unreachable(vcx, unreachable_to_snap, ty_s),

--- a/prusti-encoder/src/encoders/typ.rs
+++ b/prusti-encoder/src/encoders/typ.rs
@@ -695,6 +695,7 @@ impl TaskEncoder for TypeEncoder {
                         function prim_to_snap(Bool): s_Bool;
                         function snap_to_prim(s_Bool): Bool;
                         axiom_inverse(snap_to_prim, prim_to_snap, Bool);
+                        axiom_inverse(prim_to_snap, snap_to_prim, Bool);
                     } },
                     predicate: mk_simple_predicate(vcx, "p_Bool", "f_Bool"),
                     unreachable_to_snap: mk_unreachable(vcx, unreachable_to_snap, ty_s),
@@ -746,6 +747,7 @@ impl TaskEncoder for TypeEncoder {
                         function prim_to_snap(Int): [ty_s];
                         function snap_to_prim([ty_s]): Int;
                         axiom_inverse(snap_to_prim, prim_to_snap, Int);
+                        axiom_inverse(prim_to_snap, snap_to_prim, Int);
                     } },
                     predicate: mk_simple_predicate(vcx, name_p, name_field),
                     unreachable_to_snap: mk_unreachable(vcx, unreachable_to_snap, ty_s),

--- a/prusti-encoder/src/encoders/typ.rs
+++ b/prusti-encoder/src/encoders/typ.rs
@@ -695,7 +695,7 @@ impl TaskEncoder for TypeEncoder {
                         function prim_to_snap(Bool): s_Bool;
                         function snap_to_prim(s_Bool): Bool;
                         axiom_inverse(snap_to_prim, prim_to_snap, Bool);
-                        axiom_inverse(prim_to_snap, snap_to_prim, Bool);
+                        axiom_inverse(prim_to_snap, snap_to_prim, s_Bool);
                     } },
                     predicate: mk_simple_predicate(vcx, "p_Bool", "f_Bool"),
                     unreachable_to_snap: mk_unreachable(vcx, unreachable_to_snap, ty_s),
@@ -747,7 +747,7 @@ impl TaskEncoder for TypeEncoder {
                         function prim_to_snap(Int): [ty_s];
                         function snap_to_prim([ty_s]): Int;
                         axiom_inverse(snap_to_prim, prim_to_snap, Int);
-                        axiom_inverse(prim_to_snap, snap_to_prim, Int);
+                        axiom_inverse(prim_to_snap, snap_to_prim, ty_s);
                     } },
                     predicate: mk_simple_predicate(vcx, name_p, name_field),
                     unreachable_to_snap: mk_unreachable(vcx, unreachable_to_snap, ty_s),


### PR DESCRIPTION
For the primitive types currently this axiom exists `forall val: Int :: {s_Int_i32_cons(val)} (s_Int_i32_val(s_Int_i32_cons(val))) == (val)`. This PR additionally also adds the inverse of it `forall val: s_Int_i32 :: {s_Int_i32_val(val)} (s_Int_i32_cons(s_Int_i32_val(val))) == (val)`. This might be dangerous but for the few cases i tested it improved/allowed verification to complete.
The necessity of the new additional inverse axiom is shown by this example 
  ```rust
  extern crate prusti_contracts;
  use prusti_contracts::*;
  
  #[requires(a >= 0)]
  fn f(a: i32)  {
      if a < 1 {
          assert_true(a == 0);
      }
     
  }
  
  #[requires(b)]
  fn assert_true(b: bool) {}
  
  fn main() {
      
  }
  ```
  
  This works with the new axiom but not without it. This also serves as an example why the trigger cannot be `s_Int_i32_cons(s_Int_i32_val(val))` instead of `s_Int_i32_val(val)`: if one manually changes the trigger in the resulting viper code the verification fails.

(This is a part of what used to be #15)