### PR TITLE
Introduce ExprKind

### DIFF
--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -21,7 +21,7 @@ pub enum MirPureEncoderError {
 
 // TODO: does this need to be `&'vir [..]`?
 type ExprInput<'vir> = (DefId, &'vir [vir::Expr<'vir>]);
-type ExprRet<'vir> = vir::ExprGen<'vir, ExprInput<'vir>, vir::Expr<'vir>>;
+type ExprRet<'vir> = vir::ExprGen<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>;
 
 #[derive(Clone, Debug)]
 pub struct MirPureEncoderOutput<'vir> {
@@ -134,7 +134,7 @@ impl TaskEncoder for MirPureEncoder {
                     assert_eq!(lctx.1.len(), body.arg_count);
 
                     use vir::Reify;
-                    expr_inner.reify(vcx, lctx)
+                    expr_inner.0.reify(vcx, lctx)
                 }),
             )
         });
@@ -298,7 +298,7 @@ impl<'tcx, 'vir: 'enc, 'enc> Encoder<'tcx, 'vir, 'enc>
         for local in 1..=self.body.arg_count {
             let local_ex = self.vcx.mk_lazy_expr(
                 vir::vir_format!(self.vcx, "pure in _{local}"),
-                Box::new(move |_vcx, lctx: ExprInput<'vir>| lctx.1[local - 1]),
+                Box::new(move |_vcx, lctx: ExprInput<'vir>| lctx.1[local - 1].0),
             );
             init.binds.push(UpdateBind::Local(local.into(), 0, local_ex));
             init.versions.insert(local.into(), 0);

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -134,7 +134,7 @@ impl TaskEncoder for MirPureEncoder {
                     assert_eq!(lctx.1.len(), body.arg_count);
 
                     use vir::Reify;
-                    expr_inner.0.reify(vcx, lctx)
+                    expr_inner.kind.reify(vcx, lctx)
                 }),
             )
         });
@@ -298,7 +298,7 @@ impl<'tcx, 'vir: 'enc, 'enc> Encoder<'tcx, 'vir, 'enc>
         for local in 1..=self.body.arg_count {
             let local_ex = self.vcx.mk_lazy_expr(
                 vir::vir_format!(self.vcx, "pure in _{local}"),
-                Box::new(move |_vcx, lctx: ExprInput<'vir>| lctx.1[local - 1].0),
+                Box::new(move |_vcx, lctx: ExprInput<'vir>| lctx.1[local - 1].kind),
             );
             init.binds.push(UpdateBind::Local(local.into(), 0, local_ex));
             init.versions.insert(local.into(), 0);

--- a/vir-proc-macro/src/lib.rs
+++ b/vir-proc-macro/src/lib.rs
@@ -17,7 +17,7 @@ pub fn derive_reify(input: TokenStream) -> TokenStream {
     let name = input.ident;
     let slice_impl = quote! {
         impl<'vir, Curr: Copy, NextA, NextB> crate::Reify<'vir, Curr>
-            for [&'vir #name<'vir, Curr, ExprGen<'vir, NextA, NextB>>]
+            for [&'vir #name<'vir, Curr, ExprKindGen<'vir, NextA, NextB>>]
         {
             type Next = &'vir [&'vir #name<'vir, NextA, NextB>];
             fn reify<'tcx>(&self, vcx: &'vir crate::VirCtxt<'tcx>, lctx: Curr) -> Self::Next {
@@ -59,7 +59,7 @@ pub fn derive_reify(input: TokenStream) -> TokenStream {
                 .collect::<Vec<_>>();
             quote! {
                 impl<'vir, Curr: Copy, NextA, NextB> crate::Reify<'vir, Curr>
-                    for &'vir #name<'vir, Curr, ExprGen<'vir, NextA, NextB>>
+                    for &'vir #name<'vir, Curr, ExprKindGen<'vir, NextA, NextB>>
                 {
                     type Next = &'vir #name<'vir, NextA, NextB>;
                     fn reify<'tcx>(&self, vcx: &'vir crate::VirCtxt<'tcx>, lctx: Curr) -> Self::Next {
@@ -130,7 +130,7 @@ pub fn derive_reify(input: TokenStream) -> TokenStream {
                 .collect::<Vec<_>>();
             quote! {
                 impl<'vir, Curr: Copy, NextA, NextB> crate::Reify<'vir, Curr>
-                    for &'vir #name<'vir, Curr, ExprGen<'vir, NextA, NextB>>
+                    for &'vir #name<'vir, Curr, ExprKindGen<'vir, NextA, NextB>>
                 {
                     type Next = &'vir #name<'vir, NextA, NextB>;
                     fn reify<'tcx>(&self, vcx: &'vir crate::VirCtxt<'tcx>, lctx: Curr) -> Self::Next {

--- a/vir/src/context.rs
+++ b/vir/src/context.rs
@@ -57,7 +57,7 @@ impl<'tcx> VirCtxt<'tcx> {
         &'vir self,
         local: Local<'vir>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Local(local))))
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Local(local))})
     }
     pub fn mk_local_ex<'vir, Curr, Next>(&'vir self, name: &'vir str) -> ExprGen<'vir, Curr, Next> {
         self.mk_local_ex_local(self.mk_local(name))
@@ -67,16 +67,16 @@ impl<'tcx> VirCtxt<'tcx> {
         target: &'vir str,
         src_args: &[ExprGen<'vir, Curr, Next>],
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::FuncApp(self.arena.alloc(FuncAppGenData {
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::FuncApp(self.arena.alloc(FuncAppGenData {
             target,
             args: self.alloc_slice(src_args),
-        })))))
+        })))})
     }
     pub fn mk_pred_app<'vir>(&'vir self, target: &'vir str, src_args: &[Expr<'vir>]) -> Expr<'vir> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::PredicateApp(self.arena.alloc(PredicateAppData {
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::PredicateApp(self.arena.alloc(PredicateAppData {
             target,
             args: self.alloc_slice(src_args),
-        })))))
+        })))})
     }
 
     pub fn mk_lazy_expr<'vir, Curr, Next>(
