### PR TITLE
Implement `old` and `rel`

### DIFF
--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -341,21 +341,18 @@ pub fn old<T>(arg: T) -> T {
 
 #[prusti::builtin="old_start"]
 pub fn old_start(){}
-
 #[prusti::builtin="old_end"]
 pub fn old_end(){}
 
 
 #[prusti::builtin="rel0_start"]
 pub fn rel0_start(){}
-
 #[prusti::builtin="rel0_end"]
 pub fn rel0_end(){}
 
 
 #[prusti::builtin="rel1_start"]
 pub fn rel1_start(){}
-
 #[prusti::builtin="rel1_end"]
 pub fn rel1_end(){}
 

--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -339,6 +339,28 @@ pub fn old<T>(arg: T) -> T {
     arg
 }
 
+#[prusti::builtin="old_start"]
+pub fn old_start(){}
+
+#[prusti::builtin="old_end"]
+pub fn old_end(){}
+
+
+#[prusti::builtin="rel0_start"]
+pub fn rel0_start(){}
+
+#[prusti::builtin="rel0_end"]
+pub fn rel0_end(){}
+
+
+#[prusti::builtin="rel1_start"]
+pub fn rel1_start(){}
+
+#[prusti::builtin="rel1_end"]
+pub fn rel1_end(){}
+
+
+
 /// Universal quantifier.
 ///
 /// This is a Prusti-internal representation of the `forall` syntax.

--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -327,36 +327,34 @@ mod private {
     }
 }
 
-/// This function is used to evaluate an expression in the context just
-/// before the borrows expires.
-pub fn before_expiry<T>(arg: T) -> T {
-    arg
-}
+/// This function is used to mark the beginning of evaluation of expressions
+/// in the "before expiration" context, just before the expiry of the borrow
+/// that the pledge is specifying.
+#[cfg_attr(feature = "prusti", prusti::builtin = "before_expiry_start")]
+pub fn before_expiry_start() {}
 
-/// This function is used to evaluate an expression in the “old”
-/// context, that is at the beginning of the method call.
-pub fn old<T>(arg: T) -> T {
-    arg
-}
+/// End of the context started with `before_expiry_start`.
+#[cfg_attr(feature = "prusti", prusti::builtin = "before_expiry_end")]
+pub fn before_expiry_end() {}
 
-#[prusti::builtin="old_start"]
-pub fn old_start(){}
-#[prusti::builtin="old_end"]
-pub fn old_end(){}
+/// This function is used to mark the beginning of evaluation of expressions
+/// in the "old" context, that is at the beginning of the method call.
+#[cfg_attr(feature = "prusti", prusti::builtin = "old_start")]
+pub fn old_start() {}
 
+/// End of the context started with `old_start`.
+#[cfg_attr(feature = "prusti", prusti::builtin = "old_end")]
+pub fn old_end() {}
 
-#[prusti::builtin="rel0_start"]
-pub fn rel0_start(){}
-#[prusti::builtin="rel0_end"]
-pub fn rel0_end(){}
+/// This function is used to mark the beginning of evaluation of expressions
+/// in a given execution, when specifying a hyperproperty concerning multiple
+/// exeuctions.
+#[cfg_attr(feature = "prusti", prusti::builtin = "rel_start")]
+pub fn rel_start<const E: usize>() {}
 
-
-#[prusti::builtin="rel1_start"]
-pub fn rel1_start(){}
-#[prusti::builtin="rel1_end"]
-pub fn rel1_end(){}
-
-
+/// End of the context started with `rel_start`.
+#[cfg_attr(feature = "prusti", prusti::builtin = "rel_end")]
+pub fn rel_end<const E: usize>() {}
 
 /// Universal quantifier.
 ///

