### PR TITLE
Support `assert!`

### DIFF
--- a/prusti-encoder/src/encoders/type/domain.rs
+++ b/prusti-encoder/src/encoders/type/domain.rs
@@ -255,6 +255,13 @@ impl TaskEncoder for DomainEnc {
                     );
                     Ok((None, DomainEncSpecifics::Param))
                 }
+                &TyKind::Str => {
+                    let mut enc = DomainEncData::new(vcx, task_key, vec![], deps);
+                    let base_name = String::from("String");
+                    enc.deps.emit_output_ref::<Self>(*task_key, enc.output_ref(base_name));
+                    let specifics = enc.mk_struct_specifics(vec![]);
+                    Ok((Some(enc.finalize(task_key)), specifics))
+                }
                 kind => todo!("{kind:?}"),
             }
         })

--- a/prusti-encoder/src/encoders/type/lifted/func_def_ty_params.rs
+++ b/prusti-encoder/src/encoders/type/lifted/func_def_ty_params.rs
@@ -65,7 +65,9 @@ fn extract_ty_params(ty: Ty<'_>) -> Vec<ParamTy> {
             .filter_map(|arg| arg.as_type())
             .flat_map(|arg| extract_ty_params(arg))
             .collect(),
-        TyKind::Int(_) | TyKind::Uint(_) | TyKind::Float(_) | TyKind::Bool | TyKind::Char => vec![],
+        TyKind::Int(_) | TyKind::Uint(_) | TyKind::Float(_) | TyKind::Bool | TyKind::Char | TyKind::Str => vec![],
+        // TODO: special case to support constant strings
+        _ if matches!(ty.peel_refs().kind(), TyKind::Str) => vec![],
         other => todo!("{:?}", other),
     }
 }

--- a/prusti-encoder/src/encoders/type/most_generic_ty.rs
+++ b/prusti-encoder/src/encoders/type/most_generic_ty.rs
@@ -27,6 +27,7 @@ impl<'tcx> MostGenericTy<'tcx> {
             TyKind::Bool => String::from("Bool"),
             TyKind::Int(kind) => format!("Int_{}", kind.name_str()),
             TyKind::Uint(kind) => format!("UInt_{}", kind.name_str()),
+            TyKind::Str => String::from("String"),
             TyKind::Adt(adt, _) => vcx.tcx().item_name(adt.did()).to_ident_string(),
             TyKind::Tuple(params) => format!("{}_Tuple", params.len()),
             TyKind::Never => String::from("Never"),
@@ -84,6 +85,7 @@ impl<'tcx> MostGenericTy<'tcx> {
             TyKind::Bool => Vec::new(),
             TyKind::Int(_) => Vec::new(),
             TyKind::Uint(_) => Vec::new(),
+            TyKind::Str => Vec::new(),
             TyKind::Param(_) => Vec::new(),
             TyKind::Never => Vec::new(),
             other => todo!("generics for {:?}", other),
@@ -144,7 +146,7 @@ pub fn extract_type_params<'tcx>(
             (MostGenericTy(ty), vec![orig])
         }
         TyKind::Param(_) => (MostGenericTy(to_placeholder(tcx, None)), Vec::new()),
-        TyKind::Bool | TyKind::Int(_) | TyKind::Uint(_) | TyKind::Never => {
+        TyKind::Bool | TyKind::Int(_) | TyKind::Uint(_) | TyKind::Str | TyKind::Never => {
             (MostGenericTy(ty), Vec::new())
         }
         _ => todo!("extract_type_params for {:?}", ty),

--- a/prusti-encoder/src/encoders/type/predicate.rs
+++ b/prusti-encoder/src/encoders/type/predicate.rs
@@ -365,6 +365,15 @@ impl TaskEncoder for PredicateEnc {
                     .generic_predicate;
                 Ok((enc.mk_ref(inner, lifted_ty, specifics), ()))
             }
+            TyKind::Str => {
+                let specifics = enc.mk_struct_ref(None, snap.specifics.expect_structlike());
+
+                deps.emit_output_ref::<Self>(
+                    *task_key,
+                    enc.output_ref(PredicateEncData::StructLike(specifics)),
+                );
+                Ok((enc.mk_prim(&snap.base_name), ()))
+            }
             unsupported_type => todo!("type not supported: {unsupported_type:?}"),
         }
     }

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# To verify a Silver file 'test.sil', run './silicon.sh test.sil'.
+
+set -e
+
+BASEDIR="$(realpath "$(dirname "$0")")"
+
+exec java -Xss30M -Dlogback.configurationFile="$BASEDIR/src/main/resources/logback.xml" -cp $BASEDIR/viper_tools/backends/viperserver.jar viper.silicon.SiliconRunner "$@" --z3Exe=$BASEDIR/viper_tools/z3/bin/z3


### PR DESCRIPTION
This PR adds support for `assert!` and soon `prusti_assert!` to Prusti 2.0.

Concretely the only change was adding support for encoding `&str` which is encoded to an opaque type. 
Ideally, we would like to use this string to provide a better error message to the user as well, for the moment I haven't figured out how to do that though. 