@@ -84,7 +84,7 @@ impl<'tcx> VirCtxt<'tcx> {
         name: &'vir str,
         func: Box<dyn for<'a> Fn(&'vir VirCtxt<'a>, Curr) -> Next + 'vir>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Lazy(name, func))))
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Lazy(name, func))})
     }
 
     pub fn mk_ternary_expr<'vir, Curr, Next>(
@@ -93,11 +93,11 @@ impl<'tcx> VirCtxt<'tcx> {
         then: ExprGen<'vir, Curr, Next>,
         else_: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Ternary(self.alloc(TernaryGenData {
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Ternary(self.alloc(TernaryGenData {
             cond,
             then,
             else_,
-        })))))
+        })))})
     }
 
     pub fn mk_unary_op_expr<'vir, Curr, Next>(
@@ -105,14 +105,14 @@ impl<'tcx> VirCtxt<'tcx> {
         kind: UnOpKind,
         expr: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::UnOp(self.alloc(UnOpGenData { kind, expr })))))
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::UnOp(self.alloc(UnOpGenData { kind, expr })))})
     }
 
     pub fn mk_old_expr<'vir, Curr, Next>(
         &'vir self,
         expr: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Old(expr))))
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Old(expr))})
     }
 
     pub fn mk_forall_expr<'vir, Curr, Next>(
@@ -121,11 +121,11 @@ impl<'tcx> VirCtxt<'tcx> {
         triggers: &'vir [&'vir [ExprGen<'vir, Curr, Next>]],
         body: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Forall(self.alloc(ForallGenData {
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Forall(self.alloc(ForallGenData {
             qvars,
             triggers,
             body,
-        })))))
+        })))})
     }
 
     pub fn mk_let_expr<'vir, Curr, Next>(
@@ -134,14 +134,14 @@ impl<'tcx> VirCtxt<'tcx> {
         val: ExprGen<'vir, Curr, Next>,
         expr: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Let(self.alloc(LetGenData { name, val, expr })))))
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Let(self.alloc(LetGenData { name, val, expr })))})
     }
 
     pub fn mk_predicate_app_expr<'vir, Curr, Next>(
         &'vir self,
         pred_app: PredicateAppGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::PredicateApp(pred_app))))
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::PredicateApp(pred_app))})
     }
 
     pub fn mk_bin_op_expr<'vir, Curr, Next>(
@@ -150,11 +150,11 @@ impl<'tcx> VirCtxt<'tcx> {
         lhs: ExprGen<'vir, Curr, Next>,
         rhs: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::BinOp(self.alloc(BinOpGenData {
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::BinOp(self.alloc(BinOpGenData {
             kind,
             lhs,
             rhs,
-        })))))
+        })))})
     }
 
     pub fn mk_field_expr<'vir, Curr, Next>(
@@ -162,7 +162,7 @@ impl<'tcx> VirCtxt<'tcx> {
         recv: ExprGen<'vir, Curr, Next>,
         field: &'vir str,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Field(recv, field))))
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Field(recv, field))})
     }
 
     pub fn mk_unfolding_expr<'vir, Curr, Next>(
@@ -170,7 +170,7 @@ impl<'tcx> VirCtxt<'tcx> {
         target: PredicateAppGen<'vir, Curr, Next>,
         expr: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Unfolding(self.alloc(UnfoldingGenData { target, expr }),))))
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Unfolding(self.alloc(UnfoldingGenData { target, expr })))})
     }
 
     pub fn mk_acc_field_expr<'vir, Curr, Next>(
@@ -178,35 +178,35 @@ impl<'tcx> VirCtxt<'tcx> {
         recv: ExprGen<'vir, Curr, Next>,
         field: &'vir str,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::AccField(self.alloc(AccFieldGenData { recv, field }),))))
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::AccField(self.alloc(AccFieldGenData { recv, field })))})
     }
 
     pub fn mk_const_expr<'vir, Curr, Next>(
         &'vir self,
         value: ConstData,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Const(self.alloc(value)))))
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Const(self.alloc(value)))})
     }
 
     pub fn mk_todo_expr<'vir, Curr, Next>(&'vir self, msg: &'vir str) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Todo(msg))))
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Todo(msg))})
     }
 
     pub const fn mk_bool<'vir, const VALUE: bool>(&'vir self) -> Expr<'vir> {