--- a/prusti-contracts/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-contracts/prusti-specs/src/specifications/preparser.rs
@@ -155,6 +155,15 @@ impl PrustiTokenStream {
                     (TokenTree::Ident(ident), _, _, _) if ident == "exists" => {
                         PrustiToken::Quantifier(ident.span(), Quantifier::Exists)
                     }
+                    (TokenTree::Ident(ident), _, _, _) if ident == "old" => {
+                        PrustiToken::ModeMarker(ident.span(), MarkerKind::Old)
+                    }
+                    (TokenTree::Ident(ident), _, _, _) if ident == "rel0" => {
+                        PrustiToken::ModeMarker(ident.span(), MarkerKind::Rel0)
+                    }
+                    (TokenTree::Ident(ident), _, _, _) if ident == "rel1" => {
+                        PrustiToken::ModeMarker(ident.span(), MarkerKind::Rel1)
+                    }
                     (TokenTree::Punct(punct), _, _, _)
                         if punct.as_char() == ',' && punct.spacing() == Alone =>
                     {
@@ -289,6 +298,9 @@ impl PrustiTokenStream {
                     .ok_or_else(|| error(span, "expected parenthesized expression after outer"))?;
                 todo!()
             }
+            Some(PrustiToken::ModeMarker(span, kind )) => {
+               self.parse_marker(span, kind)?
+            }
             Some(PrustiToken::Quantifier(span, kind)) => {
                 let mut stream = self.pop_group(Delimiter::Parenthesis).ok_or_else(|| {
                     error(span, "expected parenthesized expression after quantifier")
@@ -384,6 +396,15 @@ impl PrustiTokenStream {
                 Some(PrustiToken::Quantifier(span, _)) => {
                     return err(*span, "unexpected quantifier")
                 }
+                Some(PrustiToken::ModeMarker(span, kind )) => {
+                    let span = span.clone();
+                    let kind = kind.clone();
+
+                    self.tokens.pop_front();
+                    lhs.extend(self.parse_marker(span, kind)?);
+
+                    continue;
+                 }
 
                 None => break,
             };
@@ -489,6 +510,24 @@ impl PrustiTokenStream {
             .map(|stream| stream.and_then(|s| s.parse()))
             .collect::<syn::Result<Vec<NestedSpec<TokenStream>>>>()?;
         Ok(parsed)
+    }
+
+    fn parse_marker(&mut self, span: Span, kind: MarkerKind) -> syn::Result<TokenStream> {
+        let args = self.pop_group(Delimiter::Parenthesis).ok_or_else(|| {
+            error(span, "expected parenthesized expression after mode marker")
+        })?;
+
+        let parsed = args.parse()?;
+        let start_fn = kind.start_fn();
+        let end_fn = kind.end_fn();
+
+        Ok(quote_spanned! { span => {
+            #start_fn ;
+            let r = { #parsed };
+            #end_fn ;
+            r
+        }
+        })
     }
 
     fn split(self, split_on: PrustiBinaryOp, allow_trailing: bool) -> Vec<Self> {
@@ -665,6 +704,7 @@ enum PrustiToken {
     #[allow(unused)]
     // TODO: the "once" flag is not used since there is no calldesc translation yet
     CallDesc(Span, bool),
+    ModeMarker(Span, MarkerKind)
 }
 
 fn translate_spec_ent(
@@ -818,7 +858,8 @@ impl PrustiToken {
             | Self::Outer(span)
             | Self::Quantifier(span, _)
             | Self::SpecEnt(span, _)
-            | Self::CallDesc(span, _) => *span,
+            | Self::CallDesc(span, _)
+            | Self::ModeMarker(span, _)=> *span,
             Self::Token(tree) => tree.span(),
         }
     }
@@ -922,6 +963,31 @@ enum PrustiBinaryOp {
     And,
     SnapEq,
     SnapNe,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MarkerKind {
+   Old,
+   Rel0,
+   Rel1,
+}
+
+impl MarkerKind {
+    fn start_fn(&self) -> TokenStream {
+        match self {
+            MarkerKind::Old =>  quote!(::prusti_contracts::old_start()),
+            MarkerKind::Rel0 => quote!(::prusti_contracts::rel0_start()),
+            MarkerKind::Rel1 => quote!(::prusti_contracts::rel1_start()),
+        }
+    }
+
+    fn end_fn(&self) -> TokenStream {
+        match self {
+            MarkerKind::Old =>  quote!(::prusti_contracts::old_end()),
+            MarkerKind::Rel0 => quote!(::prusti_contracts::rel0_end()),
+            MarkerKind::Rel1 => quote!(::prusti_contracts::rel1_end()),
+        }
+    }
 }
 
 impl PrustiBinaryOp {

--- a/prusti-contracts/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-contracts/prusti-specs/src/specifications/preparser.rs
@@ -298,7 +298,7 @@ impl PrustiTokenStream {
                     .ok_or_else(|| error(span, "expected parenthesized expression after outer"))?;
                 todo!()
             }
-            Some(PrustiToken::ModeMarker(span, kind )) => {
+            Some(PrustiToken::ModeMarker(span, kind)) => {
                self.parse_marker(span, kind)?
             }
             Some(PrustiToken::Quantifier(span, kind)) => {
@@ -396,7 +396,7 @@ impl PrustiTokenStream {
                 Some(PrustiToken::Quantifier(span, _)) => {
                     return err(*span, "unexpected quantifier")
                 }
-                Some(PrustiToken::ModeMarker(span, kind )) => {
+                Some(PrustiToken::ModeMarker(span, kind)) => {
                     let span = span.clone();
                     let kind = kind.clone();
 
@@ -521,12 +521,13 @@ impl PrustiTokenStream {
         let start_fn = kind.start_fn();
         let end_fn = kind.end_fn();
 
-        Ok(quote_spanned! { span => {
-            #start_fn ;
-            let r = { #parsed };
-            #end_fn ;
-            r
-        }
+        Ok(quote_spanned! { span =>
+            {
+                #start_fn ;
+                let r = { #parsed };
+                #end_fn ;
+                r
+            }
         })
     }
 

--- a/prusti-contracts/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-contracts/prusti-specs/src/specifications/preparser.rs
@@ -159,10 +159,13 @@ impl PrustiTokenStream {
                         PrustiToken::ModeMarker(ident.span(), MarkerKind::Old)
                     }
                     (TokenTree::Ident(ident), _, _, _) if ident == "rel0" => {
-                        PrustiToken::ModeMarker(ident.span(), MarkerKind::Rel0)
+                        PrustiToken::ModeMarker(ident.span(), MarkerKind::Rel(0))
                     }
                     (TokenTree::Ident(ident), _, _, _) if ident == "rel1" => {
-                        PrustiToken::ModeMarker(ident.span(), MarkerKind::Rel1)
+                        PrustiToken::ModeMarker(ident.span(), MarkerKind::Rel(1))
+                    }
+                    (TokenTree::Ident(ident), _, _, _) if ident == "before_expiry" => {
+                        PrustiToken::ModeMarker(ident.span(), MarkerKind::BeforeExpiry)
                     }
                     (TokenTree::Punct(punct), _, _, _)
                         if punct.as_char() == ',' && punct.spacing() == Alone =>
@@ -299,7 +302,11 @@ impl PrustiTokenStream {
                 todo!()
             }
             Some(PrustiToken::ModeMarker(span, kind)) => {
-               self.parse_marker(span, kind)?
+                let expr = self.pop_group(Delimiter::Parenthesis).ok_or_else(|| {
+                    error(span, "expected parenthesized expression after mode marker")
+                })?;
+                let expr = expr.parse()?;
+                kind.translate(span, expr)
             }
             Some(PrustiToken::Quantifier(span, kind)) => {
                 let mut stream = self.pop_group(Delimiter::Parenthesis).ok_or_else(|| {
@@ -397,14 +404,16 @@ impl PrustiTokenStream {
                     return err(*span, "unexpected quantifier")
                 }
                 Some(PrustiToken::ModeMarker(span, kind)) => {
-                    let span = span.clone();
-                    let kind = kind.clone();
-
+                    let span = *span;
+                    let kind = *kind;
                     self.tokens.pop_front();
-                    lhs.extend(self.parse_marker(span, kind)?);
-
+                    let expr = self.pop_group(Delimiter::Parenthesis).ok_or_else(|| {
+                        error(span, "expected parenthesized expression after mode marker")
+                    })?;
+                    let expr = expr.parse()?;
+                    lhs.extend(kind.translate(span, expr).to_token_stream());
                     continue;
-                 }
+                }
 
                 None => break,
             };
@@ -510,25 +519,6 @@ impl PrustiTokenStream {
             .map(|stream| stream.and_then(|s| s.parse()))
             .collect::<syn::Result<Vec<NestedSpec<TokenStream>>>>()?;
         Ok(parsed)
-    }
-
-    fn parse_marker(&mut self, span: Span, kind: MarkerKind) -> syn::Result<TokenStream> {
-        let args = self.pop_group(Delimiter::Parenthesis).ok_or_else(|| {
-            error(span, "expected parenthesized expression after mode marker")
-        })?;
-
-        let parsed = args.parse()?;
-        let start_fn = kind.start_fn();
-        let end_fn = kind.end_fn();
-
-        Ok(quote_spanned! { span =>
-            {
-                #start_fn ;
-                let r = { #parsed };
-                #end_fn ;
-                r
-            }
-        })
     }
 
     fn split(self, split_on: PrustiBinaryOp, allow_trailing: bool) -> Vec<Self> {
@@ -705,7 +695,7 @@ enum PrustiToken {
     #[allow(unused)]
     // TODO: the "once" flag is not used since there is no calldesc translation yet
     CallDesc(Span, bool),
-    ModeMarker(Span, MarkerKind)
+    ModeMarker(Span, MarkerKind),
 }
 
 fn translate_spec_ent(
@@ -781,6 +771,38 @@ fn translate_spec_ent(
             ( #( #[prusti::spec_only] || -> bool { ((#postconds): bool) }, )* ),
         )
     } }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MarkerKind {
+    Old,
+    Rel(usize),
+    BeforeExpiry,
+}
+
+impl MarkerKind {
+    fn translate(&self, span: Span, expr: TokenStream) -> TokenStream {
+        let (start, end) = match self {
+            MarkerKind::Old => (
+                quote_spanned!(span => ::prusti_contracts::old_start()),
+                quote_spanned!(span => ::prusti_contracts::old_end()),
+            ),
+            MarkerKind::Rel(execution) => (
+                quote_spanned!(span => ::prusti_contracts::rel_start::<#execution>()),
+                quote_spanned!(span => ::prusti_contracts::rel_end::<#execution>()),
+            ),
+            MarkerKind::BeforeExpiry => (
+                quote_spanned!(span => ::prusti_contracts::before_expiry_start()),
+                quote_spanned!(span => ::prusti_contracts::before_expiry_end()),
+            ),
+        };
+        quote_spanned! { span => {
+            #start ;
+            let r = { #expr };
+            #end ;
+            r
+        } }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -860,7 +882,7 @@ impl PrustiToken {
             | Self::Quantifier(span, _)
             | Self::SpecEnt(span, _)
             | Self::CallDesc(span, _)
-            | Self::ModeMarker(span, _)=> *span,
+            | Self::ModeMarker(span, _) => *span,
             Self::Token(tree) => tree.span(),
         }
     }
@@ -964,31 +986,6 @@ enum PrustiBinaryOp {
     And,
     SnapEq,
     SnapNe,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum MarkerKind {
-   Old,
-   Rel0,
-   Rel1,
-}
-
-impl MarkerKind {
-    fn start_fn(&self) -> TokenStream {
-        match self {
-            MarkerKind::Old =>  quote!(::prusti_contracts::old_start()),
-            MarkerKind::Rel0 => quote!(::prusti_contracts::rel0_start()),
-            MarkerKind::Rel1 => quote!(::prusti_contracts::rel1_start()),
-        }
-    }
-
-    fn end_fn(&self) -> TokenStream {
-        match self {
-            MarkerKind::Old =>  quote!(::prusti_contracts::old_end()),
-            MarkerKind::Rel0 => quote!(::prusti_contracts::rel0_end()),
-            MarkerKind::Rel1 => quote!(::prusti_contracts::rel1_end()),
-        }
-    }
 }
 
 impl PrustiBinaryOp {

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -47,7 +47,6 @@ pub enum ModeMarker {
     Rel0End,
 }
 
-
 // TODO: does this need to be `&'vir [..]`?
 type ExprInput<'vir> = (DefId, &'vir [vir::Expr<'vir>]);
 type ExprRet<'vir> = vir::ExprGen<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>;
@@ -782,17 +781,17 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
 
         let mut place_ty = mir::tcx::PlaceTy::from_ty(self.body.local_decls[place.local].ty);
 
-        let is_in_a_mode = self.old_mode || self.rel0_mode || self.rel1_mode;
-
-        let local_kind = self.body.local_kind(place.local);
-
-        let should_wrap = (local_kind == mir::LocalKind::Arg || local_kind == mir::LocalKind::ReturnPointer) && is_in_a_mode;
+        let should_wrap = {
+            let is_in_a_mode = self.old_mode || self.rel0_mode || self.rel1_mode;
+            let local_kind = self.body.local_kind(place.local);
+            (local_kind == mir::LocalKind::Arg || local_kind == mir::LocalKind::ReturnPointer) && is_in_a_mode
+        };
 
         let mut expr = if should_wrap {
             let local_as_uzize = place.local.as_usize();
 
             self.vcx.mk_lazy_expr(
-                vir::vir_format!(self.vcx, "wraped in _{}",local_as_uzize),
+                vir::vir_format!(self.vcx, "wraped in _{}", local_as_uzize),
                 Box::new(move |_vcx, lctx: ExprInput<'vir>| lctx.1[local_as_uzize - 1].kind),
             )
         }
@@ -800,7 +799,6 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
             self.mk_local_ex(place.local, curr_ver[&place.local])
         };
         let mut place_ref = None;
-
         // TODO: factor this out (duplication with impure encoder)?
         for elem in place.projection {
             (expr, place_ref) = self.encode_place_element(place_ty, elem, expr, place_ref);

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -37,6 +37,17 @@ pub enum MirPureEncError {
     // UnsupportedTerminator,
 }
 
+#[derive(Clone, Debug)]
+pub enum ModeMarker {
+    OldStart, 
+    OldEnd,
+    Rel1Start,
+    Rel1End,
+    Rel0Start,
+    Rel0End,
+}
+
+
 // TODO: does this need to be `&'vir [..]`?
 type ExprInput<'vir> = (DefId, &'vir [vir::Expr<'vir>]);
 type ExprRet<'vir> = vir::ExprGen<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>;
@@ -198,6 +209,9 @@ struct Enc<'vir: 'enc, 'enc> {
     // visited: IndexVec<mir::BasicBlock, bool>,
     version_ctr: IndexVec<mir::Local, usize>,
     phi_ctr: usize,
+    old_mode: bool,
+    rel0_mode: bool,
+    rel1_mode: bool,
 }
 
 impl<'vir, 'enc> PureFuncAppEnc<'vir, MirPureEnc> for Enc<'vir, 'enc> {
@@ -259,6 +273,9 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
             // visited: IndexVec::from_elem_n(false, body.basic_blocks.len()),
             version_ctr: IndexVec::from_elem_n(0, body.local_decls.len()),
             phi_ctr: 0,
+            old_mode: false,
+            rel0_mode: false,
+            rel1_mode: false,
         }
     }
 
@@ -764,8 +781,26 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         assert!(curr_ver.contains_key(&place.local));
 
         let mut place_ty = mir::tcx::PlaceTy::from_ty(self.body.local_decls[place.local].ty);
-        let mut expr = self.mk_local_ex(place.local, curr_ver[&place.local]);
+
+        let is_in_a_mode = self.old_mode || self.rel0_mode || self.rel1_mode;
+
+        let local_kind = self.body.local_kind(place.local);
+
+        let should_wrap = (local_kind == mir::LocalKind::Arg || local_kind == mir::LocalKind::ReturnPointer) && is_in_a_mode;
+
+        let mut expr = if should_wrap {
+            let local_as_uzize = place.local.as_usize();
+
+            self.vcx.mk_lazy_expr(
+                vir::vir_format!(self.vcx, "wraped in _{}",local_as_uzize),
+                Box::new(move |_vcx, lctx: ExprInput<'vir>| lctx.1[local_as_uzize - 1].kind),
+            )
+        }
+        else {
+            self.mk_local_ex(place.local, curr_ver[&place.local])
+        };
         let mut place_ref = None;
+
         // TODO: factor this out (duplication with impure encoder)?
         for elem in place.projection {
             (expr, place_ref) = self.encode_place_element(place_ty, elem, expr, place_ref);
@@ -773,6 +808,19 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         }
         // Can we ever have the use of a projected place?
         assert!(place_ty.variant_index.is_none());
+
+        if should_wrap {
+            if self.old_mode {
+                expr = self.vcx.mk_old_expr(expr)
+            }
+            if self.rel0_mode {
+                expr = self.vcx.mk_rel_expr(expr, 0)
+            }
+            if self.rel1_mode {
+                expr = self.vcx.mk_rel_expr(expr, 1)
+            }
+        }
+
         (expr, place_ref)
     }
 
@@ -864,6 +912,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         enum PrustiBuiltin {
             Forall,
             SnapshotEquality,
+            Mode(ModeMarker),
         }
 
         // TODO: this attribute extraction should be done elsewhere?
@@ -885,6 +934,12 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
                     builtin = Some(match lit.symbol.as_str() {
                         "forall" => PrustiBuiltin::Forall,
                         "snapshot_equality" => PrustiBuiltin::SnapshotEquality,
+                        "old_start" => PrustiBuiltin::Mode(ModeMarker::OldStart),
+                        "old_end" => PrustiBuiltin::Mode(ModeMarker::OldEnd),
+                        "rel0_start" => PrustiBuiltin::Mode(ModeMarker::Rel0Start),
+                        "rel0_end" => PrustiBuiltin::Mode(ModeMarker::Rel0End),
+                        "rel1_start" => PrustiBuiltin::Mode(ModeMarker::Rel1Start),
+                        "rel1_end" => PrustiBuiltin::Mode(ModeMarker::Rel1End),
                         other => panic!("illegal prusti::builtin ({other})"),
                     });
                 }
@@ -1013,6 +1068,44 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
                         bool.snap_to_prim.apply(self.vcx, [body]),
                     )],
                 )
+            }
+            PrustiBuiltin::Mode(marker) => {
+                match marker {
+                    ModeMarker::OldStart => {
+                        assert!(!self.old_mode);
+                        self.old_mode = true;
+                    }
+                    ModeMarker::OldEnd => {
+                        assert!(self.old_mode);
+                        self.old_mode = false;
+                    }
+                    ModeMarker::Rel1Start => {
+                        assert!(!self.rel1_mode);
+                        assert!(!self.rel0_mode);
+
+                        self.rel1_mode = true;
+                    }
+                    ModeMarker::Rel1End => {
+                        assert!(!self.rel0_mode);
+                        assert!(self.rel1_mode);
+
+                        self.rel1_mode = false;
+                    }
+                    ModeMarker::Rel0Start => {
+                        assert!(!self.rel0_mode);
+                        assert!(!self.rel1_mode);
+
+                        self.rel0_mode = true;
+                    }
+                    ModeMarker::Rel0End => {
+                        assert!(self.rel0_mode);
+                        assert!(!self.rel1_mode);
+
+                        self.rel0_mode = false;
+                    }
+                }
+
+                self.vcx.mk_todo_expr("true") //TODO what value do we return?
             }
         }
     }

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -38,13 +38,10 @@ pub enum MirPureEncError {
 }
 
 #[derive(Clone, Debug)]
-pub enum ModeMarker {
-    OldStart, 
-    OldEnd,
-    Rel1Start,
-    Rel1End,
-    Rel0Start,
-    Rel0End,
+pub enum Mode {
+    Old,
+    Rel(usize),
+    BeforeExpiry,
 }
 
 // TODO: does this need to be `&'vir [..]`?
@@ -784,7 +781,8 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         let should_wrap = {
             let is_in_a_mode = self.old_mode || self.rel0_mode || self.rel1_mode;
             let local_kind = self.body.local_kind(place.local);
-            (local_kind == mir::LocalKind::Arg || local_kind == mir::LocalKind::ReturnPointer) && is_in_a_mode
+            (local_kind == mir::LocalKind::Arg || local_kind == mir::LocalKind::ReturnPointer)
+                && is_in_a_mode
         };
 
         let mut expr = if should_wrap {
@@ -794,8 +792,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
                 vir::vir_format!(self.vcx, "wraped in _{}", local_as_uzize),
                 Box::new(move |_vcx, lctx: ExprInput<'vir>| lctx.1[local_as_uzize - 1].kind),
             )
-        }
-        else {
+        } else {
             self.mk_local_ex(place.local, curr_ver[&place.local])
         };
         let mut place_ref = None;
@@ -910,7 +907,8 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         enum PrustiBuiltin {
             Forall,
             SnapshotEquality,
-            Mode(ModeMarker),
+            ModeStart(Mode),
+            ModeEnd(Mode),
         }
 
         // TODO: this attribute extraction should be done elsewhere?
@@ -926,18 +924,33 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
                 && item.path.segments[0].ident.as_str() == "prusti"
                 && item.path.segments[1].ident.as_str() == "builtin"
         }) {
+            let param_env = self.vcx.tcx().param_env(self.def_id);
             match &attr.args {
                 ast::AttrArgs::Eq(_, ast::AttrArgsEq::Hir(lit)) => {
                     assert!(builtin.is_none(), "multiple prusti::builtin");
                     builtin = Some(match lit.symbol.as_str() {
                         "forall" => PrustiBuiltin::Forall,
                         "snapshot_equality" => PrustiBuiltin::SnapshotEquality,
-                        "old_start" => PrustiBuiltin::Mode(ModeMarker::OldStart),
-                        "old_end" => PrustiBuiltin::Mode(ModeMarker::OldEnd),
-                        "rel0_start" => PrustiBuiltin::Mode(ModeMarker::Rel0Start),
-                        "rel0_end" => PrustiBuiltin::Mode(ModeMarker::Rel0End),
-                        "rel1_start" => PrustiBuiltin::Mode(ModeMarker::Rel1Start),
-                        "rel1_end" => PrustiBuiltin::Mode(ModeMarker::Rel1End),
+                        "old_start" => PrustiBuiltin::ModeStart(Mode::Old),
+                        "old_end" => PrustiBuiltin::ModeEnd(Mode::Old),
+                        "rel_start" => PrustiBuiltin::ModeStart(Mode::Rel(
+                            arg_tys[0]
+                                .expect_const()
+                                .try_eval_scalar_int(self.vcx.tcx(), param_env)
+                                .unwrap()
+                                .1
+                                .to_bits_unchecked() as usize,
+                        )),
+                        "rel_end" => PrustiBuiltin::ModeEnd(Mode::Rel(
+                            arg_tys[0]
+                                .expect_const()
+                                .try_eval_scalar_int(self.vcx.tcx(), param_env)
+                                .unwrap()
+                                .1
+                                .to_bits_unchecked() as usize,
+                        )),
+                        "before_expiry_start" => PrustiBuiltin::ModeStart(Mode::BeforeExpiry),
+                        "before_expiry_end" => PrustiBuiltin::ModeEnd(Mode::BeforeExpiry),
                         other => panic!("illegal prusti::builtin ({other})"),
                     });
                 }
@@ -1067,43 +1080,45 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
                     )],
                 )
             }
-            PrustiBuiltin::Mode(marker) => {
-                match marker {
-                    ModeMarker::OldStart => {
+            PrustiBuiltin::ModeStart(mode) => {
+                match mode {
+                    Mode::Old => {
                         assert!(!self.old_mode);
                         self.old_mode = true;
                     }
-                    ModeMarker::OldEnd => {
+                    Mode::Rel(0) => {
+                        assert!(!self.rel0_mode);
+                        assert!(!self.rel1_mode);
+                        self.rel0_mode = true;
+                    }
+                    Mode::Rel(_) => {
+                        assert!(!self.rel1_mode);
+                        assert!(!self.rel0_mode);
+                        self.rel1_mode = true;
+                    }
+                    Mode::BeforeExpiry => todo!(),
+                }
+                self.vcx.mk_bool::<true>().lift() //TODO what value do we return?
+            }
+            PrustiBuiltin::ModeEnd(mode) => {
+                match mode {
+                    Mode::Old => {
                         assert!(self.old_mode);
                         self.old_mode = false;
                     }
-                    ModeMarker::Rel1Start => {
-                        assert!(!self.rel1_mode);
-                        assert!(!self.rel0_mode);
-
-                        self.rel1_mode = true;
-                    }
-                    ModeMarker::Rel1End => {
-                        assert!(!self.rel0_mode);
-                        assert!(self.rel1_mode);
-
-                        self.rel1_mode = false;
-                    }
-                    ModeMarker::Rel0Start => {
-                        assert!(!self.rel0_mode);
-                        assert!(!self.rel1_mode);
-
-                        self.rel0_mode = true;
-                    }
-                    ModeMarker::Rel0End => {
+                    Mode::Rel(0) => {
                         assert!(self.rel0_mode);
                         assert!(!self.rel1_mode);
-
                         self.rel0_mode = false;
                     }
+                    Mode::Rel(_) => {
+                        assert!(!self.rel0_mode);
+                        assert!(self.rel1_mode);
+                        self.rel1_mode = false;
+                    }
+                    Mode::BeforeExpiry => todo!(),
                 }
-
-                self.vcx.mk_todo_expr("true") //TODO what value do we return?
+                self.vcx.mk_bool::<true>().lift() //TODO what value do we return?
             }
         }
     }

--- a/vir/src/make.rs
+++ b/vir/src/make.rs
@@ -249,6 +249,15 @@ impl<'tcx> VirCtxt<'tcx> {
         self.alloc(ExprGenData::new(self.alloc(ExprKindGenData::Old(expr))))
     }
 
+    pub fn mk_rel_expr<'vir, Curr, Next>(
+        &'vir self,
+        expr: ExprGen<'vir, Curr, Next>,
+        exec: u32,
+    ) -> ExprGen<'vir, Curr, Next> {
+        let v = self.mk_const_expr(ConstData::Int(exec as u128));
+        self.mk_func_app("rel", &[expr, v], expr.typ())
+    }
+
     pub fn mk_forall_expr<'vir, Curr, Next>(
         &'vir self,
         qvars: &'vir [LocalDecl<'vir>],

--- a/vir/src/make.rs
+++ b/vir/src/make.rs
@@ -255,7 +255,9 @@ impl<'tcx> VirCtxt<'tcx> {
         exec: u32,
     ) -> ExprGen<'vir, Curr, Next> {
         let v = self.mk_const_expr(ConstData::Int(exec as u128));
-        self.mk_func_app("rel", &[expr, v], expr.typ())
+        // TODO: the type here is wrong; we cannot just call .typ() though,
+        // because the arguments may be lazy
+        self.mk_func_app("rel", &[expr, v], &crate::TypeData::Int)
     }
 
     pub fn mk_forall_expr<'vir, Curr, Next>(


### PR DESCRIPTION
This implements `old` , `rel0` and `rel1`

- The syntax for calling rel from Rust is `rel0(...)` instead of `rel(...,0)` , since the integer needs to be a constant in viper 

---
Notes for me:

- branch with everything merged in:
  - https://github.com/tillarnold/prusti-dev/compare/till_old_impl2...tillarnold:prusti-dev:till_old_impl2_remove_defid
  - https://github.com/tillarnold/prusti-dev/compare/Aurel300:rewrite-2023...tillarnold:prusti-dev:till_old_impl2_remove_defid