### PR TITLE
References in pure code

### DIFF
--- a/prusti-encoder/src/encoders/local_def.rs
+++ b/prusti-encoder/src/encoders/local_def.rs
@@ -61,7 +61,7 @@ impl TaskEncoder for MirLocalDefEnc {
             let local = vcx.mk_local(name);
             let local_ex = vcx.mk_local_ex_local(local);
             let impure_snap = ty.ref_to_snap.apply(vcx, [local_ex]);
-            let impure_pred = vcx.mk_predicate_app_expr(ty.ref_to_pred.apply(vcx, [local_ex]));
+            let impure_pred = vcx.mk_predicate_app_expr(ty.ref_to_pred.apply(vcx, [local_ex], None));
             LocalDef {
                 local,
                 local_ex,

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -667,19 +667,6 @@ impl<'tcx, 'vir, 'enc> mir::visit::Visitor<'tcx> for EncVisitor<'tcx, 'vir, 'enc
                         }
                     }
 
-                    mir::Rvalue::Ref(_, kind, source) => {
-                        let place_ty = source.ty(self.local_decls, self.vcx.tcx);
-                        assert!(place_ty.variant_index.is_none());
-                        let perm = match kind {
-                            mir::BorrowKind::Shared => e_rvalue_ty.expect_ref().perm,
-                            mir::BorrowKind::Shallow => todo!(),
-                            mir::BorrowKind::Mut { kind: mir::MutBorrowKind::Default } => e_rvalue_ty.expect_ref().perm,
-                            mir::BorrowKind::Mut { .. } => todo!(),
-                        };
-                        let (snap, place_expr) = self.encode_place_snap(Place::from(*source), place_ty.ty, perm);
-                        e_rvalue_ty.expect_ref().snap_data.field_snaps_to_snap.apply(self.vcx, &[snap, place_expr])
-                    }
-
                     //mir::Rvalue::Discriminant(Place<'tcx>) => {}
                     //mir::Rvalue::ShallowInitBox(Operand<'tcx>, Ty<'tcx>) => {}
                     //mir::Rvalue::CopyForDeref(Place<'tcx>) => {}

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -433,7 +433,7 @@ impl<'tcx, 'vir, 'enc> EncVisitor<'tcx, 'vir, 'enc> {
     }
 
     fn encode_place_element(&mut self, place_ty: mir::tcx::PlaceTy<'tcx>, elem: mir::PlaceElem<'tcx>, expr: vir::Expr<'vir>) -> vir::Expr<'vir> {
-         match elem {
+        match elem {
             mir::ProjectionElem::Field(field_idx, _) => {
                 let e_ty = self.deps.require_ref::<PredicateEnc>(place_ty.ty).unwrap();
                 let field_access = e_ty.expect_variant_opt(place_ty.variant_index).ref_to_field_refs;

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -631,7 +631,7 @@ impl<'tcx, 'vir: 'enc, 'enc> Enc<'tcx, 'vir, 'enc>
     }
 
     fn encode_place_element(&mut self, place_ty: mir::tcx::PlaceTy<'tcx>, elem: mir::PlaceElem<'tcx>, expr: ExprRet<'vir>) -> ExprRet<'vir> {
-         match elem {
+        match elem {
             mir::ProjectionElem::Deref => {
                 assert!(place_ty.variant_index.is_none());
                 let e_ty = self.deps.require_local::<SnapshotEnc>(place_ty.ty).unwrap();

--- a/prusti-encoder/src/encoders/type/domain.rs
+++ b/prusti-encoder/src/encoders/type/domain.rs
@@ -186,7 +186,15 @@ impl TaskEncoder for DomainEnc {
                 let specifics = enc.mk_enum_specifics(None);
                 Ok((enc.finalize(), specifics))
             }
-            _ => todo!(),
+            &TyKind::Ref(_, inner, m) => {
+                let base_name = format!("Ref_{m:?}");
+                let (mut enc, mut ty_params) = DomainEncData::new(vcx, &base_name, [inner].into_iter());
+                deps.emit_output_ref::<Self>(*task_key, enc.output_ref(base_name));
+                ty_params.push(&vir::TypeData::Ref);
+                let specifics = enc.mk_struct_specifics(ty_params);
+                Ok((enc.finalize(), specifics))
+            }
+            kind => todo!("{kind:?}"),
         })
     }
 }

--- a/prusti-encoder/src/encoders/type/domain.rs
+++ b/prusti-encoder/src/encoders/type/domain.rs
@@ -190,7 +190,9 @@ impl TaskEncoder for DomainEnc {
                 let base_name = format!("Ref_{m:?}");
                 let (mut enc, mut ty_params) = DomainEncData::new(vcx, &base_name, [inner].into_iter());
                 deps.emit_output_ref::<Self>(*task_key, enc.output_ref(base_name));
-                ty_params.push(&vir::TypeData::Ref);
+                if m.is_mut() {
+                    ty_params.push(&vir::TypeData::Ref);
+                }
                 let specifics = enc.mk_struct_specifics(ty_params);
                 Ok((enc.finalize(), specifics))
             }

--- a/prusti-encoder/src/encoders/type/predicate.rs
+++ b/prusti-encoder/src/encoders/type/predicate.rs
@@ -41,11 +41,19 @@ pub struct PredicateEncDataVariant<'vir> {
 }
 
 #[derive(Clone, Copy, Debug)]
+pub struct PredicateEncDataRef<'vir> {
+    pub ref_field: vir::Field<'vir>,
+    pub perm: Option<vir::Expr<'vir>>,
+    pub snap_data: DomainDataStruct<'vir>,
+}
+
+#[derive(Clone, Copy, Debug)]
 pub enum PredicateEncData<'vir> {
     Primitive(DomainDataPrim<'vir>),
     // structs, tuples
     StructLike(PredicateEncDataStruct<'vir>),
     EnumLike(Option<PredicateEncDataEnum<'vir>>),
+    Ref(PredicateEncDataRef<'vir>),
     Param,
 }
 
@@ -73,6 +81,12 @@ impl<'vir> PredicateEncOutputRef<'vir> {
         match self.specifics {
             PredicateEncData::Primitive(prim) => prim,
             _ => panic!("expected primitive type"),
+        }
+    }
+    pub fn expect_ref(&self) -> PredicateEncDataRef<'vir> {
+        match self.specifics {
+            PredicateEncData::Ref(r) => r,
+            s => panic!("expected ref type ({s:?})"),
         }
     }
     pub fn get_structlike(&self) -> Option<&PredicateEncDataStruct<'vir>> {
@@ -174,25 +188,25 @@ impl TaskEncoder for PredicateEnc {
 
             TyKind::Tuple(tys) => {
                 let snap_data = snap.specifics.expect_structlike();
-                let specifics = enc.mk_struct_ref(enc.ref_to_pred.name(), snap_data);
+                let specifics = enc.mk_struct_ref(None, snap_data);
                 deps.emit_output_ref::<Self>(*task_key, enc.output_ref(PredicateEncData::StructLike(specifics)));
 
                 let fields: Vec<_> = tys.iter().map(|ty| deps.require_ref::<PredicateEnc>(ty).unwrap()).collect();
                 let fields = enc.mk_field_apps(specifics.ref_to_field_refs, fields);
-                let (fn_snap_body, _) = enc.mk_struct_ref_to_snap_body(None, fields, snap_data.field_snaps_to_snap);
+                let fn_snap_body = enc.mk_struct_ref_to_snap_body(None, fields, snap_data.field_snaps_to_snap);
                 Ok((enc.mk_struct(fn_snap_body), ()))
             }
             TyKind::Adt(adt, args) => {
                 match adt.adt_kind() {
                     ty::AdtKind::Struct => {
                         let snap_data = snap.specifics.expect_structlike();
-                        let specifics = enc.mk_struct_ref(enc.ref_to_pred.name(), snap_data);
+                        let specifics = enc.mk_struct_ref(None, snap_data);
                         deps.emit_output_ref::<Self>(*task_key, enc.output_ref(PredicateEncData::StructLike(specifics)));
 
                         let variant = adt.non_enum_variant();
                         let fields: Vec<_> = variant.fields.iter().map(|f| deps.require_ref::<PredicateEnc>(f.ty(enc.tcx(), args)).unwrap()).collect();
                         let fields = enc.mk_field_apps(specifics.ref_to_field_refs, fields);
-                        let (fn_snap_body, _) = enc.mk_struct_ref_to_snap_body(None, fields, snap_data.field_snaps_to_snap);
+                        let fn_snap_body = enc.mk_struct_ref_to_snap_body(None, fields, snap_data.field_snaps_to_snap);
                         Ok((enc.mk_struct(fn_snap_body), ()))
                     }
                     ty::AdtKind::Enum => {
@@ -217,6 +231,15 @@ impl TaskEncoder for PredicateEnc {
 
                 Ok((enc.mk_enum(None), ()))
             }
+            &TyKind::Ref(_, inner, m) => {
+                let snap_data = snap.specifics.expect_structlike();
+                let specifics = enc.mk_ref_ref(snap_data, m.is_mut());
+                deps.emit_output_ref::<Self>(*task_key, enc.output_ref(PredicateEncData::Ref(specifics)));
+
+                let inner = deps.require_ref::<PredicateEnc>(inner).unwrap();
+                Ok((enc.mk_ref(inner, specifics), ()))
+
+            }
             unsupported_type => todo!("type not supported: {unsupported_type:?}"),
         }
     }
@@ -231,8 +254,7 @@ struct PredicateEncValues<'vir, 'tcx> {
     method_assign: MethodIdent<'vir, BinaryArity<'vir>>,
 
     self_ex: vir::Expr<'vir>,
-    self_pred: vir::PredicateApp<'vir>,
-    self_pred_ex: vir::Expr<'vir>,
+    self_pred_read: vir::PredicateApp<'vir>,
     self_decl: &'vir [vir::LocalDecl<'vir>; 1],
 
     fields: Vec<vir::Field<'vir>>,
@@ -260,19 +282,18 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
             BinaryArity::new(vcx.alloc_array(&[&vir::TypeData::Ref, snap_inst])),
         );
         let self_ex = vcx.mk_local_ex("self");
-        let self_pred = ref_to_pred.apply(vcx, [self_ex]);
-        let self_pred_ex = vcx.mk_predicate_app_expr(self_pred);
+        let self_pred_read = ref_to_pred.apply(vcx, [self_ex], Some(vcx.mk_wildcard()));
         let self_decl = vcx.alloc_array(&[vcx.mk_local_decl("self", &vir::TypeData::Ref)]);
-        Self { vcx, snap_inst, ref_to_pred, ref_to_snap, unreachable_to_snap, method_assign, self_ex, self_pred, self_pred_ex, self_decl, fields: Vec::new(), predicates: Vec::new(), ref_to_field_refs: Vec::new() }
+        Self { vcx, snap_inst, ref_to_pred, ref_to_snap, unreachable_to_snap, method_assign, self_ex, self_pred_read, self_decl, fields: Vec::new(), predicates: Vec::new(), ref_to_field_refs: Vec::new() }
     }
     pub fn tcx(&self) -> ty::TyCtxt<'tcx> {
         self.vcx.tcx
     }
 
     // Ref creation
-    pub fn mk_struct_ref(&mut self, base_name: &str, snap_data: DomainDataStruct<'vir>) -> PredicateEncDataStruct<'vir> {
+    pub fn mk_struct_ref(&mut self, base_name: Option<&str>, snap_data: DomainDataStruct<'vir>) -> PredicateEncDataStruct<'vir> {
         let ref_to_field_refs: Vec<_> = (0..snap_data.field_access.len()).map(|idx| {
-            let name = vir::vir_format!(self.vcx, "{base_name}_field_{idx}");
+            let name = vir::vir_format!(self.vcx, "{}_field_{idx}", base_name.unwrap_or(self.ref_to_pred.name()));
             let field = self.vcx.mk_function(name, self.self_decl, &vir::TypeData::Ref, &[], &[], None);
             self.ref_to_field_refs.push(field);
             FunctionIdent::new(name, UnaryArity::new(&[&vir::TypeData::Ref]))
@@ -282,6 +303,17 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
             ref_to_field_refs: self.vcx.alloc_slice(&ref_to_field_refs),
         }
     }
+    pub fn mk_ref_ref(&mut self, snap_data: DomainDataStruct<'vir>, mutbl: bool) -> PredicateEncDataRef<'vir> {
+        let name = vir::vir_format!(self.vcx, "{}_ref", self.ref_to_pred.name());
+        let ref_field = self.vcx.mk_field(name, &vir::TypeData::Ref);
+        self.fields.push(ref_field);
+        let perm = if mutbl {
+            None
+        } else {
+            Some(self.vcx.mk_wildcard())
+        };
+        PredicateEncDataRef { ref_field, perm, snap_data }
+    }
     pub fn mk_enum_ref(&mut self, snap_data: Option<DomainDataEnum<'vir>>) -> Option<PredicateEncDataEnum<'vir>> {
         snap_data.map(|data| {
             let name = vir::vir_format!(self.vcx, "{}_discr", self.ref_to_pred.name());
@@ -290,7 +322,7 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
             let variants: Vec<_> = data.variants.iter().map(|variant| {
                 let base_name = vir::vir_format!(self.vcx, "{}_{}", self.ref_to_pred.name(), variant.name);
                 let predicate = vir::PredicateIdent::new(base_name, vir::UnaryArity::new(&[&vir::TypeData::Ref]));
-                let fields = self.mk_struct_ref(base_name, variant.fields);
+                let fields = self.mk_struct_ref(Some(base_name), variant.fields);
                 PredicateEncDataVariant {
                     predicate,
                     vid: variant.vid,
@@ -318,20 +350,20 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
         fields.into_iter().enumerate().map(|(idx, f)| {
             let self_field = field_fns[idx].apply(self.vcx, [self.self_ex]);
             FieldApp {
-                self_field_pred: self.vcx.mk_predicate_app_expr(f.ref_to_pred.apply(self.vcx, [self_field])),
+                self_field_pred: self.vcx.mk_predicate_app_expr(f.ref_to_pred.apply(self.vcx, [self_field], None)),
                 self_field_snap: f.ref_to_snap.apply(self.vcx, [self_field]),
             }
         }).collect()
     }
-    pub fn mk_struct_ref_to_snap_body(&mut self, predicate: Option<PredicateIdent<'vir, UnaryArity<'vir>>>, fields: Vec<FieldApp<'vir>>, field_snaps_to_snap: FunctionIdent<'vir, UnknownArity<'vir>>) -> (vir::Expr<'vir>, Option<vir::PredicateApp<'vir>>) {
+    pub fn mk_struct_ref_to_snap_body(&mut self, predicate: Option<PredicateIdent<'vir, UnaryArity<'vir>>>, fields: Vec<FieldApp<'vir>>, field_snaps_to_snap: FunctionIdent<'vir, UnknownArity<'vir>>) -> vir::Expr<'vir> {
         let fields_pred: Vec<_> = fields.iter().map(|f| f.self_field_pred).collect();
         let expr = self.vcx.mk_conj(&fields_pred);
         self.predicates.push(self.vcx.mk_predicate(predicate.unwrap_or(self.ref_to_pred).name(), self.self_decl, Some(expr)));
 
         let args: Vec<_> = fields.iter().map(|f| f.self_field_snap).collect();
         let expr = field_snaps_to_snap.apply(self.vcx, &args);
-        let self_pred = predicate.map(|p| p.apply(self.vcx, [self.self_ex]));
-        (self.vcx.mk_unfolding_expr(self_pred.unwrap_or(self.self_pred), expr), self_pred)
+        let self_pred = predicate.map(|p| p.apply(self.vcx, [self.self_ex], Some(self.vcx.mk_wildcard())));
+        self.vcx.mk_unfolding_expr(self_pred.unwrap_or(self.self_pred_read), expr)
     }
 
     // Final results
@@ -340,11 +372,11 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
         let field = self.vcx.mk_field(name, self.snap_inst);
         self.fields.push(field);
 
-        let self_field_acc = self.vcx.mk_acc_field_expr(self.self_ex, field);
+        let self_field_acc = self.vcx.mk_acc_field_expr(self.self_ex, field, None);
         self.predicates.push(self.vcx.mk_predicate(self.ref_to_pred.name(), self.self_decl, Some(self_field_acc)));
 
         let self_field = self.vcx.mk_field_expr(self.self_ex, field);
-        let fn_snap_body = self.vcx.mk_unfolding_expr(self.self_pred, self_field);
+        let fn_snap_body = self.vcx.mk_unfolding_expr(self.self_pred_read, self_field);
         self.finalize(Some(fn_snap_body))
     }
     pub fn mk_param(mut self) -> PredicateEncOutput<'vir> {
@@ -354,19 +386,32 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
     pub fn mk_struct(self, fn_snap_body: vir::Expr<'vir>) -> PredicateEncOutput<'vir> {
         self.finalize(Some(fn_snap_body))
     }
+    pub fn mk_ref(mut self, inner: PredicateEncOutputRef<'vir>, data: PredicateEncDataRef<'vir>) -> PredicateEncOutput<'vir> {
+        let self_field = self.vcx.mk_acc_field_expr(self.self_ex, data.ref_field, None);
+
+        let self_ref = self.vcx.mk_field_expr(self.self_ex, data.ref_field);
+        let inner_pred = self.vcx.mk_predicate_app_expr(inner.ref_to_pred.apply(self.vcx, [self_ref], data.perm));
+        let predicate = self.vcx.mk_conj(&[self_field, inner_pred]);
+        self.predicates.push(self.vcx.mk_predicate(self.ref_to_pred.name(), self.self_decl, Some(predicate)));
+
+        let inner_snap = inner.ref_to_snap.apply(self.vcx, [self_ref]);
+        let snap = data.snap_data.field_snaps_to_snap.apply(self.vcx, &[inner_snap, self_ref]);
+        let fn_snap_body = self.vcx.mk_unfolding_expr(self.self_pred_read, snap);
+        self.finalize(Some(fn_snap_body))
+    }
     pub fn mk_enum(mut self, data: Option<(PredicateEncDataEnum<'vir>, Vec<(abi::VariantIdx, Vec<PredicateEncOutputRef<'vir>>)>)>) -> PredicateEncOutput<'vir> {
         let mut predicate_body = self.vcx.mk_bool::<false>();
         let fn_snap_body = data.map(|(data, fields)| {
-            let discr_acc = self.vcx.mk_acc_field_expr(self.self_ex, data.discr);
+            let discr_acc = self.vcx.mk_acc_field_expr(self.self_ex, data.discr, None);
             let discr = data.discr_prim.snap_to_prim.apply(self.vcx, [self.vcx.mk_field_expr(self.self_ex, data.discr)]);
 
             let mut variants: Vec<_> = data.variants.iter().zip(fields).map(|(variant, (vid, fields))| {
                 let field_fns = variant.fields.ref_to_field_refs;
                 assert_eq!(variant.vid, vid);
                 let fields = self.mk_field_apps(field_fns, fields);
-                let (body, pred) = self.mk_struct_ref_to_snap_body(Some(variant.predicate), fields, variant.fields.snap_data.field_snaps_to_snap);
+                let body = self.mk_struct_ref_to_snap_body(Some(variant.predicate), fields, variant.fields.snap_data.field_snaps_to_snap);
                 let cond = self.vcx.mk_eq_expr(discr, variant.discr);
-                let pred = self.vcx.mk_predicate_app_expr(pred.unwrap());
+                let pred = self.vcx.mk_predicate_app_expr(variant.predicate.apply(self.vcx, [self.self_ex], None));
                 (cond, pred, body)
             }).collect();
             predicate_body = variants.iter().fold(predicate_body, |acc, (cond, pred, _)| self.vcx.mk_ternary_expr(cond, pred, acc));
@@ -386,7 +431,7 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
 
             let (_, _, body) = variants.pop().unwrap();
             let body = variants.into_iter().fold(body, |acc, (cond, _, body)| self.vcx.mk_ternary_expr(cond, body, acc));
-            self.vcx.mk_unfolding_expr(self.self_pred, body)
+            self.vcx.mk_unfolding_expr(self.self_pred_read, body)
         });
         self.predicates.push(self.vcx.mk_predicate(self.ref_to_pred.name(), self.self_decl, Some(predicate_body)));
         self.finalize(fn_snap_body)
@@ -397,7 +442,7 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
             self.ref_to_snap.name(),
             self.self_decl,
             self.snap_inst,
-            self.vcx.alloc_slice(&[self.self_pred_ex]),
+            self.vcx.alloc_slice(&[self.vcx.mk_predicate_app_expr(self.self_pred_read)]),
             &[],
             fn_snap_body
         );
@@ -413,7 +458,7 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
             self.vcx.mk_local_decl("self_new", self.snap_inst),
         ]);
         let posts = self.vcx.alloc_slice(&[
-            self.self_pred_ex,
+            self.vcx.mk_predicate_app_expr(self.ref_to_pred.apply(self.vcx, [self.self_ex], None)),
             self.vcx.mk_eq_expr(
                 self.ref_to_snap.apply(self.vcx, [self.self_ex]),
                 self.vcx.mk_local_ex("self_new")

--- a/prusti-encoder/src/encoders/type/predicate.rs
+++ b/prusti-encoder/src/encoders/type/predicate.rs
@@ -390,8 +390,9 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
         let self_field = self.vcx.mk_acc_field_expr(self.self_ex, data.ref_field, None);
 
         let self_ref = self.vcx.mk_field_expr(self.self_ex, data.ref_field);
+        let non_null = self.vcx.mk_bin_op_expr(vir::BinOpKind::CmpNe, self_ref, self.vcx.mk_null());
         let inner_pred = self.vcx.mk_predicate_app_expr(inner.ref_to_pred.apply(self.vcx, [self_ref], data.perm));
-        let predicate = self.vcx.mk_conj(&[self_field, inner_pred]);
+        let predicate = self.vcx.mk_conj(&[self_field, non_null, inner_pred]);
         self.predicates.push(self.vcx.mk_predicate(self.ref_to_pred.name(), self.self_decl, Some(predicate)));
 
         let inner_snap = inner.ref_to_snap.apply(self.vcx, [self_ref]);

--- a/prusti-encoder/src/encoders/type/predicate.rs
+++ b/prusti-encoder/src/encoders/type/predicate.rs
@@ -396,7 +396,12 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
         self.predicates.push(self.vcx.mk_predicate(self.ref_to_pred.name(), self.self_decl, Some(predicate)));
 
         let inner_snap = inner.ref_to_snap.apply(self.vcx, [self_ref]);
-        let snap = data.snap_data.field_snaps_to_snap.apply(self.vcx, &[inner_snap, self_ref]);
+        let snap = if data.perm.is_none() {
+            // `Ref` is only part of snapshots for mutable references.
+            data.snap_data.field_snaps_to_snap.apply(self.vcx, &[inner_snap, self_ref])
+        } else {
+            data.snap_data.field_snaps_to_snap.apply(self.vcx, &[inner_snap])
+        };
         let fn_snap_body = self.vcx.mk_unfolding_expr(self.self_pred_read, snap);
         self.finalize(Some(fn_snap_body))
     }

--- a/prusti-encoder/src/encoders/type/predicate.rs
+++ b/prusti-encoder/src/encoders/type/predicate.rs
@@ -292,9 +292,18 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
 
     // Ref creation
     pub fn mk_struct_ref(&mut self, base_name: Option<&str>, snap_data: DomainDataStruct<'vir>) -> PredicateEncDataStruct<'vir> {
+        let mut post = None;
         let ref_to_field_refs: Vec<_> = (0..snap_data.field_access.len()).map(|idx| {
+            let posts = post.unwrap_or_else(|| {
+                // result is null iff input is null (will be null if reference
+                // created in pure code).
+                let in_null = self.vcx.mk_eq_expr(self.self_ex, self.vcx.mk_null());
+                let out_null = self.vcx.mk_eq_expr(self.vcx.mk_result(), self.vcx.mk_null());
+                self.vcx.alloc_slice(&[self.vcx.mk_eq_expr(in_null, out_null)])
+            });
+            post = Some(posts);
             let name = vir::vir_format!(self.vcx, "{}_field_{idx}", base_name.unwrap_or(self.ref_to_pred.name()));
-            let field = self.vcx.mk_function(name, self.self_decl, &vir::TypeData::Ref, &[], &[], None);
+            let field = self.vcx.mk_function(name, self.self_decl, &vir::TypeData::Ref, &[], posts, None);
             self.ref_to_field_refs.push(field);
             FunctionIdent::new(name, UnaryArity::new(&[&vir::TypeData::Ref]))
         }).collect();

--- a/prusti-encoder/src/encoders/type/snapshot.rs
+++ b/prusti-encoder/src/encoders/type/snapshot.rs
@@ -101,6 +101,11 @@ impl TaskEncoder for SnapshotEnc {
                     let ty = vcx.tcx.mk_ty_from_kind(TyKind::Slice(ty));
                     (ty, vec![orig])
                 }
+                TyKind::Ref(r, orig, m) => {
+                    let ty = Self::to_placeholder(vcx.tcx, None);
+                    let ty = vcx.tcx.mk_ty_from_kind(TyKind::Ref(r, ty, m));
+                    (ty, vec![orig])
+                }
                 _ => (*task_key, Vec::new()),
             };
             let out = deps.require_ref::<DomainEnc>(ty).unwrap();

--- a/prusti-interface/src/environment/body.rs
+++ b/prusti-interface/src/environment/body.rs
@@ -173,8 +173,10 @@ impl<'tcx> EnvBody<'tcx> {
                 .entry((def_id, substs, caller_def_id))
         {
             let param_env = self.tcx.param_env(caller_def_id.unwrap_or(def_id));
+            // TODO: figure out some other way to substitute without losing the region information
+            let body = self.tcx.erase_regions(body.0);
             let monomorphised = self.tcx
-                    .subst_and_normalize_erasing_regions(substs, param_env, ty::EarlyBinder::bind(body.0));
+                    .subst_and_normalize_erasing_regions(substs, param_env, ty::EarlyBinder::bind(body));
             v.insert(MirBody(monomorphised)).clone()
         } else {
             unreachable!()

--- a/vir/src/callable_idents.rs
+++ b/vir/src/callable_idents.rs
@@ -160,12 +160,14 @@ impl<'vir, const N: usize> PredicateIdent<'vir, KnownArity<'vir, N>> {
     pub fn apply<'tcx, Curr: 'vir, Next: 'vir>(
         &self,
         vcx: &'vir VirCtxt<'tcx>,
-        args: [ExprGen<'vir, Curr, Next>; N]
+        args: [ExprGen<'vir, Curr, Next>; N],
+        perm: Option<ExprGen<'vir, Curr, Next>>,
     ) -> PredicateAppGen<'vir, Curr, Next>{
         self.1.check_types(self.name(), &args);
         vcx.alloc(PredicateAppGenData {
             target: self.name(),
             args: vcx.alloc_slice(&args),
+            perm,
         })
     }
 }
@@ -220,12 +222,14 @@ impl<'vir> PredicateIdent<'vir, UnknownArity<'vir>> {
     pub fn apply<'tcx, Curr: 'vir, Next: 'vir>(
         &self,
         vcx: &'vir VirCtxt<'tcx>,
-        args: &[ExprGen<'vir, Curr, Next>]
+        args: &[ExprGen<'vir, Curr, Next>],
+        perm: Option<ExprGen<'vir, Curr, Next>>,
     ) -> PredicateAppGen<'vir, Curr, Next>{
         self.1.check_types(self.name(), args);
         vcx.alloc(PredicateAppGenData {
             target: self.name(),
             args: vcx.alloc_slice(args),
+            perm,
         })
     }
 }

--- a/vir/src/context.rs
+++ b/vir/src/context.rs
@@ -81,16 +81,6 @@ impl<'tcx> VirCtxt<'tcx> {
             }))),
         })
     }
-    pub fn mk_pred_app<'vir>(&'vir self, target: &'vir str, src_args: &[Expr<'vir>]) -> Expr<'vir> {
-        self.alloc(ExprGenData {
-            kind: self.alloc(ExprKindGenData::PredicateApp(self.arena.alloc(
-                PredicateAppData {
-                    target,
-                    args: self.alloc_slice(src_args),
-                },
-            ))),
-        })
-    }
 
     pub fn mk_lazy_expr<'vir, Curr, Next>(
         &'vir self,
@@ -225,8 +215,9 @@ impl<'tcx> VirCtxt<'tcx> {
         &'vir self,
         recv: ExprGen<'vir, Curr, Next>,
         field: Field<'vir>,
+        perm: Option<ExprGen<'vir, Curr, Next>>,
     ) -> ExprGen<'vir, Curr, Next> {
-        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::AccField(self.alloc(AccFieldGenData { recv, field })))})
+        self.alloc(ExprGenData {kind : self.alloc(ExprKindGenData::AccField(self.alloc(AccFieldGenData { recv, field, perm })))})
     }
 
     pub fn mk_const_expr<'vir, Curr, Next>(
@@ -255,6 +246,9 @@ impl<'tcx> VirCtxt<'tcx> {
     }
     pub const fn mk_uint<'vir, const VALUE: u128>(&'vir self) -> Expr<'vir> {
         &ExprGenData {kind : &ExprKindGenData::Const(&ConstData::Int(VALUE))}
+    }
+    pub const fn mk_wildcard<'vir>(&'vir self) -> Expr<'vir> {
+        &ExprGenData { kind : &ExprKindGenData::Const(&ConstData::Wildcard) }
     }
 
     pub fn mk_field<'vir>(