-        &ExprGenData(&ExprKindGenData::Const(&ConstData::Bool(VALUE)))
+        &ExprGenData {kind : &ExprKindGenData::Const(&ConstData::Bool(VALUE))}
     }
     pub const fn mk_int<'vir, const VALUE: i128>(&'vir self) -> Expr<'vir> {
         if VALUE < 0 {
-            &ExprGenData(&ExprKindGenData::UnOp(&UnOpData {
+            &ExprGenData {kind : &ExprKindGenData::UnOp(&UnOpData {
                 kind: UnOpKind::Neg,
-                expr: &ExprGenData(&ExprKindGenData::Const(&ConstData::Int((-VALUE) as u128))),
-            }))
+                expr: &ExprGenData {kind : &ExprKindGenData::Const(&ConstData::Int((-VALUE) as u128))},
+            })}
         } else {
-            &ExprGenData(&ExprKindGenData::Const(&ConstData::Int(VALUE as u128)))
+            &ExprGenData {kind : &ExprKindGenData::Const(&ConstData::Int(VALUE as u128))}
         }
     }
     pub const fn mk_uint<'vir, const VALUE: u128>(&'vir self) -> Expr<'vir> {
-        &ExprGenData(&ExprKindGenData::Const(&ConstData::Int(VALUE)))
+        &ExprGenData {kind : &ExprKindGenData::Const(&ConstData::Int(VALUE))}
     }
 
     pub fn mk_domain_axiom<'vir, Curr, Next>(

--- a/vir/src/context.rs
+++ b/vir/src/context.rs
@@ -57,7 +57,7 @@ impl<'tcx> VirCtxt<'tcx> {
         &'vir self,
         local: Local<'vir>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData::Local(local))
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Local(local))))
     }
     pub fn mk_local_ex<'vir, Curr, Next>(&'vir self, name: &'vir str) -> ExprGen<'vir, Curr, Next> {
         self.mk_local_ex_local(self.mk_local(name))
@@ -67,16 +67,16 @@ impl<'tcx> VirCtxt<'tcx> {
         target: &'vir str,
         src_args: &[ExprGen<'vir, Curr, Next>],
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData::FuncApp(self.arena.alloc(FuncAppGenData {
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::FuncApp(self.arena.alloc(FuncAppGenData {
             target,
             args: self.alloc_slice(src_args),
-        })))
+        })))))
     }
     pub fn mk_pred_app<'vir>(&'vir self, target: &'vir str, src_args: &[Expr<'vir>]) -> Expr<'vir> {
-        self.alloc(ExprData::PredicateApp(self.arena.alloc(PredicateAppData {
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::PredicateApp(self.arena.alloc(PredicateAppData {
             target,
             args: self.alloc_slice(src_args),
-        })))
+        })))))
     }
 
     pub fn mk_lazy_expr<'vir, Curr, Next>(
@@ -84,7 +84,7 @@ impl<'tcx> VirCtxt<'tcx> {
         name: &'vir str,
         func: Box<dyn for<'a> Fn(&'vir VirCtxt<'a>, Curr) -> Next + 'vir>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData::Lazy(name, func))
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Lazy(name, func))))
     }
 
     pub fn mk_ternary_expr<'vir, Curr, Next>(
@@ -93,11 +93,11 @@ impl<'tcx> VirCtxt<'tcx> {
         then: ExprGen<'vir, Curr, Next>,
         else_: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData::Ternary(self.alloc(TernaryGenData {
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Ternary(self.alloc(TernaryGenData {
             cond,
             then,
             else_,
-        })))
+        })))))
     }
 
     pub fn mk_unary_op_expr<'vir, Curr, Next>(
@@ -105,14 +105,14 @@ impl<'tcx> VirCtxt<'tcx> {
         kind: UnOpKind,
         expr: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData::UnOp(self.alloc(UnOpGenData { kind, expr })))
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::UnOp(self.alloc(UnOpGenData { kind, expr })))))
     }
 
     pub fn mk_old_expr<'vir, Curr, Next>(
         &'vir self,
         expr: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData::Old(expr))
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Old(expr))))
     }
 
     pub fn mk_forall_expr<'vir, Curr, Next>(
@@ -121,11 +121,11 @@ impl<'tcx> VirCtxt<'tcx> {
         triggers: &'vir [&'vir [ExprGen<'vir, Curr, Next>]],
         body: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData::Forall(self.alloc(ForallGenData {
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Forall(self.alloc(ForallGenData {
             qvars,
             triggers,
             body,
-        })))
+        })))))
     }
 
     pub fn mk_let_expr<'vir, Curr, Next>(
@@ -134,14 +134,14 @@ impl<'tcx> VirCtxt<'tcx> {
         val: ExprGen<'vir, Curr, Next>,
         expr: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData::Let(self.alloc(LetGenData { name, val, expr })))
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Let(self.alloc(LetGenData { name, val, expr })))))
     }
 
     pub fn mk_predicate_app_expr<'vir, Curr, Next>(
         &'vir self,
         pred_app: PredicateAppGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData::PredicateApp(pred_app))
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::PredicateApp(pred_app))))
     }
 
     pub fn mk_bin_op_expr<'vir, Curr, Next>(
