### PR TITLE
Store return type in function identifiers

### DIFF
--- a/prusti-encoder/src/encoders/generic.rs
+++ b/prusti-encoder/src/encoders/generic.rs
@@ -56,19 +56,20 @@ impl TaskEncoder for GenericEnc {
             predicate_param_name: "p_Param",
             domain_type_name: "s_Type",
         });
-        let s_Type_Bool = FunctionIdent::new("s_Type_Bool", NullaryArity::new(&[]));
-        let s_Type_Int_isize = FunctionIdent::new("s_Type_Int_isize", NullaryArity::new(&[]));
-        let s_Type_Int_i8 = FunctionIdent::new("s_Type_Int_i8", NullaryArity::new(&[]));
-        let s_Type_Int_i16 = FunctionIdent::new("s_Type_Int_i16", NullaryArity::new(&[]));
-        let s_Type_Int_i32 = FunctionIdent::new("s_Type_Int_i32", NullaryArity::new(&[]));
-        let s_Type_Int_i64 = FunctionIdent::new("s_Type_Int_i64", NullaryArity::new(&[]));
-        let s_Type_Int_i128 = FunctionIdent::new("s_Type_Int_i128", NullaryArity::new(&[]));
-        let s_Type_Uint_usize = FunctionIdent::new("s_Type_Uint_usize", NullaryArity::new(&[]));
-        let s_Type_Uint_u8 = FunctionIdent::new("s_Type_Uint_u8", NullaryArity::new(&[]));
-        let s_Type_Uint_u16 = FunctionIdent::new("s_Type_Uint_u16", NullaryArity::new(&[]));
-        let s_Type_Uint_u32 = FunctionIdent::new("s_Type_Uint_u32", NullaryArity::new(&[]));
-        let s_Type_Uint_u64 = FunctionIdent::new("s_Type_Uint_u64", NullaryArity::new(&[]));
-        let s_Type_Uint_u128 = FunctionIdent::new("s_Type_Uint_u128", NullaryArity::new(&[]));
+        let domain_ty = &vir::TypeData::Domain("s_Type", &[]);
+        let s_Type_Bool = FunctionIdent::new("s_Type_Bool", NullaryArity::new(&[]), domain_ty);
+        let s_Type_Int_isize = FunctionIdent::new("s_Type_Int_isize", NullaryArity::new(&[]), domain_ty);
+        let s_Type_Int_i8 = FunctionIdent::new("s_Type_Int_i8", NullaryArity::new(&[]), domain_ty);
+        let s_Type_Int_i16 = FunctionIdent::new("s_Type_Int_i16", NullaryArity::new(&[]), domain_ty);
+        let s_Type_Int_i32 = FunctionIdent::new("s_Type_Int_i32", NullaryArity::new(&[]), domain_ty);
+        let s_Type_Int_i64 = FunctionIdent::new("s_Type_Int_i64", NullaryArity::new(&[]), domain_ty);
+        let s_Type_Int_i128 = FunctionIdent::new("s_Type_Int_i128", NullaryArity::new(&[]), domain_ty);
+        let s_Type_Uint_usize = FunctionIdent::new("s_Type_Uint_usize", NullaryArity::new(&[]), domain_ty);
+        let s_Type_Uint_u8 = FunctionIdent::new("s_Type_Uint_u8", NullaryArity::new(&[]), domain_ty);
+        let s_Type_Uint_u16 = FunctionIdent::new("s_Type_Uint_u16", NullaryArity::new(&[]), domain_ty);
+        let s_Type_Uint_u32 = FunctionIdent::new("s_Type_Uint_u32", NullaryArity::new(&[]), domain_ty);
+        let s_Type_Uint_u64 = FunctionIdent::new("s_Type_Uint_u64", NullaryArity::new(&[]), domain_ty);
+        let s_Type_Uint_u128 = FunctionIdent::new("s_Type_Uint_u128", NullaryArity::new(&[]), domain_ty);
         vir::with_vcx(|vcx| Ok((GenericEncOutput {
             snapshot_param: vir::vir_domain! { vcx; domain s_Param {} },
             predicate_param: vir::vir_predicate! { vcx; predicate p_Param(self_p: Ref/*, self_s: s_Param*/) },

--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -101,7 +101,7 @@ impl MirBuiltinEnc {
 
         let name = vir::vir_format!(vcx, "mir_unop_{op:?}_{}", int_name(ty));
         let arity = UnknownArity::new(vcx.alloc_slice(&[e_ty.snapshot]));
-        let function = FunctionIdent::new(name, arity);
+        let function = FunctionIdent::new(name, arity, e_ty.snapshot);
         deps.emit_output_ref::<Self>(key, MirBuiltinEncOutputRef {
             function,
         });
@@ -154,7 +154,7 @@ impl MirBuiltinEnc {
 
         let name = vir::vir_format!(vcx, "mir_binop_{op:?}_{}_{}", int_name(l_ty), int_name(r_ty));
         let arity = UnknownArity::new(vcx.alloc_slice(&[e_l_ty.snapshot, e_r_ty.snapshot]));
-        let function = FunctionIdent::new(name, arity);
+        let function = FunctionIdent::new(name, arity, e_res_ty.snapshot);
         deps.emit_output_ref::<Self>(key, MirBuiltinEncOutputRef {
             function,
         });
@@ -247,12 +247,12 @@ impl MirBuiltinEnc {
 
         let name = vir::vir_format!(vcx, "mir_checkedbinop_{op:?}_{}_{}", int_name(l_ty), int_name(r_ty));
         let arity = UnknownArity::new(vcx.alloc_slice(&[e_l_ty.snapshot, e_r_ty.snapshot]));
-        let function = FunctionIdent::new(name, arity);
+        let e_res_ty = deps.require_local::<SnapshotEnc>(res_ty).unwrap();
+        let function = FunctionIdent::new(name, arity, e_res_ty.snapshot);
         deps.emit_output_ref::<Self>(key, MirBuiltinEncOutputRef {
             function,
         });
 
-        let e_res_ty = deps.require_local::<SnapshotEnc>(res_ty).unwrap();
         // The result of a checked add will always be `(T, bool)`, get the `T`
         // type
         let rvalue_pure_ty = res_ty.tuple_fields()[0];

--- a/prusti-encoder/src/encoders/mir_pure_function.rs
+++ b/prusti-encoder/src/encoders/mir_pure_function.rs
@@ -79,8 +79,9 @@ impl TaskEncoder for MirFunctionEnc {
                 .map(|def_idx| local_defs.locals[def_idx].ty.snapshot)
                 .collect();
             let args = UnknownArity::new(vcx.alloc_slice(&args));
-            let function_ref = FunctionIdent::new(function_name, args);
-            deps.emit_output_ref::<Self>(*task_key, MirFunctionEncOutputRef { function_ref, return_type: local_defs.locals[mir::RETURN_PLACE].ty });
+            let return_type = local_defs.locals[mir::RETURN_PLACE].ty;
+            let function_ref = FunctionIdent::new(function_name, args, return_type.snapshot);
+            deps.emit_output_ref::<Self>(*task_key, MirFunctionEncOutputRef { function_ref, return_type });
 
             let spec = deps.require_local::<MirSpecEnc>(
                 (def_id, substs, Some(caller_def_id), true)

--- a/prusti-encoder/src/encoders/type/domain.rs
+++ b/prusti-encoder/src/encoders/type/domain.rs
@@ -7,7 +7,7 @@ use task_encoder::{
     TaskEncoder,
     TaskEncoderDependencies,
 };
-use vir::{BinaryArity, UnaryArity, UnknownArity, FunctionIdent, CallableIdent, Arity, ToKnownArity};
+use vir::{BinaryArity, UnaryArity, UnknownArity, FunctionIdent, CallableIdent, Arity, ToKnownArity, Function};
 
 /// You probably never want to use this, use `SnapshotEnc` instead.
 /// Note: there should never be a dependency on `PredicateEnc` inside this
@@ -315,7 +315,7 @@ impl<'vir, 'tcx> DomainEncData<'vir, 'tcx> {
                 DomainDataVariant { name: *name, vid: *vid, discr: discr_vals[idx], fields }
             }).collect::<Vec<_>>());
             let discr_bounds = self.mk_discr_bounds_axioms(data.discr_prim, snap_to_discr_snap, discr_vals, data.has_explicit);
-            DomainDataEnum { 
+            DomainDataEnum {
                 discr_ty: data.discr_ty,
                 discr_prim: data.discr_prim,
                 discr_bounds,
@@ -324,6 +324,12 @@ impl<'vir, 'tcx> DomainEncData<'vir, 'tcx> {
             }
         });
         DomainEncSpecifics::EnumLike(specifics)
+    }
+
+    fn push_function(&mut self, func: vir::DomainFunction<'vir>) -> FunctionIdent<'vir, UnknownArity<'vir>> {
+        let ident = func.ident();
+        self.functions.push(func);
+        ident
     }
 
     // Helper functions
@@ -338,8 +344,7 @@ impl<'vir, 'tcx> DomainEncData<'vir, 'tcx> {
         // Constructor
         let field_snaps_to_snap = {
             let name = vir::vir_format!(self.vcx, "{base}_cons");
-            self.functions.push(self.vcx.mk_domain_function(false, name, field_tys, self.self_ty));
-            FunctionIdent::new(name, vir::UnknownArity::new(field_tys))
+            self.push_function(self.vcx.mk_domain_function(false, name, field_tys, self.self_ty))
         };
 
         // Variables and definitions useful for axioms
@@ -348,14 +353,8 @@ impl<'vir, 'tcx> DomainEncData<'vir, 'tcx> {
             self.vcx.mk_local_decl(fnames[idx], ty)
         ).collect();
         let cons_qvars = self.vcx.alloc_slice(&cons_qvars);
-        let cons_args: Vec<_> = (0..field_tys.len()).map(|idx| self.vcx.mk_local_ex(fnames[idx])).collect();
-        let cons_call_with_qvars = if field_tys.is_empty() {
-            // TODO: workaround for `https://github.com/viperproject/silver/issues/236`
-            // remove once fixed.
-            field_snaps_to_snap.apply_ty(self.vcx, &cons_args, self.self_ty)
-        } else {
-            field_snaps_to_snap.apply(self.vcx, &cons_args)
-        };
+        let cons_args: Vec<_> = fnames.into_iter().map(|fname| self.vcx.mk_local_ex(fname)).collect();
+        let cons_call_with_qvars = field_snaps_to_snap.apply(self.vcx, &cons_args);
 
         // Discriminant axioms
         if let Some((get_discr, val, _)) = discr {
@@ -383,6 +382,7 @@ impl<'vir, 'tcx> DomainEncData<'vir, 'tcx> {
                 let read = FunctionIdent::new(
                     name,
                     UnaryArity::new(args),
+                    field_ty
                 );
                 self.functions.push(self.vcx.mk_domain_function(false, name, args, field_ty));
 
@@ -402,6 +402,7 @@ impl<'vir, 'tcx> DomainEncData<'vir, 'tcx> {
                 let write = FunctionIdent::new(
                     name,
                     BinaryArity::new(args),
+                    self.self_ty
                 );
                 self.functions.push(self.vcx.mk_domain_function(false, name, args, self.self_ty));
                 FieldFunctions { read, write }
@@ -466,6 +467,7 @@ impl<'vir, 'tcx> DomainEncData<'vir, 'tcx> {
         let snap_to_discr_snap = FunctionIdent::new(
             name,
             UnaryArity::new(types),
+            discr_ty
         );
         self.functions.push(self.vcx.mk_domain_function(false, name, types, discr_ty));
         snap_to_discr_snap

--- a/prusti-encoder/src/encoders/type/domain.rs
+++ b/prusti-encoder/src/encoders/type/domain.rs
@@ -356,7 +356,7 @@ impl<'vir, 'tcx> DomainEncData<'vir, 'tcx> {
             self.vcx.mk_local_decl_local(fnames[idx])
         ).collect();
         let cons_qvars = self.vcx.alloc_slice(&cons_qvars);
-        let cons_args: Vec<_> = fnames.into_iter().map(|fname| self.vcx.mk_local_ex(fname)).collect();
+        let cons_args: Vec<_> = fnames.into_iter().map(|fname| self.vcx.mk_local_ex_local(fname)).collect();
         let cons_call_with_qvars = field_snaps_to_snap.apply(self.vcx, &cons_args);
 
         // Discriminant axioms

--- a/prusti-encoder/src/encoders/type/predicate.rs
+++ b/prusti-encoder/src/encoders/type/predicate.rs
@@ -271,11 +271,13 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
         );
         let ref_to_snap = FunctionIdent::new(
             vir::vir_format!(vcx, "{}_snap", ref_to_pred.name()),
-            UnaryArity::new(vcx.alloc_array(&[snap_inst])),
+            UnaryArity::new(vcx.alloc_array(&[&vir::TypeData::Ref])),
+            snap_inst
         );
         let unreachable_to_snap = FunctionIdent::new(
             vir::vir_format!(vcx, "{}_unreachable", ref_to_pred.name()),
             NullaryArity::new(vcx.alloc_array(&[])),
+            snap_inst
         );
         let method_assign = MethodIdent::new(
             vir::vir_format!(vcx, "assign_{}", ref_to_pred.name()),
@@ -305,7 +307,7 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
             let name = vir::vir_format!(self.vcx, "{}_field_{idx}", base_name.unwrap_or(self.ref_to_pred.name()));
             let field = self.vcx.mk_function(name, self.self_decl, &vir::TypeData::Ref, &[], posts, None);
             self.ref_to_field_refs.push(field);
-            FunctionIdent::new(name, UnaryArity::new(&[&vir::TypeData::Ref]))
+            FunctionIdent::new(name, UnaryArity::new(&[&vir::TypeData::Ref]), &vir::TypeData::Ref)
         }).collect();
         PredicateEncDataStruct {
             snap_data,

--- a/vir/src/callable_idents.rs
+++ b/vir/src/callable_idents.rs
@@ -1,36 +1,44 @@
 use crate::{ExprGen, PredicateAppGen, Type, PredicateAppGenData, StmtGenData, MethodCallGenData, VirCtxt, TypeData, DomainParamData};
 use sealed::sealed;
 
-pub trait CallableIdent<'vir, A: Arity<'vir>> {
-    fn new(name: &'vir str, args: A) -> Self;
+pub trait CallableIdent<'vir, A: Arity<'vir>, ResultTy> {
+    fn new(name: &'vir str, args: A, result_ty: ResultTy) -> Self;
     fn name(&self) -> &'vir str;
     fn arity(&self) -> &A;
+    fn result_ty(&self) -> ResultTy;
 }
-pub trait ToKnownArity<'vir, T: 'vir>: CallableIdent<'vir, UnknownArityAny<'vir, T>> + Sized {
-    fn to_known<'tcx, K: CallableIdent<'vir, KnownArityAny<'vir, T, N>>, const N: usize>(self) -> K {
-        K::new(self.name(), KnownArityAny::new(self.arity().args().try_into().unwrap()))
+pub trait ToKnownArity<'vir, T: 'vir, ResultTy>: CallableIdent<'vir, UnknownArityAny<'vir, T>, ResultTy> + Sized {
+    fn to_known<'tcx, K: CallableIdent<'vir, KnownArityAny<'vir, T, N>, ResultTy>, const N: usize>(self) -> K {
+        K::new(
+            self.name(),
+            KnownArityAny::new(self.arity().args().try_into().unwrap()),
+            self.result_ty(),
+        )
     }
 }
-impl<'vir, T: 'vir, K: CallableIdent<'vir, UnknownArityAny<'vir, T>>> ToKnownArity<'vir, T> for K {}
+impl<'vir, T: 'vir, ResultTy, K: CallableIdent<'vir, UnknownArityAny<'vir, T>, ResultTy>> ToKnownArity<'vir, T, ResultTy> for K {}
 
 #[derive(Debug, Clone, Copy)]
-pub struct FunctionIdent<'vir, A: Arity<'vir>>(&'vir str, A);
-impl<'vir, A: Arity<'vir>> CallableIdent<'vir, A> for FunctionIdent<'vir, A> {
-    fn new(name: &'vir str, args: A) -> Self {
-        Self(name, args)
+pub struct FunctionIdent<'vir, A: Arity<'vir>>(&'vir str, A, Type<'vir>);
+impl<'vir, A: Arity<'vir>> CallableIdent<'vir, A, Type<'vir>> for FunctionIdent<'vir, A> {
+    fn new(name: &'vir str, args: A, result_ty: Type<'vir>) -> Self {
+        Self(name, args, result_ty)
     }
     fn name(&self) -> &'vir str {
         self.0
     }
     fn arity(&self) -> &A {
         &self.1
+    }
+    fn result_ty(&self) -> Type<'vir> {
+        self.2
     }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct MethodIdent<'vir, A: Arity<'vir>>(&'vir str, A);
-impl<'vir, A: Arity<'vir>> CallableIdent<'vir, A> for MethodIdent<'vir, A> {
-    fn new(name: &'vir str, args: A) -> Self {
+impl<'vir, A: Arity<'vir>> CallableIdent<'vir, A, ()> for MethodIdent<'vir, A> {
+    fn new(name: &'vir str, args: A, _unused: ()) -> Self {
         Self(name, args)
     }
     fn name(&self) -> &'vir str {
@@ -38,13 +46,22 @@ impl<'vir, A: Arity<'vir>> CallableIdent<'vir, A> for MethodIdent<'vir, A> {
     }
     fn arity(&self) -> &A {
         &self.1
+    }
+    fn result_ty(&self) -> () {
+       ()
+    }
+}
+
+impl <'vir, A: Arity<'vir>> MethodIdent<'vir, A> {
+    pub fn new(name: &'vir str, args: A) -> Self {
+        Self(name, args)
     }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct PredicateIdent<'vir, A: Arity<'vir>>(&'vir str, A);
-impl<'vir, A: Arity<'vir>> CallableIdent<'vir, A> for PredicateIdent<'vir, A> {
-    fn new(name: &'vir str, args: A) -> Self {
+impl<'vir, A: Arity<'vir>> CallableIdent<'vir, A, ()> for PredicateIdent<'vir, A> {
+    fn new(name: &'vir str, args: A, _unused: ()) -> Self {
         Self(name, args)
     }
     fn name(&self) -> &'vir str {
@@ -52,13 +69,22 @@ impl<'vir, A: Arity<'vir>> CallableIdent<'vir, A> for PredicateIdent<'vir, A> {
     }
     fn arity(&self) -> &A {
         &self.1
+    }
+    fn result_ty(&self) -> () {
+        ()
+    }
+}
+
+impl <'vir, A: Arity<'vir>> PredicateIdent<'vir, A> {
+    pub fn new(name: &'vir str, args: A) -> Self {
+        Self(name, args)
     }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct DomainIdent<'vir, A: Arity<'vir>>(&'vir str, A);
-impl<'vir, A: Arity<'vir>> CallableIdent<'vir, A> for DomainIdent<'vir, A> {
-    fn new(name: &'vir str, args: A) -> Self {
+impl<'vir, A: Arity<'vir>> CallableIdent<'vir, A, ()> for DomainIdent<'vir, A> {
+    fn new(name: &'vir str, args: A, _unused: ()) -> Self {
         Self(name, args)
     }
     fn name(&self) -> &'vir str {
@@ -67,8 +93,17 @@ impl<'vir, A: Arity<'vir>> CallableIdent<'vir, A> for DomainIdent<'vir, A> {
     fn arity(&self) -> &A {
         &self.1
     }
+    fn result_ty(&self) -> () {
+        ()
+    }
 }
 pub type DomainIdentUnknownArity<'vir> = DomainIdent<'vir, UnknownArityAny<'vir, DomainParamData<'vir>>>;
+
+impl <'vir> DomainIdentUnknownArity<'vir> {
+    pub fn new(name: &'vir str, args: UnknownArityAny<'vir, DomainParamData<'vir>>) -> Self {
+        Self(name, args)
+    }
+}
 
 #[sealed]
 pub trait Arity<'vir>: Copy {
@@ -153,7 +188,7 @@ impl<'vir, const N: usize> FunctionIdent<'vir, KnownArity<'vir, N>> {
         args: [ExprGen<'vir, Curr, Next>; N]
     ) -> ExprGen<'vir, Curr, Next>{
         self.1.check_types(self.name(), &args);
-        vcx.mk_func_app(self.name(), &args, None)
+        vcx.mk_func_app(self.name(), &args, self.result_ty())
     }
 }
 impl<'vir, const N: usize> PredicateIdent<'vir, KnownArity<'vir, N>> {
@@ -205,19 +240,10 @@ impl<'vir> FunctionIdent<'vir, UnknownArity<'vir>> {
         args: &[ExprGen<'vir, Curr, Next>]
     ) -> ExprGen<'vir, Curr, Next>{
         self.1.check_types(self.name(), args);
-        vcx.mk_func_app(self.name(), args, None)
-    }
-    // TODO: deduplicate
-    pub fn apply_ty<'tcx, Curr: 'vir, Next: 'vir>(
-        &self,
-        vcx: &'vir VirCtxt<'tcx>,
-        args: &[ExprGen<'vir, Curr, Next>],
-        result_ty: Type<'vir>
-    ) -> ExprGen<'vir, Curr, Next>{
-        self.1.check_types(self.name(), args);
-        vcx.mk_func_app(self.name(), args, Some(result_ty))
+        vcx.mk_func_app(self.name(), args, self.result_ty())
     }
 }
+
 impl<'vir> PredicateIdent<'vir, UnknownArity<'vir>> {
     pub fn apply<'tcx, Curr: 'vir, Next: 'vir>(
         &self,

--- a/vir/src/context.rs
+++ b/vir/src/context.rs
@@ -71,7 +71,7 @@ impl<'tcx> VirCtxt<'tcx> {
         &'vir self,
         target: &'vir str,
         src_args: &[ExprGen<'vir, Curr, Next>],
-        result_ty: Option<Type<'vir>>,
+        result_ty: Type<'vir>,
     ) -> ExprGen<'vir, Curr, Next> {
         self.alloc(ExprGenData {
             kind: self.alloc(ExprKindGenData::FuncApp(self.arena.alloc(FuncAppGenData {

--- a/vir/src/data.rs
+++ b/vir/src/data.rs
@@ -1,7 +1,8 @@
 use std::fmt::Debug;
 
 use prusti_rustc_interface::middle::mir;
-use crate::{refs::*, UnaryArity};
+use crate::{refs::*, FunctionIdent, UnknownArity, callable_idents::CallableIdent};
+
 
 pub struct LocalData<'vir> {
     pub name: &'vir str, // TODO: identifiers
@@ -115,6 +116,12 @@ pub struct DomainFunctionData<'vir> {
     pub(crate) name: &'vir str, // TODO: identifiers
     pub(crate) args: &'vir [Type<'vir>],
     pub(crate) ret: Type<'vir>,
+}
+
+impl <'vir> DomainFunctionData<'vir> {
+    pub fn ident(&self) -> FunctionIdent<'vir, UnknownArity<'vir>> {
+        FunctionIdent::new(self.name, UnknownArity::new(self.args), self.ret)
+    }
 }
 
 pub enum CfgBlockLabelData {

--- a/vir/src/debug.rs
+++ b/vir/src/debug.rs
@@ -180,7 +180,7 @@ impl<'vir, Curr, Next> Debug for FuncAppGenData<'vir, Curr, Next> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{}(", self.target)?;
         fmt_comma_sep(f, &self.args)?;
-        write!(f, "): {:?}", self.result_ty)?;
+        write!(f, ")")?;
         Ok(())
     }
 }

--- a/vir/src/debug.rs
+++ b/vir/src/debug.rs
@@ -178,15 +178,9 @@ impl<'vir, Curr, Next> Debug for ForallGenData<'vir, Curr, Next> {
 
 impl<'vir, Curr, Next> Debug for FuncAppGenData<'vir, Curr, Next> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        if self.result_ty.is_some() {
-            write!(f, "(")?;
-        }
         write!(f, "{}(", self.target)?;
         fmt_comma_sep(f, &self.args)?;
-        write!(f, ")")?;
-        if let Some(rt) = self.result_ty {
-            write!(f, ": {rt:?})")?;
-        }
+        write!(f, "): {:?}", self.result_ty)?;
         Ok(())
     }
 }

--- a/vir/src/gendata.rs
+++ b/vir/src/gendata.rs
@@ -37,7 +37,7 @@ pub struct ForallGenData<'vir, Curr, Next> {
 pub struct FuncAppGenData<'vir, Curr, Next> {
     #[reify_copy] pub(crate) target: &'vir str, // TODO: identifiers
     pub(crate) args: &'vir [ExprGen<'vir, Curr, Next>],
-    #[reify_copy] pub(crate) result_ty: Option<Type<'vir>>,
+    #[reify_copy] pub(crate) result_ty: Type<'vir>,
 }
 
 #[derive(Reify)]


### PR DESCRIPTION
Store return type in function identifiers.

Extends `CallableIdent` to have a generic `ResTy` that could maybe also be useful (for other purposes) for predicate and method identifiers.