--- a/vir/src/context.rs
+++ b/vir/src/context.rs
@@ -253,6 +253,9 @@ impl<'tcx> VirCtxt<'tcx> {
     pub const fn mk_null<'vir, Curr, Next>(&'vir self) -> ExprGen<'vir, Curr, Next> {
         &ExprGenData { kind : &ExprKindGenData::Const(&ConstData::Null) }
     }
+    pub const fn mk_result<'vir, Curr, Next>(&'vir self) -> ExprGen<'vir, Curr, Next> {
+        &ExprGenData { kind : &ExprKindGenData::Const(&ConstData::Result) }
+    }
 
     pub fn mk_field<'vir>(
         &'vir self,

--- a/vir/src/context.rs
+++ b/vir/src/context.rs
@@ -254,7 +254,7 @@ impl<'tcx> VirCtxt<'tcx> {
         &ExprGenData { kind : &ExprKindGenData::Const(&ConstData::Null) }
     }
     pub const fn mk_result<'vir, Curr, Next>(&'vir self) -> ExprGen<'vir, Curr, Next> {
-        &ExprGenData { kind : &ExprKindGenData::Const(&ConstData::Result) }
+        &ExprGenData { kind : &ExprKindGenData::Result }
     }
 
     pub fn mk_field<'vir>(