@@ -150,11 +150,11 @@ impl<'tcx> VirCtxt<'tcx> {
         lhs: ExprGen<'vir, Curr, Next>,
         rhs: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData::BinOp(self.alloc(BinOpGenData {
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::BinOp(self.alloc(BinOpGenData {
             kind,
             lhs,
             rhs,
-        })))
+        })))))
     }
 
     pub fn mk_field_expr<'vir, Curr, Next>(
@@ -162,7 +162,7 @@ impl<'tcx> VirCtxt<'tcx> {
         recv: ExprGen<'vir, Curr, Next>,
         field: &'vir str,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData::Field(recv, field))
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Field(recv, field))))
     }
 
     pub fn mk_unfolding_expr<'vir, Curr, Next>(
@@ -170,9 +170,7 @@ impl<'tcx> VirCtxt<'tcx> {
         target: PredicateAppGen<'vir, Curr, Next>,
         expr: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData::Unfolding(
-            self.alloc(UnfoldingGenData { target, expr }),
-        ))
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Unfolding(self.alloc(UnfoldingGenData { target, expr }),))))
     }
 
     pub fn mk_acc_field_expr<'vir, Curr, Next>(
@@ -180,37 +178,35 @@ impl<'tcx> VirCtxt<'tcx> {
         recv: ExprGen<'vir, Curr, Next>,
         field: &'vir str,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData::AccField(
-            self.alloc(AccFieldGenData { recv, field }),
-        ))
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::AccField(self.alloc(AccFieldGenData { recv, field }),))))
     }
 
     pub fn mk_const_expr<'vir, Curr, Next>(
         &'vir self,
         value: ConstData,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData::Const(self.alloc(value)))
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Const(self.alloc(value)))))
     }
 
     pub fn mk_todo_expr<'vir, Curr, Next>(&'vir self, msg: &'vir str) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData::Todo(msg))
+        self.alloc(ExprGenData(self.alloc(ExprKindGenData::Todo(msg))))
     }
 
     pub const fn mk_bool<'vir, const VALUE: bool>(&'vir self) -> Expr<'vir> {
-        &ExprData::Const(&ConstData::Bool(VALUE))
+        &ExprGenData(&ExprKindGenData::Const(&ConstData::Bool(VALUE)))
     }
     pub const fn mk_int<'vir, const VALUE: i128>(&'vir self) -> Expr<'vir> {
         if VALUE < 0 {
-            &ExprData::UnOp(&UnOpData {
+            &ExprGenData(&ExprKindGenData::UnOp(&UnOpData {
                 kind: UnOpKind::Neg,
-                expr: &ExprData::Const(&ConstData::Int((-VALUE) as u128)),
-            })
+                expr: &ExprGenData(&ExprKindGenData::Const(&ConstData::Int((-VALUE) as u128))),
+            }))
         } else {
-            &ExprData::Const(&ConstData::Int(VALUE as u128))
+            &ExprGenData(&ExprKindGenData::Const(&ConstData::Int(VALUE as u128)))
         }
     }
     pub const fn mk_uint<'vir, const VALUE: u128>(&'vir self) -> Expr<'vir> {
-        &ExprData::Const(&ConstData::Int(VALUE))
+        &ExprGenData(&ExprKindGenData::Const(&ConstData::Int(VALUE)))
     }
 
     pub fn mk_domain_axiom<'vir, Curr, Next>(

--- a/vir/src/context.rs
+++ b/vir/src/context.rs
@@ -57,7 +57,9 @@ impl<'tcx> VirCtxt<'tcx> {
         &'vir self,
         local: Local<'vir>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Local(local))})
+        self.alloc(ExprGenData {
+            kind: self.alloc(ExprKindGenData::Local(local)),
+        })
     }
     pub fn mk_local_ex<'vir, Curr, Next>(&'vir self, name: &'vir str) -> ExprGen<'vir, Curr, Next> {
         self.mk_local_ex_local(self.mk_local(name))
@@ -67,16 +69,22 @@ impl<'tcx> VirCtxt<'tcx> {
         target: &'vir str,
         src_args: &[ExprGen<'vir, Curr, Next>],
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::FuncApp(self.arena.alloc(FuncAppGenData {
-            target,
-            args: self.alloc_slice(src_args),
-        })))})
+        self.alloc(ExprGenData {
+            kind: self.alloc(ExprKindGenData::FuncApp(self.arena.alloc(FuncAppGenData {
+                target,
+                args: self.alloc_slice(src_args),
+            }))),
+        })
     }
     pub fn mk_pred_app<'vir>(&'vir self, target: &'vir str, src_args: &[Expr<'vir>]) -> Expr<'vir> {
-        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::PredicateApp(self.arena.alloc(PredicateAppData {
-            target,
-            args: self.alloc_slice(src_args),
-        })))})
+        self.alloc(ExprGenData {
+            kind: self.alloc(ExprKindGenData::PredicateApp(self.arena.alloc(
+                PredicateAppData {
+                    target,
+                    args: self.alloc_slice(src_args),
+                },
+            ))),
+        })
     }
 
     pub fn mk_lazy_expr<'vir, Curr, Next>(
@@ -84,7 +92,9 @@ impl<'tcx> VirCtxt<'tcx> {
         name: &'vir str,
         func: Box<dyn for<'a> Fn(&'vir VirCtxt<'a>, Curr) -> Next + 'vir>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Lazy(name, func))})
