### PR TITLE
Cleanup, derive task encoder caches

### DIFF
--- a/prusti-encoder/src/encoders/generic.rs
+++ b/prusti-encoder/src/encoders/generic.rs
@@ -26,30 +26,15 @@ pub struct GenericEncOutput<'vir> {
     pub domain_type: vir::Domain<'vir>,
 }
 
-use std::cell::RefCell;
-thread_local! {
-    static CACHE: task_encoder::CacheStaticRef<GenericEnc> = RefCell::new(Default::default());
-}
-
 impl TaskEncoder for GenericEnc {
+    task_encoder::encoder_cache!(GenericEnc);
+
     type TaskDescription<'tcx> = (); // ?
 
     type OutputRef<'vir> = GenericEncOutputRef<'vir>;
     type OutputFullLocal<'vir> = GenericEncOutput<'vir>;
 
     type EncodingError = GenericEncError;
-
-    fn with_cache<'tcx: 'vir, 'vir, F, R>(f: F) -> R
-        where F: FnOnce(&'vir task_encoder::CacheRef<'tcx, 'vir, GenericEnc>) -> R,
-    {
-        CACHE.with(|cache| {
-            // SAFETY: the 'vir and 'tcx given to this function will always be
-            //   the same (or shorter) than the lifetimes of the VIR arena and
-            //   the rustc type context, respectively
-            let cache = unsafe { std::mem::transmute(cache) };
-            f(cache)
-        })
-    }
 
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         *task

--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -33,33 +33,17 @@ pub struct MirBuiltinEncOutput<'vir> {
     pub function: vir::Function<'vir>,
 }
 
-use std::cell::RefCell;
-
 use crate::encoders::SnapshotEnc;
 
-thread_local! {
-    static CACHE: task_encoder::CacheStaticRef<MirBuiltinEnc> = RefCell::new(Default::default());
-}
-
 impl TaskEncoder for MirBuiltinEnc {
+    task_encoder::encoder_cache!(MirBuiltinEnc);
+
     type TaskDescription<'vir> = MirBuiltinEncTask<'vir>;
 
     type OutputRef<'vir> = MirBuiltinEncOutputRef<'vir>;
     type OutputFullLocal<'vir> = MirBuiltinEncOutput<'vir>;
 
     type EncodingError = MirBuiltinEncError;
-
-    fn with_cache<'tcx: 'vir, 'vir, F, R>(f: F) -> R
-        where F: FnOnce(&'vir task_encoder::CacheRef<'tcx, 'vir, MirBuiltinEnc>) -> R,
-    {
-        CACHE.with(|cache| {
-            // SAFETY: the 'vir and 'tcx given to this function will always be
-            //   the same (or shorter) than the lifetimes of the VIR arena and
-            //   the rustc type context, respectively
-            let cache = unsafe { std::mem::transmute(cache) };
-            f(cache)
-        })
-    }
 
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         task.clone()

--- a/prusti-encoder/src/encoders/type/predicate.rs
+++ b/prusti-encoder/src/encoders/type/predicate.rs
@@ -132,14 +132,11 @@ pub struct PredicateEncOutput<'vir> {
     pub method_assign: vir::Method<'vir>,
 }
 
-use std::cell::RefCell;
-
 use super::{snapshot::SnapshotEnc, domain::{DomainDataPrim, DomainDataStruct, DomainDataEnum, DiscrBounds}};
-thread_local! {
-    static CACHE: task_encoder::CacheStaticRef<PredicateEnc> = RefCell::new(Default::default());
-}
 
 impl TaskEncoder for PredicateEnc {
+    task_encoder::encoder_cache!(PredicateEnc);
+
     type TaskDescription<'vir> = ty::Ty<'vir>;
 
     type OutputRef<'vir> = PredicateEncOutputRef<'vir>;
@@ -147,18 +144,6 @@ impl TaskEncoder for PredicateEnc {
     //type OutputFullDependency<'vir> = PredicateEncOutputDep<'vir>;
 
     type EncodingError = PredicateEncError;
-
-    fn with_cache<'tcx: 'vir, 'vir, F, R>(f: F) -> R
-        where F: FnOnce(&'vir task_encoder::CacheRef<'tcx, 'vir, PredicateEnc>) -> R,
-    {
-        CACHE.with(|cache| {
-            // SAFETY: the 'vir and 'tcx given to this function will always be
-            //   the same (or shorter) than the lifetimes of the VIR arena and
-            //   the rustc type context, respectively
-            let cache = unsafe { std::mem::transmute(cache) };
-            f(cache)
-        })
-    }
 
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         *task

--- a/prusti-encoder/src/encoders/type/snapshot.rs
+++ b/prusti-encoder/src/encoders/type/snapshot.rs
@@ -25,30 +25,15 @@ pub struct SnapshotEncOutput<'vir> {
     pub specifics: DomainEncSpecifics<'vir>,
 }
 
-use std::cell::RefCell;
-
 use super::domain::{DomainEnc, DomainEncSpecifics};
-thread_local! {
-    static CACHE: task_encoder::CacheStaticRef<SnapshotEnc> = RefCell::new(Default::default());
-}
 
 impl TaskEncoder for SnapshotEnc {
+    task_encoder::encoder_cache!(SnapshotEnc);
+
     type TaskDescription<'tcx> = ty::Ty<'tcx>;
     type OutputRef<'vir> = SnapshotEncOutputRef<'vir>;
     type OutputFullLocal<'vir> = SnapshotEncOutput<'vir>;
     type EncodingError = ();
-
-    fn with_cache<'tcx: 'vir, 'vir, F, R>(f: F) -> R
-        where F: FnOnce(&'vir task_encoder::CacheRef<'tcx, 'vir, SnapshotEnc>) -> R,
-    {
-        CACHE.with(|cache| {
-            // SAFETY: the 'vir and 'tcx given to this function will always be
-            //   the same (or shorter) than the lifetimes of the VIR arena and
-            //   the rustc type context, respectively
-            let cache = unsafe { std::mem::transmute(cache) };
-            f(cache)
-        })
-    }
 
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         *task

--- a/prusti-encoder/src/lib.rs
+++ b/prusti-encoder/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(rustc_private)]
 #![feature(associated_type_defaults)]
 #![feature(box_patterns)]
-#![feature(local_key_cell_methods)]
 
 extern crate rustc_middle;
 extern crate rustc_serialize;

--- a/prusti-encoder/src/lib.rs
+++ b/prusti-encoder/src/lib.rs
@@ -14,105 +14,6 @@ use prusti_rustc_interface::{
     hir,
 };
 
-/*
-struct MirBodyPureEnc;
-#[derive(Hash, Clone, PartialEq, Eq)]
-enum MirBodyPureEncTask<'tcx> {
-    Function {
-        parent_def_id: ty::WithOptConstParam<DefId>, // ID of the function
-        param_env: ty::ParamEnv<'tcx>, // param environment at the usage site
-        substs: ty::SubstsRef<'tcx>, // type substitutions at the usage site
-    },
-    Constant {
-        parent_def_id: ty::WithOptConstParam<DefId>, // ID of the function
-        promoted: mir::Promoted, // ID of a constant within the function
-        param_env: ty::ParamEnv<'tcx>, // param environment at the usage site
-        substs: ty::SubstsRef<'tcx>, // type substitutions at the usage site
-    },
-}
-// impl<'tcx> MirBodyPureEnc {} // TODO: shortcuts for creating tasks?
-impl TaskEncoder for MirBodyPureEnc {
-    type TaskDescription<'vir, 'tcx> = MirBodyPureEncTask<'tcx>;
-    type TaskKey<'vir, 'tcx> = (
-        DefId, // ID of the function
-        Option<mir::Promoted>, // ID of a constant within the function, or `None` if encoding the function itself
-        ty::SubstsRef<'tcx>, // ? this should be the "signature", after applying the env/substs
-    );
-    type OutputFullLocal<'vir, 'tcx> = vir::Expr<'vir> where 'tcx: 'vir;
-
-    type EncodingError = ();
-
-    encoder_cache!(MirBodyPureEnc);
-
-    fn do_encode_full<'vir, 'tcx>(
-        task_key: &Self::TaskKey<'vir, 'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir, 'tcx>,
-    ) -> Result<(
-        Self::OutputFullLocal<'vir, 'tcx>,
-        Self::OutputFullDependency<'vir, 'tcx>,
-    ), (
-        Self::EncodingError,
-        Option<Self::OutputFullDependency<'vir, 'tcx>>,
-    )> {
-        todo!()
-    }
-
-    fn task_to_key<'vir, 'tcx>(task: &Self::TaskDescription<'vir, 'tcx>) -> Self::TaskKey<'vir, 'tcx> {
-        match task {
-            MirBodyPureEncTask::Function {
-                parent_def_id,
-                param_env,
-                substs,
-            } => (
-                parent_def_id.did,
-                None,
-                substs, // TODO
-            ),
-            MirBodyPureEncTask::Constant {
-                parent_def_id,
-                promoted,
-                param_env,
-                substs,
-            } => (
-                parent_def_id.did,
-                Some(*promoted),
-                substs, // TODO
-            ),
-        }
-    }
-
-    fn task_to_output_ref<'vir, 'tcx>(_task: &Self::TaskDescription<'vir, 'tcx>) -> Self::OutputRef<'vir, 'tcx> {
-        ()
-    }
-}*/
-
-// delegate to MirBodyPureEnc
-// - MirConstantEnc
-// - MirFunctionPureEnc
-/*
-struct MirBodyImpureEnc<'vir, 'tcx>(PhantomData<&'vir ()>, PhantomData<&'tcx ()>);
-impl<'vir, 'tcx> TaskEncoder<'vir, 'tcx> for MirBodyImpureEnc<'vir, 'tcx> {
-    type TaskDescription = (
-        ty::WithOptConstParam<DefId>, // ID of the function
-        ty::ParamEnv<'tcx>, // param environment at the usage site
-        ty::SubstsRef<'tcx>, // type substitutions at the usage site
-    );
-    // TaskKey, OutputRef same as above
-    type OutputFull = vir::Method<'vir>;
-}
-
-struct MirTyEnc<'vir, 'tcx>(PhantomData<&'vir ()>, PhantomData<&'tcx ()>);
-impl<'vir, 'tcx> TaskEncoder<'vir, 'tcx> for MirTyEnc<'vir, 'tcx> {
-    type TaskDescription = ty::Ty<'tcx>;
-    // TaskKey = TaskDescription
-    type OutputRef = vir::Type<'vir>;
-    type OutputFull = (
-        Vec<vir::Domain<'vir>>,
-        Vec<vir::Predicate<'vir>>,
-    );
-}
-*/
-
 pub fn test_entrypoint<'tcx>(
     tcx: ty::TyCtxt<'tcx>,
     body: EnvBody<'tcx>,
@@ -128,10 +29,6 @@ pub fn test_entrypoint<'tcx>(
     for def_id in tcx.hir().body_owners() {
         tracing::debug!("test_entrypoint item: {def_id:?}");
         let kind = tcx.def_kind(def_id);
-        //println!("  kind: {:?}", kind);
-        /*if !format!("{def_id:?}").contains("foo") {
-            continue;
-        }*/
         match kind {
             hir::def::DefKind::Fn |
             hir::def::DefKind::AssocFn => {
@@ -151,19 +48,12 @@ pub fn test_entrypoint<'tcx>(
                     let res = crate::encoders::MirImpureEnc::encode((def_id, substs, None));
                     assert!(res.is_ok());
                 }
-
-                /*
-                match res {
-                    Ok(res) => println!("ok: {:?}", res),
-                    Err(err) => println!("err: {:?}", err),
-                }*/
             }
             unsupported_item_kind => {
                 tracing::debug!("unsupported item: {unsupported_item_kind:?}");
             }
         }
     }
-    //println!("all items in crate: {:?}", tcx.hir_crate_items(()).definitions().collect::<Vec<_>>());
 
     fn header(code: &mut String, title: &str) {
         code.push_str("// -----------------------------\n");
@@ -212,8 +102,6 @@ pub fn test_entrypoint<'tcx>(
         for pred in output.predicates {
             viper_code.push_str(&format!("{:?}\n", pred));
         }
-
-        //viper_code.push_str(&format!("{:?}\n", output.method_refold));
         viper_code.push_str(&format!("{:?}\n", output.method_assign));
     }
 

--- a/vir/src/lib.rs
+++ b/vir/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(rustc_private)]
-#![feature(local_key_cell_methods)]
 #![feature(never_type)]
 #![feature(iter_intersperse)]
 


### PR DESCRIPTION
Cleanup changes. Replaces https://github.com/Aurel300/prusti-dev/pull/27

- `CACHE` and `with_cache` in every encoder is replaced by a macro call.
- Some Rust feature attributes were no longer needed.
- Code commented out in `prusti-encoder/src/lib.rs` was a sketch of various encoders that now exist.