--- a/vir/src/context.rs
+++ b/vir/src/context.rs
@@ -247,8 +247,11 @@ impl<'tcx> VirCtxt<'tcx> {
     pub const fn mk_uint<'vir, const VALUE: u128>(&'vir self) -> Expr<'vir> {
         &ExprGenData {kind : &ExprKindGenData::Const(&ConstData::Int(VALUE))}
     }
-    pub const fn mk_wildcard<'vir>(&'vir self) -> Expr<'vir> {
+    pub const fn mk_wildcard<'vir, Curr, Next>(&'vir self) -> ExprGen<'vir, Curr, Next> {
         &ExprGenData { kind : &ExprKindGenData::Const(&ConstData::Wildcard) }
+    }
+    pub const fn mk_null<'vir, Curr, Next>(&'vir self) -> ExprGen<'vir, Curr, Next> {
+        &ExprGenData { kind : &ExprKindGenData::Const(&ConstData::Null) }
     }
 
     pub fn mk_field<'vir>(
@@ -546,16 +549,16 @@ impl<'tcx> VirCtxt<'tcx> {
     }
 
     pub fn mk_conj<'vir>(&'vir self, elems: &[Expr<'vir>]) -> Expr<'vir> {
-        elems.split_first().map(|(first, rest)| {
-            rest.iter().rfold(*first, |acc, e| {
-                self.mk_bin_op_expr(BinOpKind::And, acc, *e)
+        elems.split_last().map(|(last, rest)| {
+            rest.iter().rfold(*last, |acc, e| {
+                self.mk_bin_op_expr(BinOpKind::And, *e, acc)
             })
         }).unwrap_or_else(|| self.mk_bool::<true>())
     }
     pub fn mk_disj<'vir>(&'vir self, elems: &[Expr<'vir>]) -> Expr<'vir> {
-        elems.split_first().map(|(first, rest)| {
-            rest.iter().rfold(*first, |acc, e| {
-                self.mk_bin_op_expr(BinOpKind::Or, acc, *e)
+        elems.split_last().map(|(last, rest)| {
+            rest.iter().rfold(*last, |acc, e| {
+                self.mk_bin_op_expr(BinOpKind::Or, *e, acc)
             })
         }).unwrap_or_else(|| self.mk_bool::<false>())
     }

--- a/vir/src/data.rs
+++ b/vir/src/data.rs
@@ -83,6 +83,7 @@ impl From<&mir::BinOp> for BinOpKind {
 pub enum ConstData {
     Bool(bool),
     Int(u128), // TODO: what about negative numbers? larger numbers?
+    Wildcard,
 }
 
 pub enum TypeData<'vir> {
@@ -95,6 +96,7 @@ pub enum TypeData<'vir> {
     Domain(&'vir str, &'vir [Type<'vir>]), // TODO: identifiers
     // TODO: separate `TyParam` variant? `Domain` used for now
     Ref, // TODO: typed references ?
+    Perm,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/vir/src/data.rs
+++ b/vir/src/data.rs
@@ -84,6 +84,7 @@ pub enum ConstData {
     Bool(bool),
     Int(u128), // TODO: what about negative numbers? larger numbers?
     Wildcard,
+    Null,
 }
 
 pub enum TypeData<'vir> {

--- a/vir/src/data.rs
+++ b/vir/src/data.rs
@@ -85,7 +85,6 @@ pub enum ConstData {
     Int(u128), // TODO: what about negative numbers? larger numbers?
     Wildcard,
     Null,
-    Result,
 }
 
 pub enum TypeData<'vir> {

--- a/vir/src/data.rs
+++ b/vir/src/data.rs
@@ -85,6 +85,7 @@ pub enum ConstData {
     Int(u128), // TODO: what about negative numbers? larger numbers?
     Wildcard,
     Null,
+    Result,
 }
 
 pub enum TypeData<'vir> {

--- a/vir/src/debug.rs
+++ b/vir/src/debug.rs
@@ -40,7 +40,11 @@ fn indent(s: String) -> String {
 
 impl<'vir, Curr, Next> Debug for AccFieldGenData<'vir, Curr, Next> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "acc({:?}.{})", self.recv, self.field.name)
+        write!(f, "acc({:?}.{}", self.recv, self.field.name)?;
+        if let Some(perm) = self.perm {
+            write!(f, ", {perm:?}")?;
+        }
+        write!(f, ")")
     }
 }
 
@@ -79,9 +83,9 @@ impl Debug for CfgBlockLabelData {
 impl Debug for ConstData {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::Bool(true) => write!(f, "true"),
-            Self::Bool(false) => write!(f, "false"),
+            Self::Bool(b) => write!(f, "{b}"),
             Self::Int(n) => write!(f, "{n}"),
+            Self::Wildcard => write!(f, "wildcard"),
         }
     }
 }
@@ -272,9 +276,16 @@ impl<'vir, Curr, Next> Debug for PredicateGenData<'vir, Curr, Next> {
 
 impl<'vir, Curr, Next> Debug for PredicateAppGenData<'vir, Curr, Next> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        if self.perm.is_some() {
+            write!(f, "acc(")?;
+        }
         write!(f, "{}(", self.target)?;
         fmt_comma_sep(f, &self.args)?;
-        write!(f, ")")
+        write!(f, ")")?;
+        if let Some(perm) = self.perm {
+            write!(f, ", {perm:?})")?;
+        }
+        Ok(())
     }
 }
 
@@ -365,6 +376,7 @@ impl<'vir> Debug for TypeData<'vir> {
                 Ok(())
             }
             Self::Ref => write!(f, "Ref"),
+            Self::Perm => write!(f, "Perm"),
         }
     }
 }

--- a/vir/src/debug.rs
+++ b/vir/src/debug.rs
@@ -86,6 +86,7 @@ impl Debug for ConstData {
             Self::Bool(b) => write!(f, "{b}"),
             Self::Int(n) => write!(f, "{n}"),
             Self::Wildcard => write!(f, "wildcard"),
+            Self::Null => write!(f, "null"),
         }
     }
 }

--- a/vir/src/debug.rs
+++ b/vir/src/debug.rs
@@ -87,6 +87,7 @@ impl Debug for ConstData {
             Self::Int(n) => write!(f, "{n}"),
             Self::Wildcard => write!(f, "wildcard"),
             Self::Null => write!(f, "null"),
+            Self::Result => write!(f, "result"),
         }
     }
 }

--- a/vir/src/debug.rs
+++ b/vir/src/debug.rs
@@ -87,7 +87,6 @@ impl Debug for ConstData {
             Self::Int(n) => write!(f, "{n}"),
             Self::Wildcard => write!(f, "wildcard"),
             Self::Null => write!(f, "null"),
-            Self::Result => write!(f, "result"),
         }
     }
 }