+        self.alloc(ExprGenData {
+            kind: self.alloc(ExprKindGenData::Lazy(name, func)),
+        })
     }
 
     pub fn mk_ternary_expr<'vir, Curr, Next>(
@@ -93,11 +103,13 @@ impl<'tcx> VirCtxt<'tcx> {
         then: ExprGen<'vir, Curr, Next>,
         else_: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Ternary(self.alloc(TernaryGenData {
-            cond,
-            then,
-            else_,
-        })))})
+        self.alloc(ExprGenData {
+            kind: self.alloc(ExprKindGenData::Ternary(self.alloc(TernaryGenData {
+                cond,
+                then,
+                else_,
+            }))),
+        })
     }
 
     pub fn mk_unary_op_expr<'vir, Curr, Next>(
@@ -105,14 +117,20 @@ impl<'tcx> VirCtxt<'tcx> {
         kind: UnOpKind,
         expr: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::UnOp(self.alloc(UnOpGenData { kind, expr })))})
+        self.alloc(ExprGenData {
+            kind: self.alloc(ExprKindGenData::UnOp(
+                self.alloc(UnOpGenData { kind, expr }),
+            )),
+        })
     }
 
     pub fn mk_old_expr<'vir, Curr, Next>(
         &'vir self,
         expr: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Old(expr))})
+        self.alloc(ExprGenData {
+            kind: self.alloc(ExprKindGenData::Old(expr)),
+        })
     }
 
     pub fn mk_forall_expr<'vir, Curr, Next>(
@@ -121,11 +139,13 @@ impl<'tcx> VirCtxt<'tcx> {
         triggers: &'vir [&'vir [ExprGen<'vir, Curr, Next>]],
         body: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Forall(self.alloc(ForallGenData {
-            qvars,
-            triggers,
-            body,
-        })))})
+        self.alloc(ExprGenData {
+            kind: self.alloc(ExprKindGenData::Forall(self.alloc(ForallGenData {
+                qvars,
+                triggers,
+                body,
+            }))),
+        })
     }
 
     pub fn mk_let_expr<'vir, Curr, Next>(
@@ -134,14 +154,22 @@ impl<'tcx> VirCtxt<'tcx> {
         val: ExprGen<'vir, Curr, Next>,
         expr: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Let(self.alloc(LetGenData { name, val, expr })))})
+        self.alloc(ExprGenData {
+            kind: self.alloc(ExprKindGenData::Let(self.alloc(LetGenData {
+                name,
+                val,
+                expr,
+            }))),
+        })
     }
 
     pub fn mk_predicate_app_expr<'vir, Curr, Next>(
         &'vir self,
         pred_app: PredicateAppGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::PredicateApp(pred_app))})
+        self.alloc(ExprGenData {
+            kind: self.alloc(ExprKindGenData::PredicateApp(pred_app)),
+        })
     }
 
     pub fn mk_bin_op_expr<'vir, Curr, Next>(
@@ -150,11 +178,13 @@ impl<'tcx> VirCtxt<'tcx> {
         lhs: ExprGen<'vir, Curr, Next>,
         rhs: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::BinOp(self.alloc(BinOpGenData {
-            kind,
-            lhs,
-            rhs,
-        })))})
+        self.alloc(ExprGenData {
+            kind: self.alloc(ExprKindGenData::BinOp(self.alloc(BinOpGenData {
+                kind,
+                lhs,
+                rhs,
+            }))),
+        })
     }
 
     pub fn mk_field_expr<'vir, Curr, Next>(
@@ -162,7 +192,9 @@ impl<'tcx> VirCtxt<'tcx> {
         recv: ExprGen<'vir, Curr, Next>,
         field: &'vir str,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Field(recv, field))})
+        self.alloc(ExprGenData {
+            kind: self.alloc(ExprKindGenData::Field(recv, field)),
+        })
     }
 
     pub fn mk_unfolding_expr<'vir, Curr, Next>(
@@ -170,7 +202,11 @@ impl<'tcx> VirCtxt<'tcx> {
         target: PredicateAppGen<'vir, Curr, Next>,
         expr: ExprGen<'vir, Curr, Next>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::Unfolding(self.alloc(UnfoldingGenData { target, expr })))})
+        self.alloc(ExprGenData {
+            kind: self.alloc(ExprKindGenData::Unfolding(
+                self.alloc(UnfoldingGenData { target, expr }),
+            )),
+        })
     }
 
     pub fn mk_acc_field_expr<'vir, Curr, Next>(

--- a/vir/src/data.rs
+++ b/vir/src/data.rs
@@ -129,6 +129,7 @@ pub type CfgBlockData<'vir> = crate::gendata::CfgBlockGenData<'vir, !, !>;
 pub type DomainAxiomData<'vir> = crate::gendata::DomainAxiomGenData<'vir, !, !>;
 pub type DomainData<'vir> = crate::gendata::DomainGenData<'vir, !, !>;
 pub type ExprData<'vir> = crate::gendata::ExprGenData<'vir, !, !>;
+pub type ExprKindData<'vir> = crate::gendata::ExprKindGenData<'vir, ! ,!>;
 pub type ForallData<'vir> = crate::gendata::ForallGenData<'vir, !, !>;
 pub type FuncAppData<'vir> = crate::gendata::FuncAppGenData<'vir, !, !>;
 pub type FunctionData<'vir> = crate::gendata::FunctionGenData<'vir, !, !>;

--- a/vir/src/debug.rs
+++ b/vir/src/debug.rs
@@ -123,6 +123,13 @@ impl<'vir> Debug for DomainFunctionData<'vir> {
 
 impl<'vir, Curr, Next> Debug for ExprGenData<'vir, Curr, Next> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        // TODO: Position, etc
+        self.0.fmt(f)
+    }
+}
+
+impl<'vir, Curr, Next> Debug for ExprKindGenData<'vir, Curr, Next> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Self::AccField(e) => e.fmt(f),
             Self::BinOp(e) => e.fmt(f),

--- a/vir/src/debug.rs
+++ b/vir/src/debug.rs
@@ -124,7 +124,7 @@ impl<'vir> Debug for DomainFunctionData<'vir> {
 impl<'vir, Curr, Next> Debug for ExprGenData<'vir, Curr, Next> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         // TODO: Position, etc
-        self.0.fmt(f)
+        self.kind.fmt(f)
     }
 }
 

--- a/vir/src/gendata.rs
+++ b/vir/src/gendata.rs
@@ -83,7 +83,9 @@ impl<A, B: GenRow> GenRow for fn(A) -> B {
 
 
 // TODO add position and other metadata
-pub struct ExprGenData<'vir, Curr: 'vir, Next: 'vir>(pub ExprKindGen<'vir, Curr, Next>);
+pub struct ExprGenData<'vir, Curr: 'vir, Next: 'vir>{
+    pub kind: ExprKindGen<'vir, Curr, Next>
+}
 
 pub enum ExprKindGenData<'vir, Curr: 'vir, Next: 'vir> {
     Local(Local<'vir>),
@@ -114,7 +116,7 @@ pub enum ExprKindGenData<'vir, Curr: 'vir, Next: 'vir> {
 }
 impl<'vir, Curr, Next> ExprGenData<'vir, Curr, Next> {
     pub fn lift<Prev>(&self) -> ExprGen<'vir, Prev, ExprKindGen<'vir, Curr, Next>> {
-        match self.0 {
+        match self.kind {
             ExprKindGenData::Lazy(..) => panic!("cannot lift lazy expression"),
             _ => unsafe { std::mem::transmute(self) },
         }

--- a/vir/src/gendata.rs
+++ b/vir/src/gendata.rs
@@ -81,7 +81,11 @@ impl<A, B: GenRow> GenRow for fn(A) -> B {
     type Next = B;
 }*/
 
-pub enum ExprGenData<'vir, Curr: 'vir, Next: 'vir> {
+
+// TODO add position and other metadata
+pub struct ExprGenData<'vir, Curr: 'vir, Next: 'vir>(pub ExprKindGen<'vir, Curr, Next>);
+
+pub enum ExprKindGenData<'vir, Curr: 'vir, Next: 'vir> {
     Local(Local<'vir>),
     Field(ExprGen<'vir, Curr, Next>, &'vir str), // TODO: FieldApp?
     Old(ExprGen<'vir, Curr, Next>),
@@ -109,14 +113,13 @@ pub enum ExprGenData<'vir, Curr: 'vir, Next: 'vir> {
     Todo(&'vir str),
 }
 impl<'vir, Curr, Next> ExprGenData<'vir, Curr, Next> {
-    pub fn lift<Prev>(&self) -> ExprGen<'vir, Prev, ExprGen<'vir, Curr, Next>> {
-        match self {
-            Self::Lazy(..) => panic!("cannot lift lazy expression"),
-            e => unsafe { std::mem::transmute(e) },
+    pub fn lift<Prev>(&self) -> ExprGen<'vir, Prev, ExprKindGen<'vir, Curr, Next>> {
+        match self.0 {
+            ExprKindGenData::Lazy(..) => panic!("cannot lift lazy expression"),
+            _ => unsafe { std::mem::transmute(self) },
         }
     }
 }
-// + position, meta?
 
 #[derive(Reify)]
 pub struct DomainAxiomGenData<'vir, Curr, Next> {

--- a/vir/src/genrefs.rs
+++ b/vir/src/genrefs.rs
@@ -4,6 +4,7 @@ pub type CfgBlockGen<'vir, Curr, Next> = &'vir crate::gendata::CfgBlockGenData<'
 pub type DomainAxiomGen<'vir, Curr, Next> = &'vir crate::gendata::DomainAxiomGenData<'vir, Curr, Next>;
 pub type DomainGen<'vir, Curr, Next> = &'vir crate::gendata::DomainGenData<'vir, Curr, Next>;
 pub type ExprGen<'vir, Curr, Next> = &'vir crate::gendata::ExprGenData<'vir, Curr, Next>;
+pub type ExprKindGen<'vir, Curr, Next> = &'vir crate::gendata::ExprKindGenData<'vir, Curr, Next>;
 pub type ForallGen<'vir, Curr, Next> = &'vir crate::gendata::ForallGenData<'vir, Curr, Next>;
 pub type FuncAppGen<'vir, Curr, Next> = &'vir crate::gendata::FuncAppGenData<'vir, Curr, Next>;
 pub type FunctionGen<'vir, Curr, Next> = &'vir crate::gendata::FunctionGenData<'vir, Curr, Next>;

--- a/vir/src/refs.rs
+++ b/vir/src/refs.rs
@@ -7,6 +7,7 @@ pub type Domain<'vir> = &'vir crate::data::DomainData<'vir>;
 pub type DomainAxiom<'vir> = &'vir crate::data::DomainAxiomData<'vir>;
 pub type DomainFunction<'vir> = &'vir crate::data::DomainFunctionData<'vir>;
 pub type Expr<'vir> = &'vir crate::data::ExprData<'vir>;
+pub type ExprKind<'vir> = &'vir crate::data::ExprKindData<'vir>;
 pub type Field<'vir> = &'vir crate::data::FieldData<'vir>;
 pub type Forall<'vir> = &'vir crate::data::ForallData<'vir>;
 pub type FuncApp<'vir> = &'vir crate::data::FuncAppData<'vir>;

--- a/vir/src/reify.rs
+++ b/vir/src/reify.rs
@@ -16,38 +16,47 @@ pub trait Reify<'vir, Curr> {
 }
 
 impl<'vir, Curr: Copy, NextA, NextB> Reify<'vir, Curr>
-    for ExprGen<'vir, Curr, ExprGen<'vir, NextA, NextB>>
-{
+    for ExprGen<'vir, Curr, ExprKindGen<'vir, NextA, NextB>> {
     type Next = ExprGen<'vir, NextA, NextB>;
     fn reify<'tcx>(&self, vcx: &'vir VirCtxt<'tcx>, lctx: Curr) -> Self::Next {
+        vcx.alloc(ExprGenData(self.0.reify(vcx, lctx)))
+    }
+}
+
+impl<'vir, Curr: Copy, NextA, NextB> Reify<'vir, Curr>
+    for ExprKindGen<'vir, Curr, ExprKindGen<'vir, NextA, NextB>>
+{
+    type Next = ExprKindGen<'vir, NextA, NextB>;
+    fn reify<'tcx>(&self, vcx: &'vir VirCtxt<'tcx>, lctx: Curr) -> Self::Next {
         match self {
-            ExprGenData::Field(v, f) => vcx.alloc(ExprGenData::Field(v.reify(vcx, lctx), f)),
-            ExprGenData::Old(v) => vcx.alloc(ExprGenData::Old(v.reify(vcx, lctx))),
-            ExprGenData::AccField(v) => vcx.alloc(ExprGenData::AccField(v.reify(vcx, lctx))),
-            ExprGenData::Unfolding(v) => vcx.alloc(ExprGenData::Unfolding(v.reify(vcx, lctx))),
-            ExprGenData::UnOp(v) => vcx.alloc(ExprGenData::UnOp(v.reify(vcx, lctx))),
-            ExprGenData::BinOp(v) => vcx.alloc(ExprGenData::BinOp(v.reify(vcx, lctx))),
-            ExprGenData::Ternary(v) => vcx.alloc(ExprGenData::Ternary(v.reify(vcx, lctx))),
-            ExprGenData::Forall(v) => vcx.alloc(ExprGenData::Forall(v.reify(vcx, lctx))),
-            ExprGenData::Let(v) => vcx.alloc(ExprGenData::Let(v.reify(vcx, lctx))),
-            ExprGenData::FuncApp(v) => vcx.alloc(ExprGenData::FuncApp(v.reify(vcx, lctx))),
-            ExprGenData::PredicateApp(v) => vcx.alloc(ExprGenData::PredicateApp(v.reify(vcx, lctx))),
+            ExprKindGenData::Field(v, f) => vcx.alloc(ExprKindGenData::Field(v.reify(vcx, lctx), f)),
+            ExprKindGenData::Old(v) => vcx.alloc(ExprKindGenData::Old(v.reify(vcx, lctx))),
+            ExprKindGenData::AccField(v) => vcx.alloc(ExprKindGenData::AccField(v.reify(vcx, lctx))),
+            ExprKindGenData::Unfolding(v) => vcx.alloc(ExprKindGenData::Unfolding(v.reify(vcx, lctx))),
+            ExprKindGenData::UnOp(v) => vcx.alloc(ExprKindGenData::UnOp(v.reify(vcx, lctx))),
+            ExprKindGenData::BinOp(v) => vcx.alloc(ExprKindGenData::BinOp(v.reify(vcx, lctx))),
+            ExprKindGenData::Ternary(v) => vcx.alloc(ExprKindGenData::Ternary(v.reify(vcx, lctx))),
+            ExprKindGenData::Forall(v) => vcx.alloc(ExprKindGenData::Forall(v.reify(vcx, lctx))),
+            ExprKindGenData::Let(v) => vcx.alloc(ExprKindGenData::Let(v.reify(vcx, lctx))),
+            ExprKindGenData::FuncApp(v) => vcx.alloc(ExprKindGenData::FuncApp(v.reify(vcx, lctx))),
+            ExprKindGenData::PredicateApp(v) => vcx.alloc(ExprKindGenData::PredicateApp(v.reify(vcx, lctx))),
 
-            ExprGenData::Local(v) => vcx.alloc(ExprGenData::Local(v)),
-            ExprGenData::Const(v) => vcx.alloc(ExprGenData::Const(v)),
-            ExprGenData::Todo(v) => vcx.alloc(ExprGenData::Todo(v)),
+            ExprKindGenData::Local(v) => vcx.alloc(ExprKindGenData::Local(v)),
+            ExprKindGenData::Const(v) => vcx.alloc(ExprKindGenData::Const(v)),
+            ExprKindGenData::Todo(v) => vcx.alloc(ExprKindGenData::Todo(v)),
 
-            ExprGenData::Lazy(_, f) => f(vcx, lctx),
+            ExprKindGenData::Lazy(_, f) => f(vcx, lctx),
         }
     }
 }
+
 
 // TODO: how to make these generic? i.e. how to implement `Reify` for *any*
 //   slice of reify-able elements? same for an Option of a slice;
 //   for now these implementations are generated in the Reify derive macro
 
 impl<'vir, Curr: Copy, NextA, NextB> Reify<'vir, Curr>
-    for [ExprGen<'vir, Curr, ExprGen<'vir, NextA, NextB>>]
+    for [ExprGen<'vir, Curr, ExprKindGen<'vir, NextA, NextB>>]
 {
     type Next = &'vir [ExprGen<'vir, NextA, NextB>];
     fn reify<'tcx>(&self, vcx: &'vir VirCtxt<'tcx>, lctx: Curr) -> Self::Next {
@@ -58,7 +67,7 @@ impl<'vir, Curr: Copy, NextA, NextB> Reify<'vir, Curr>
 }
 
 impl<'vir, Curr: Copy, NextA, NextB> Reify<'vir, Curr>
-    for [&'vir [ExprGen<'vir, Curr, ExprGen<'vir, NextA, NextB>>]]
+    for [&'vir [ExprGen<'vir, Curr, ExprKindGen<'vir, NextA, NextB>>]]
 {
     type Next = &'vir [&'vir [ExprGen<'vir, NextA, NextB>]];
     fn reify<'tcx>(&self, vcx: &'vir VirCtxt<'tcx>, lctx: Curr) -> Self::Next {
@@ -69,7 +78,7 @@ impl<'vir, Curr: Copy, NextA, NextB> Reify<'vir, Curr>
 }
 
 impl<'vir, Curr: Copy, NextA, NextB> Reify<'vir, Curr>
-    for [(ExprGen<'vir, Curr, ExprGen<'vir, NextA, NextB>>, CfgBlockLabel<'vir>)]
+    for [(ExprGen<'vir, Curr, ExprKindGen<'vir, NextA, NextB>>, CfgBlockLabel<'vir>)]
 {
     type Next = &'vir [(ExprGen<'vir, NextA, NextB>, CfgBlockLabel<'vir>)];
     fn reify<'tcx>(&self, vcx: &'vir VirCtxt<'tcx>, lctx: Curr) -> Self::Next {
@@ -80,7 +89,7 @@ impl<'vir, Curr: Copy, NextA, NextB> Reify<'vir, Curr>
 }
 
 impl<'vir, Curr: Copy, NextA, NextB> Reify<'vir, Curr>
-    for Option<ExprGen<'vir, Curr, ExprGen<'vir, NextA, NextB>>>
+    for Option<ExprGen<'vir, Curr, ExprKindGen<'vir, NextA, NextB>>>
 {
     type Next = Option<ExprGen<'vir, NextA, NextB>>;
     fn reify<'tcx>(&self, vcx: &'vir VirCtxt<'tcx>, lctx: Curr) -> Self::Next {
@@ -89,7 +98,7 @@ impl<'vir, Curr: Copy, NextA, NextB> Reify<'vir, Curr>
 }
 
 impl<'vir, Curr: Copy, NextA, NextB> Reify<'vir, Curr>
-    for Option<&'vir [CfgBlockGen<'vir, Curr, ExprGen<'vir, NextA, NextB>>]>
+    for Option<&'vir [CfgBlockGen<'vir, Curr, ExprKindGen<'vir, NextA, NextB>>]>
 {
     type Next = Option<&'vir [CfgBlockGen<'vir, NextA, NextB>]>;
     fn reify<'tcx>(&self, vcx: &'vir VirCtxt<'tcx>, lctx: Curr) -> Self::Next {

--- a/vir/src/reify.rs
+++ b/vir/src/reify.rs
@@ -19,7 +19,7 @@ impl<'vir, Curr: Copy, NextA, NextB> Reify<'vir, Curr>
     for ExprGen<'vir, Curr, ExprKindGen<'vir, NextA, NextB>> {
     type Next = ExprGen<'vir, NextA, NextB>;
     fn reify<'tcx>(&self, vcx: &'vir VirCtxt<'tcx>, lctx: Curr) -> Self::Next {
-        vcx.alloc(ExprGenData(self.0.reify(vcx, lctx)))
+        vcx.alloc(ExprGenData { kind: self.kind.reify(vcx, lctx) })
     }
 }
 


### PR DESCRIPTION
This PR renames the `Expr*` enum to `ExprKind`, and introduces a new `Expr*` struct to represent expressions including position, metadata, etc.

The `Reify` implementation for `ExprKind` is essentially the same as the previous implementation for `Expr`.
The `Reify` implementation for the (new) `Expr` simply calls `reify` on the contained `ExprKind` and wraps the result in an `Expr`.