@@ -140,6 +139,7 @@ impl<'vir, Curr, Next> Debug for ExprKindGenData<'vir, Curr, Next> {
             Self::AccField(e) => e.fmt(f),
             Self::BinOp(e) => e.fmt(f),
             Self::Const(e) => e.fmt(f),
+            Self::Result => write!(f, "result"),
             Self::Field(e, field) => write!(f, "{:?}.{}", e, field.name),
             Self::Forall(e) => e.fmt(f),
             Self::FuncApp(e) => e.fmt(f),

--- a/vir/src/gendata.rs
+++ b/vir/src/gendata.rs
@@ -95,6 +95,7 @@ pub enum ExprKindGenData<'vir, Curr: 'vir, Next: 'vir> {
     Old(ExprGen<'vir, Curr, Next>),
     //LabelledOld(Expr<'vir>, &'vir str),
     Const(Const<'vir>),
+    Result,
     // magic wand
     AccField(AccFieldGen<'vir, Curr, Next>),
     Unfolding(UnfoldingGen<'vir, Curr, Next>),

--- a/vir/src/gendata.rs
+++ b/vir/src/gendata.rs
@@ -44,6 +44,7 @@ pub struct FuncAppGenData<'vir, Curr, Next> {
 pub struct PredicateAppGenData<'vir, Curr, Next> {
     #[reify_copy] pub(crate) target: &'vir str, // TODO: identifiers
     pub(crate) args: &'vir [ExprGen<'vir, Curr, Next>],
+    pub(crate) perm: Option<ExprGen<'vir, Curr, Next>>,
 }
 
 #[derive(Reify)]
@@ -56,7 +57,7 @@ pub struct UnfoldingGenData<'vir, Curr, Next> {
 pub struct AccFieldGenData<'vir, Curr, Next> {
     pub(crate) recv: ExprGen<'vir, Curr, Next>,
     #[reify_copy] pub(crate) field: Field<'vir>, // TODO: identifiers
-    // TODO: permission amount
+    pub(crate) perm: Option<ExprGen<'vir, Curr, Next>>,
 }
 
 #[derive(Reify)]

--- a/vir/src/reify.rs
+++ b/vir/src/reify.rs
@@ -43,6 +43,7 @@ impl<'vir, Curr: Copy, NextA, NextB> Reify<'vir, Curr>
 
             ExprKindGenData::Local(v) => vcx.alloc(ExprKindGenData::Local(v)),
             ExprKindGenData::Const(v) => vcx.alloc(ExprKindGenData::Const(v)),
+            ExprKindGenData::Result => &ExprKindGenData::Result,
             ExprKindGenData::Todo(v) => vcx.alloc(ExprKindGenData::Todo(v)),
 
             ExprKindGenData::Lazy(_, f) => f(vcx, lctx),


### PR DESCRIPTION
Adds the domain and predicate to make references work fully in pure code and partially in impure. The only references operation not supported in impure is the `Rvalue::Ref`.