### PR TITLE
Support cycles in encoders

### DIFF
--- a/prusti-encoder/src/encoder_traits/function_enc.rs
+++ b/prusti-encoder/src/encoder_traits/function_enc.rs
@@ -19,10 +19,10 @@ pub trait FunctionEnc
     /// this should be the identity substitution obtained from the DefId of the
     /// function. For the monomorphic encoding, the substitutions at the call
     /// site should be used.
-    fn get_substs<'tcx>(
-        vcx: &vir::VirCtxt<'tcx>,
-        substs_src: &Self::TaskKey<'tcx>,
-    ) -> &'tcx GenericArgs<'tcx>;
+    fn get_substs<'vir>(
+        vcx: &vir::VirCtxt<'vir>,
+        substs_src: &Self::TaskKey<'vir>,
+    ) -> &'vir GenericArgs<'vir>;
 }
 
 /// Implementation for polymorphic encoding
@@ -35,10 +35,10 @@ impl <T: 'static + for<'vir> TaskEncoder<TaskKey<'vir> = DefId>> FunctionEnc for
         None
     }
 
-    fn get_substs<'tcx>(
-        vcx: &vir::VirCtxt<'tcx>,
-        def_id: &Self::TaskKey<'tcx>,
-    ) -> &'tcx GenericArgs<'tcx> {
+    fn get_substs<'vir>(
+        vcx: &vir::VirCtxt<'vir>,
+        def_id: &Self::TaskKey<'vir>,
+    ) -> &'vir GenericArgs<'vir> {
         GenericArgs::identity_for_item(vcx.tcx(), *def_id)
     }
 

--- a/prusti-encoder/src/encoder_traits/impure_function_enc.rs
+++ b/prusti-encoder/src/encoder_traits/impure_function_enc.rs
@@ -79,7 +79,7 @@ where
             args.extend(param_ty_decls.iter().map(|decl| decl.ty));
             let args = UnknownArity::new(vcx.alloc_slice(&args));
             let method_ref = MethodIdent::new(method_name, args);
-            deps.emit_output_ref(task_key, ImpureFunctionEncOutputRef { method_ref });
+            deps.emit_output_ref(task_key, ImpureFunctionEncOutputRef { method_ref })?;
 
             // Do not encode the method body if it is external, trusted or just
             // a call stub.

--- a/prusti-encoder/src/encoder_traits/impure_function_enc.rs
+++ b/prusti-encoder/src/encoder_traits/impure_function_enc.rs
@@ -33,13 +33,13 @@ where
 {
     /// Generates the identifier for the method; for a monomorphic encoding,
     /// this should be a name including (mangled) type arguments
-    fn mk_method_ident<'vir, 'tcx>(
-        vcx: &'vir vir::VirCtxt<'tcx>,
-        task_key: &Self::TaskKey<'tcx>,
+    fn mk_method_ident<'vir>(
+        vcx: &'vir vir::VirCtxt<'vir>,
+        task_key: &Self::TaskKey<'vir>,
     ) -> ViperIdent<'vir>;
 
-    fn encode<'vir, 'tcx: 'vir>(
-        task_key: Self::TaskKey<'tcx>,
+    fn encode<'vir>(
+        task_key: Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> Result<
         ImpureFunctionEncOutput<'vir>,

--- a/prusti-encoder/src/encoder_traits/impure_function_enc.rs
+++ b/prusti-encoder/src/encoder_traits/impure_function_enc.rs
@@ -40,7 +40,7 @@ where
 
     fn encode<'vir, 'tcx: 'vir>(
         task_key: Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> ImpureFunctionEncOutput<'vir> {
         let def_id = Self::get_def_id(&task_key);
         let caller_def_id = Self::get_caller_def_id(&task_key);
@@ -78,7 +78,7 @@ where
             args.extend(param_ty_decls.iter().map(|decl| decl.ty));
             let args = UnknownArity::new(vcx.alloc_slice(&args));
             let method_ref = MethodIdent::new(method_name, args);
-            deps.emit_output_ref::<Self>(task_key, ImpureFunctionEncOutputRef { method_ref });
+            deps.emit_output_ref(task_key, ImpureFunctionEncOutputRef { method_ref });
 
             // Do not encode the method body if it is external, trusted or just
             // a call stub.

--- a/prusti-encoder/src/encoder_traits/pure_func_app_enc.rs
+++ b/prusti-encoder/src/encoder_traits/pure_func_app_enc.rs
@@ -5,7 +5,7 @@ use prusti_rustc_interface::{
     },
     span::def_id::DefId,
 };
-use task_encoder::TaskEncoderDependencies;
+use task_encoder::{TaskEncoder, TaskEncoderDependencies};
 
 use crate::encoders::{
     lifted::{
@@ -16,7 +16,7 @@ use crate::encoders::{
 /// Encoders (such as [`crate::encoders::MirPureEnc`],
 /// [`crate::encoders::MirImpureEnc`]) implement this trait to encode
 /// applications of Rust functions annotated as pure.
-pub trait PureFuncAppEnc<'tcx: 'vir, 'vir> {
+pub trait PureFuncAppEnc<'tcx: 'vir, 'vir, E: TaskEncoder + 'vir + ?Sized> {
     /// Extra arguments required for the encoder to encode an argument to the
     /// function (in mir this is an `Operand`)
     type EncodeOperandArgs;
@@ -36,7 +36,7 @@ pub trait PureFuncAppEnc<'tcx: 'vir, 'vir> {
 
     /// Task encoder dependencies are required for encoding Viper casts between
     /// generic and concrete types.
-    fn deps(&mut self) -> &mut TaskEncoderDependencies<'vir>;
+    fn deps(&mut self) -> &mut TaskEncoderDependencies<'vir, E>;
 
     /// The data source that can provide local declarations, necesary for determining
     /// the function type

--- a/prusti-encoder/src/encoder_traits/pure_func_app_enc.rs
+++ b/prusti-encoder/src/encoder_traits/pure_func_app_enc.rs
@@ -16,7 +16,7 @@ use crate::encoders::{
 /// Encoders (such as [`crate::encoders::MirPureEnc`],
 /// [`crate::encoders::MirImpureEnc`]) implement this trait to encode
 /// applications of Rust functions annotated as pure.
-pub trait PureFuncAppEnc<'tcx: 'vir, 'vir, E: TaskEncoder + 'vir + ?Sized> {
+pub trait PureFuncAppEnc<'vir, E: TaskEncoder + 'vir + ?Sized> {
     /// Extra arguments required for the encoder to encode an argument to the
     /// function (in mir this is an `Operand`)
     type EncodeOperandArgs;
@@ -29,7 +29,7 @@ pub trait PureFuncAppEnc<'tcx: 'vir, 'vir, E: TaskEncoder + 'vir + ?Sized> {
 
     /// The type of the data source that can provide local declarations; this is used
     /// when getting the type of the function.
-    type LocalDeclsSrc: ?Sized + HasLocalDecls<'tcx>;
+    type LocalDeclsSrc: ?Sized + HasLocalDecls<'vir>;
 
     // Are we monomorphizing functions?
     fn monomorphize(&self) -> bool;
@@ -41,20 +41,20 @@ pub trait PureFuncAppEnc<'tcx: 'vir, 'vir, E: TaskEncoder + 'vir + ?Sized> {
     /// The data source that can provide local declarations, necesary for determining
     /// the function type
     fn local_decls_src(&self) -> &Self::LocalDeclsSrc;
-    fn vcx(&self) -> &'vir vir::VirCtxt<'tcx>;
+    fn vcx(&self) -> &'vir vir::VirCtxt<'vir>;
 
     /// Encodes an operand (an argument to a function) as a pure Viper expression.
     fn encode_operand(
         &mut self,
         args: &Self::EncodeOperandArgs,
-        operand: &mir::Operand<'tcx>,
+        operand: &mir::Operand<'vir>,
     ) -> vir::ExprGen<'vir, Self::Curr, Self::Next>;
 
     /// Obtains the function's definition ID and the substitutions made at the callsite
     fn get_def_id_and_caller_substs(
         &self,
-        func: &mir::Operand<'tcx>,
-    ) -> (DefId, &'tcx List<GenericArg<'tcx>>) {
+        func: &mir::Operand<'vir>,
+    ) -> (DefId, &'vir List<GenericArg<'vir>>) {
         let func_ty = func.ty(self.local_decls_src(), self.vcx().tcx());
         match func_ty.kind() {
             &ty::TyKind::FnDef(def_id, arg_tys) => (def_id, arg_tys),
@@ -67,9 +67,9 @@ pub trait PureFuncAppEnc<'tcx: 'vir, 'vir, E: TaskEncoder + 'vir + ?Sized> {
     /// are inserted to convert from/to generic and concrete arguments as necessary.
     fn encode_fn_args(
         &mut self,
-        sig: Binder<'tcx, FnSig<'tcx>>,
-        substs: &'tcx List<GenericArg<'tcx>>,
-        args: &[mir::Operand<'tcx>],
+        sig: Binder<'vir, FnSig<'vir>>,
+        substs: &'vir List<GenericArg<'vir>>,
+        args: &[mir::Operand<'vir>],
         encode_operand_args: &Self::EncodeOperandArgs,
     ) -> Vec<vir::ExprGen<'vir, Self::Curr, Self::Next>> {
         let mono = self.monomorphize();
@@ -118,10 +118,10 @@ pub trait PureFuncAppEnc<'tcx: 'vir, 'vir, E: TaskEncoder + 'vir + ?Sized> {
     fn encode_pure_func_app(
         &mut self,
         def_id: DefId,
-        sig: Binder<'tcx, FnSig<'tcx>>,
-        substs: &'tcx List<GenericArg<'tcx>>,
-        args: &Vec<mir::Operand<'tcx>>,
-        destination: &mir::Place<'tcx>,
+        sig: Binder<'vir, FnSig<'vir>>,
+        substs: &'vir List<GenericArg<'vir>>,
+        args: &Vec<mir::Operand<'vir>>,
+        destination: &mir::Place<'vir>,
         caller_def_id: DefId,
         encode_operand_args: &Self::EncodeOperandArgs,
     ) -> vir::ExprGen<'vir, Self::Curr, Self::Next> {

--- a/prusti-encoder/src/encoder_traits/pure_function_enc.rs
+++ b/prusti-encoder/src/encoder_traits/pure_function_enc.rs
@@ -34,21 +34,20 @@ where
 
     /// Generates the identifier for the function; for a monomorphic encoding,
     /// this should be a name including (mangled) type arguments
-    fn mk_function_ident<'vir, 'tcx>(
-        vcx: &'vir vir::VirCtxt<'tcx>,
-        task_key: &Self::TaskKey<'tcx>,
+    fn mk_function_ident<'vir>(
+        vcx: &'vir vir::VirCtxt<'vir>,
+        task_key: &Self::TaskKey<'vir>,
     ) -> ViperIdent<'vir>;
-
 
     /// Adds an assertion connecting the type of an argument (or return) of the
     /// function with the appropriate type based on the param, e.g. in f<T,
     /// U>(u: U) -> T, this would be called to require that the type of `u` be
     /// `U`
-    fn mk_type_assertion<'vir, 'tcx: 'vir, Curr, Next>(
-        vcx: &'vir vir::VirCtxt<'tcx>,
+    fn mk_type_assertion<'vir, Curr, Next>(
+        vcx: &'vir vir::VirCtxt<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
         arg: ExprGen<'vir, Curr, Next>, // Snapshot encoded argument
-        ty: Ty<'tcx>,
+        ty: Ty<'vir>,
     ) -> Option<ExprGen<'vir, Curr, Next>> {
         let lifted_ty = deps
             .require_local::<LiftedTyEnc<EncodeGenericsAsLifted>>(ty)
@@ -78,8 +77,8 @@ where
         }
     }
 
-    fn encode<'vir, 'tcx: 'vir>(
-        task_key: Self::TaskKey<'tcx>,
+    fn encode<'vir>(
+        task_key: Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> MirFunctionEncOutput<'vir> {
         let def_id = Self::get_def_id(&task_key);

--- a/prusti-encoder/src/encoder_traits/pure_function_enc.rs
+++ b/prusti-encoder/src/encoder_traits/pure_function_enc.rs
@@ -1,7 +1,8 @@
-use prusti_rustc_interface::
-    middle::{mir, ty::Ty}
-;
-use task_encoder::{TaskEncoder, TaskEncoderDependencies};
+use prusti_rustc_interface::{
+    middle::{mir, ty::{GenericArgs, Ty}},
+    span::def_id::DefId,
+};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies, EncodeFullResult};
 use vir::{CallableIdent, ExprGen, FunctionIdent, Reify, UnknownArity, ViperIdent};
 
 use crate::encoders::{

--- a/prusti-encoder/src/encoder_traits/pure_function_enc.rs
+++ b/prusti-encoder/src/encoder_traits/pure_function_enc.rs
@@ -2,7 +2,7 @@ use prusti_rustc_interface::{
     middle::{mir, ty::{GenericArgs, Ty}},
     span::def_id::DefId,
 };
-use task_encoder::{TaskEncoder, TaskEncoderDependencies, EncodeFullResult};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies};
 use vir::{CallableIdent, ExprGen, FunctionIdent, Reify, UnknownArity, ViperIdent};
 
 use crate::encoders::{
@@ -46,7 +46,7 @@ where
     /// `U`
     fn mk_type_assertion<'vir, 'tcx: 'vir, Curr, Next>(
         vcx: &'vir vir::VirCtxt<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
         arg: ExprGen<'vir, Curr, Next>, // Snapshot encoded argument
         ty: Ty<'tcx>,
     ) -> Option<ExprGen<'vir, Curr, Next>> {
@@ -80,7 +80,7 @@ where
 
     fn encode<'vir, 'tcx: 'vir>(
         task_key: Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> MirFunctionEncOutput<'vir> {
         let def_id = Self::get_def_id(&task_key);
         let caller_def_id = Self::get_caller_def_id(&task_key);
@@ -107,7 +107,7 @@ where
             let ident_args = UnknownArity::new(vcx.alloc_slice(&ident_args));
             let return_type = local_defs.locals[mir::RETURN_PLACE].ty;
             let function_ref = FunctionIdent::new(function_ident, ident_args, return_type.snapshot);
-            deps.emit_output_ref::<Self>(task_key, MirFunctionEncOutputRef { function_ref });
+            deps.emit_output_ref(task_key, MirFunctionEncOutputRef { function_ref });
 
             let spec = deps
                 .require_local::<MirSpecEnc>((def_id, substs, None, true))

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -6,6 +6,7 @@ use rustc_middle::mir::interpret::{ConstValue, Scalar, GlobalAlloc};
 use task_encoder::{
     TaskEncoder,
     TaskEncoderDependencies,
+    EncodeFullResult,
 };
 use vir::{CallableIdent, Arity};
 
@@ -40,13 +41,7 @@ impl TaskEncoder for ConstEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<(
-        Self::OutputFullLocal<'vir>,
-        Self::OutputFullDependency<'vir>,
-    ), (
-        Self::EncodingError,
-        Option<Self::OutputFullDependency<'vir>>,
-    )> {
+    ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref::<Self>(*task_key, ());
         let (const_, encoding_depth, def_id) = *task_key;
         let res = match const_ {

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -46,7 +46,7 @@ impl TaskEncoder for ConstEnc {
         let (const_, encoding_depth, def_id) = *task_key;
         let res = match const_ {
             mir::ConstantKind::Val(val, ty) => {
-                let kind = deps.require_local::<RustTySnapshotsEnc>(ty).unwrap().generic_snapshot.specifics;
+                let kind = deps.require_local::<RustTySnapshotsEnc>(ty)?.generic_snapshot.specifics;
                 match val {
                     ConstValue::Scalar(Scalar::Int(int)) => {
                         let prim = kind.expect_primitive();
@@ -79,12 +79,11 @@ impl TaskEncoder for ConstEnc {
                         let ref_ty = kind.expect_structlike();
                         let str_ty = ty.peel_refs();
                         let str_snap = deps
-                            .require_local::<RustTySnapshotsEnc>(str_ty)
-                            .unwrap()
+                            .require_local::<RustTySnapshotsEnc>(str_ty)?
                             .generic_snapshot
                             .specifics
                             .expect_structlike();
-                        let cast = deps.require_local::<RustTyCastersEnc<CastTypePure>>(str_ty).unwrap();
+                        let cast = deps.require_local::<RustTyCastersEnc<CastTypePure>>(str_ty)?;
                         vir::with_vcx(|vcx| {
                             // first, we create a string snapshot
                             let snap = str_snap.field_snaps_to_snap.apply(vcx, &[]);
@@ -107,10 +106,10 @@ impl TaskEncoder for ConstEnc {
                     kind: PureKind::Constant(uneval.promoted.unwrap()),
                     caller_def_id: Some(def_id)
                 };
-                let expr = deps.require_local::<MirPureEnc>(task).unwrap().expr;
+                let expr = deps.require_local::<MirPureEnc>(task)?.expr;
                 use vir::Reify;
-                expr.reify(vcx, (uneval.def, &[]))
-            }),
+                Ok(expr.reify(vcx, (uneval.def, &[])))
+            })?,
             mir::ConstantKind::Ty(_) => todo!("ConstantKind::Ty"),
         };
         Ok((res, ()))

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -40,9 +40,9 @@ impl TaskEncoder for ConstEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref::<Self>(*task_key, ());
+        deps.emit_output_ref(*task_key, ());
         let (const_, encoding_depth, def_id) = *task_key;
         let res = match const_ {
             mir::ConstantKind::Val(val, ty) => {

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -26,8 +26,8 @@ use super::{lifted::{casters::CastTypePure, rust_ty_cast::RustTyCastersEnc}, rus
 impl TaskEncoder for ConstEnc {
     task_encoder::encoder_cache!(ConstEnc);
 
-    type TaskDescription<'tcx> = (
-        mir::ConstantKind<'tcx>,
+    type TaskDescription<'vir> = (
+        mir::ConstantKind<'vir>,
         usize, // current encoding depth
         DefId, // DefId of the current function
     );
@@ -38,8 +38,8 @@ impl TaskEncoder for ConstEnc {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(*task_key, ());

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -42,7 +42,7 @@ impl TaskEncoder for ConstEnc {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref(*task_key, ());
+        deps.emit_output_ref(*task_key, ())?;
         let (const_, encoding_depth, def_id) = *task_key;
         let res = match const_ {
             mir::ConstantKind::Val(val, ty) => {

--- a/prusti-encoder/src/encoders/generic.rs
+++ b/prusti-encoder/src/encoders/generic.rs
@@ -53,7 +53,7 @@ impl TaskEncoder for GenericEnc {
     #[allow(non_snake_case)]
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let ref_to_pred =
             PredicateIdent::new(ViperIdent::new("p_Param"), BinaryArity::new(&[&TypeData::Ref, &TYP_DOMAIN]));
@@ -89,7 +89,7 @@ impl TaskEncoder for GenericEnc {
         };
 
         #[allow(clippy::unit_arg)]
-        deps.emit_output_ref::<Self>(
+        deps.emit_output_ref(
             *task_key,
             output_ref
         );

--- a/prusti-encoder/src/encoders/generic.rs
+++ b/prusti-encoder/src/encoders/generic.rs
@@ -1,4 +1,4 @@
-use task_encoder::{TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies, EncodeFullResult};
 use vir::{
     BinaryArity, CallableIdent, DomainIdent, DomainParamData, FunctionIdent,
     KnownArityAny, NullaryArity, PredicateIdent, TypeData, UnaryArity, ViperIdent,
@@ -54,16 +54,7 @@ impl TaskEncoder for GenericEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         let ref_to_pred =
             PredicateIdent::new(ViperIdent::new("p_Param"), BinaryArity::new(&[&TypeData::Ref, &TYP_DOMAIN]));
         let type_domain_ident = DomainIdent::nullary(ViperIdent::new("Type"));

--- a/prusti-encoder/src/encoders/generic.rs
+++ b/prusti-encoder/src/encoders/generic.rs
@@ -39,7 +39,7 @@ const SNAPSHOT_PARAM_DOMAIN: TypeData<'static> = TypeData::Domain("s_Param", &[]
 impl TaskEncoder for GenericEnc {
     task_encoder::encoder_cache!(GenericEnc);
 
-    type TaskDescription<'tcx> = (); // ?
+    type TaskDescription<'vir> = (); // ?
 
     type OutputRef<'vir> = GenericEncOutputRef<'vir>;
     type OutputFullLocal<'vir> = GenericEncOutput<'vir>;
@@ -51,8 +51,8 @@ impl TaskEncoder for GenericEnc {
     }
 
     #[allow(non_snake_case)]
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let ref_to_pred =

--- a/prusti-encoder/src/encoders/generic.rs
+++ b/prusti-encoder/src/encoders/generic.rs
@@ -92,7 +92,7 @@ impl TaskEncoder for GenericEnc {
         deps.emit_output_ref(
             *task_key,
             output_ref
-        );
+        )?;
 
         let typ = FunctionIdent::new(
             ViperIdent::new("typ"),

--- a/prusti-encoder/src/encoders/local_def.rs
+++ b/prusti-encoder/src/encoders/local_def.rs
@@ -4,7 +4,7 @@ use prusti_rustc_interface::{
     span::def_id::DefId
 };
 
-use task_encoder::{TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies, EncodeFullResult};
 
 use crate::encoders::{
     rust_ty_predicates::{RustTyPredicatesEnc, RustTyPredicatesEncOutputRef},
@@ -48,16 +48,7 @@ impl TaskEncoder for MirLocalDefEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         let (def_id, substs, caller_def_id) = *task_key;
         deps.emit_output_ref::<Self>(*task_key, ());
 

--- a/prusti-encoder/src/encoders/local_def.rs
+++ b/prusti-encoder/src/encoders/local_def.rs
@@ -47,10 +47,10 @@ impl TaskEncoder for MirLocalDefEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let (def_id, substs, caller_def_id) = *task_key;
-        deps.emit_output_ref::<Self>(*task_key, ());
+        deps.emit_output_ref(*task_key, ());
 
         fn mk_local_def<'vir, 'tcx>(
             vcx: &'vir vir::VirCtxt<'tcx>,

--- a/prusti-encoder/src/encoders/local_def.rs
+++ b/prusti-encoder/src/encoders/local_def.rs
@@ -31,9 +31,9 @@ pub struct LocalDef<'vir> {
 impl TaskEncoder for MirLocalDefEnc {
     task_encoder::encoder_cache!(MirLocalDefEnc);
 
-    type TaskDescription<'tcx> = (
+    type TaskDescription<'vir> = (
         DefId, // ID of the function
-        ty::GenericArgsRef<'tcx>, // ? this should be the "signature", after applying the env/substs
+        ty::GenericArgsRef<'vir>, // ? this should be the "signature", after applying the env/substs
         Option<DefId>, // ID of the caller function, if any
     );
 
@@ -45,15 +45,15 @@ impl TaskEncoder for MirLocalDefEnc {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let (def_id, substs, caller_def_id) = *task_key;
         deps.emit_output_ref(*task_key, ());
 
-        fn mk_local_def<'vir, 'tcx>(
-            vcx: &'vir vir::VirCtxt<'tcx>,
+        fn mk_local_def<'vir>(
+            vcx: &'vir vir::VirCtxt<'vir>,
             name: &'vir str,
             ty: RustTyPredicatesEncOutputRef<'vir>,
         ) -> LocalDef<'vir> {

--- a/prusti-encoder/src/encoders/local_def.rs
+++ b/prusti-encoder/src/encoders/local_def.rs
@@ -50,7 +50,7 @@ impl TaskEncoder for MirLocalDefEnc {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let (def_id, substs, caller_def_id) = *task_key;
-        deps.emit_output_ref(*task_key, ());
+        deps.emit_output_ref(*task_key, ())?;
 
         fn mk_local_def<'vir>(
             vcx: &'vir vir::VirCtxt<'vir>,

--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -54,7 +54,7 @@ impl TaskEncoder for MirBuiltinEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         vir::with_vcx(|vcx| {
             match *task_key {
@@ -89,7 +89,7 @@ fn int_name<'tcx>(ty: ty::Ty<'tcx>) -> &'static str {
 impl MirBuiltinEnc {
     fn handle_un_op<'vir, 'tcx>(
         vcx: &'vir vir::VirCtxt<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
         key: <Self as TaskEncoder>::TaskKey<'tcx>,
         op: mir::UnOp,
         ty: ty::Ty<'tcx>,
@@ -102,7 +102,7 @@ impl MirBuiltinEnc {
         let name = vir::vir_format_identifier!(vcx, "mir_unop_{op:?}_{}", int_name(ty));
         let arity = UnknownArity::new(vcx.alloc_slice(&[e_ty.snapshot]));
         let function = FunctionIdent::new(name, arity, e_ty.snapshot);
-        deps.emit_output_ref::<Self>(key, MirBuiltinEncOutputRef {
+        deps.emit_output_ref(key, MirBuiltinEncOutputRef {
             function,
         });
 
@@ -137,7 +137,7 @@ impl MirBuiltinEnc {
 
     fn handle_bin_op<'vir, 'tcx>(
         vcx: &'vir vir::VirCtxt<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
         key: <Self as TaskEncoder>::TaskKey<'tcx>,
         res_ty: ty::Ty<'tcx>,
         op: mir::BinOp,
@@ -164,7 +164,7 @@ impl MirBuiltinEnc {
         let name = vir::vir_format_identifier!(vcx, "mir_binop_{op:?}_{}_{}", int_name(l_ty), int_name(r_ty));
         let arity = UnknownArity::new(vcx.alloc_slice(&[e_l_ty.snapshot, e_r_ty.snapshot]));
         let function = FunctionIdent::new(name, arity, e_res_ty.snapshot);
-        deps.emit_output_ref::<Self>(key, MirBuiltinEncOutputRef {
+        deps.emit_output_ref(key, MirBuiltinEncOutputRef {
             function,
         });
         let lhs = prim_l_ty.snap_to_prim.apply(vcx,
@@ -265,7 +265,7 @@ impl MirBuiltinEnc {
 
     fn handle_checked_bin_op<'vir, 'tcx>(
         vcx: &'vir vir::VirCtxt<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
         key: <Self as TaskEncoder>::TaskKey<'tcx>,
         res_ty: ty::Ty<'tcx>,
         op: mir::BinOp,
@@ -298,7 +298,7 @@ impl MirBuiltinEnc {
             .unwrap()
             .generic_snapshot;
         let function = FunctionIdent::new(name, arity, e_res_ty.snapshot);
-        deps.emit_output_ref::<Self>(key, MirBuiltinEncOutputRef { function });
+        deps.emit_output_ref(key, MirBuiltinEncOutputRef { function });
 
         let e_res_ty = deps
             .require_local::<RustTySnapshotsEnc>(res_ty)

--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -5,6 +5,7 @@ use prusti_rustc_interface::{
 use task_encoder::{
     TaskEncoder,
     TaskEncoderDependencies,
+    EncodeFullResult,
 };
 use vir::{UnknownArity, FunctionIdent, CallableIdent};
 
@@ -54,13 +55,7 @@ impl TaskEncoder for MirBuiltinEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<(
-        Self::OutputFullLocal<'vir>,
-        Self::OutputFullDependency<'vir>,
-    ), (
-        Self::EncodingError,
-        Option<Self::OutputFullDependency<'vir>>,
-    )> {
+    ) -> EncodeFullResult<'vir, Self> {
         vir::with_vcx(|vcx| {
             match *task_key {
                 MirBuiltinEncTask::UnOp(res_ty, op, operand_ty) => {

--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -52,8 +52,8 @@ impl TaskEncoder for MirBuiltinEnc {
         task.clone()
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         vir::with_vcx(|vcx| {
@@ -87,12 +87,12 @@ fn int_name<'tcx>(ty: ty::Ty<'tcx>) -> &'static str {
 }
 
 impl MirBuiltinEnc {
-    fn handle_un_op<'vir, 'tcx>(
-        vcx: &'vir vir::VirCtxt<'tcx>,
+    fn handle_un_op<'vir>(
+        vcx: &'vir vir::VirCtxt<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
-        key: <Self as TaskEncoder>::TaskKey<'tcx>,
+        key: <Self as TaskEncoder>::TaskKey<'vir>,
         op: mir::UnOp,
-        ty: ty::Ty<'tcx>,
+        ty: ty::Ty<'vir>,
     ) -> vir::Function<'vir> {
         let e_ty = deps
             .require_local::<RustTySnapshotsEnc>(ty)
@@ -135,14 +135,14 @@ impl MirBuiltinEnc {
         )
     }
 
-    fn handle_bin_op<'vir, 'tcx>(
-        vcx: &'vir vir::VirCtxt<'tcx>,
+    fn handle_bin_op<'vir>(
+        vcx: &'vir vir::VirCtxt<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
-        key: <Self as TaskEncoder>::TaskKey<'tcx>,
-        res_ty: ty::Ty<'tcx>,
+        key: <Self as TaskEncoder>::TaskKey<'vir>,
+        res_ty: ty::Ty<'vir>,
         op: mir::BinOp,
-        l_ty: ty::Ty<'tcx>,
-        r_ty: ty::Ty<'tcx>,
+        l_ty: ty::Ty<'vir>,
+        r_ty: ty::Ty<'vir>,
     ) -> vir::Function<'vir> {
         use mir::BinOp::*;
         let e_l_ty = deps
@@ -263,14 +263,14 @@ impl MirBuiltinEnc {
         )
     }
 
-    fn handle_checked_bin_op<'vir, 'tcx>(
-        vcx: &'vir vir::VirCtxt<'tcx>,
+    fn handle_checked_bin_op<'vir>(
+        vcx: &'vir vir::VirCtxt<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
-        key: <Self as TaskEncoder>::TaskKey<'tcx>,
-        res_ty: ty::Ty<'tcx>,
+        key: <Self as TaskEncoder>::TaskKey<'vir>,
+        res_ty: ty::Ty<'vir>,
         op: mir::BinOp,
-        l_ty: ty::Ty<'tcx>,
-        r_ty: ty::Ty<'tcx>,
+        l_ty: ty::Ty<'vir>,
+        r_ty: ty::Ty<'vir>,
     ) -> vir::Function<'vir> {
         // `op` can only be `Add`, `Sub` or `Mul`
         assert!(matches!(

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -91,15 +91,15 @@ impl TaskEncoder for MirImpureEnc {
     ) -> EncodeFullResult<'vir, Self> {
         let monomorphize = Self::monomorphize();
         let output_ref = if monomorphize {
-            deps.require_ref::<MirMonoImpureEnc>(*task_key).unwrap()
+            deps.require_ref::<MirMonoImpureEnc>(*task_key)?
         } else {
-            deps.require_ref::<MirPolyImpureEnc>(task_key.def_id).unwrap()
+            deps.require_ref::<MirPolyImpureEnc>(task_key.def_id)?
         };
         deps.emit_output_ref(*task_key, output_ref);
         let output: ImpureFunctionEncOutput<'_> = if monomorphize {
-            deps.require_local::<MirMonoImpureEnc>(*task_key).unwrap()
+            deps.require_local::<MirMonoImpureEnc>(*task_key)?
         } else {
-            deps.require_local::<MirPolyImpureEnc>(task_key.def_id).unwrap()
+            deps.require_local::<MirPolyImpureEnc>(task_key.def_id)?
         };
         Ok((output, ()))
     }

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -13,7 +13,7 @@ use prusti_rustc_interface::{
 //use mir_ssa_analysis::{
 //    SsaAnalysis,
 //};
-use task_encoder::{TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies, EncodeFullResult};
 use vir::{MethodIdent, UnknownArity};
 
 pub struct MirImpureEnc;
@@ -88,16 +88,7 @@ impl TaskEncoder for MirImpureEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         let monomorphize = Self::monomorphize();
         let output_ref = if monomorphize {
             deps.require_ref::<MirMonoImpureEnc>(*task_key).unwrap()

--- a/prusti-encoder/src/encoders/mir_poly_impure.rs
+++ b/prusti-encoder/src/encoders/mir_poly_impure.rs
@@ -47,7 +47,7 @@ impl TaskEncoder for MirPolyImpureEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         def_id: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         Ok((<Self as ImpureFunctionEnc>::encode(*def_id, deps), ()))
     }

--- a/prusti-encoder/src/encoders/mir_poly_impure.rs
+++ b/prusti-encoder/src/encoders/mir_poly_impure.rs
@@ -1,5 +1,5 @@
 use prusti_rustc_interface::span::def_id::DefId;
-use task_encoder::{TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 use vir::{MethodIdent, UnknownArity};
 
 /// Encodes a Rust function as a Viper method using the polymorphic encoding of generics.
@@ -48,16 +48,7 @@ impl TaskEncoder for MirPolyImpureEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         def_id: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         Ok((<Self as ImpureFunctionEnc>::encode(*def_id, deps), ()))
     }
 }

--- a/prusti-encoder/src/encoders/mir_poly_impure.rs
+++ b/prusti-encoder/src/encoders/mir_poly_impure.rs
@@ -45,8 +45,8 @@ impl TaskEncoder for MirPolyImpureEnc {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        def_id: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        def_id: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         <Self as ImpureFunctionEnc>::encode(*def_id, deps)

--- a/prusti-encoder/src/encoders/mir_poly_impure.rs
+++ b/prusti-encoder/src/encoders/mir_poly_impure.rs
@@ -49,6 +49,7 @@ impl TaskEncoder for MirPolyImpureEnc {
         def_id: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        Ok((<Self as ImpureFunctionEnc>::encode(*def_id, deps), ()))
+        <Self as ImpureFunctionEnc>::encode(*def_id, deps)
+            .map(|r| (r, ()))
     }
 }

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -96,7 +96,7 @@ impl TaskEncoder for MirPureEnc {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref(*task_key, ());
+        deps.emit_output_ref(*task_key, ())?;
 
         let (_, kind, def_id, substs, caller_def_id) = *task_key;
 

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -8,6 +8,7 @@ use prusti_rustc_interface::{
 use task_encoder::{
     TaskEncoder,
     TaskEncoderDependencies,
+    EncodeFullResult,
 };
 use vir::add_debug_note;
 use std::collections::HashMap;
@@ -94,13 +95,7 @@ impl TaskEncoder for MirPureEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<(
-        Self::OutputFullLocal<'vir>,
-        Self::OutputFullDependency<'vir>,
-    ), (
-        Self::EncodingError,
-        Option<Self::OutputFullDependency<'vir>>,
-    )> {
+    ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref::<Self>(*task_key, ());
 
         let (_, kind, def_id, substs, caller_def_id) = *task_key;

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -53,27 +53,27 @@ pub enum PureKind {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct MirPureEncTask<'tcx> {
+pub struct MirPureEncTask<'vir> {
     // TODO: depth of encoding should be in the lazy context rather than here;
     //   can we integrate the lazy context into the identifier system?
     pub encoding_depth: usize,
     pub kind: PureKind,
     pub parent_def_id: DefId, // ID of the function
-    pub param_env: ty::ParamEnv<'tcx>, // param environment at the usage site
-    pub substs: ty::GenericArgsRef<'tcx>, // type substitutions at the usage site
+    pub param_env: ty::ParamEnv<'vir>, // param environment at the usage site
+    pub substs: ty::GenericArgsRef<'vir>, // type substitutions at the usage site
     pub caller_def_id: Option<DefId>, // ID of the caller function, if any
 }
 
 impl TaskEncoder for MirPureEnc {
     task_encoder::encoder_cache!(MirPureEnc);
 
-    type TaskDescription<'tcx> = MirPureEncTask<'tcx>;
+    type TaskDescription<'vir> = MirPureEncTask<'vir>;
 
-    type TaskKey<'tcx> = (
+    type TaskKey<'vir> = (
         usize, // encoding depth
         PureKind, // encoding a pure function?
         DefId, // ID of the function
-        ty::GenericArgsRef<'tcx>, // ? this should be the "signature", after applying the env/substs
+        ty::GenericArgsRef<'vir>, // ? this should be the "signature", after applying the env/substs
         Option<DefId>, // Caller/Use DefID
     );
 
@@ -81,7 +81,7 @@ impl TaskEncoder for MirPureEnc {
 
     type EncodingError = MirPureEncError;
 
-    fn task_to_key<'tcx>(task: &Self::TaskDescription<'tcx>) -> Self::TaskKey<'tcx> {
+    fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         (
             // TODO
             task.encoding_depth,
@@ -92,8 +92,8 @@ impl TaskEncoder for MirPureEnc {
         )
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(*task_key, ());
@@ -169,13 +169,12 @@ impl<'vir> Update<'vir> {
     }
 }
 
-struct Enc<'tcx, 'vir: 'enc, 'enc>
-{
+struct Enc<'vir: 'enc, 'enc> {
     monomorphize: bool,
-    vcx: &'vir vir::VirCtxt<'tcx>,
+    vcx: &'vir vir::VirCtxt<'vir>,
     encoding_depth: usize,
     def_id: DefId,
-    body: &'enc mir::Body<'tcx>,
+    body: &'enc mir::Body<'vir>,
     rev_doms: rev_doms::ReverseDominators,
     deps: &'enc mut TaskEncoderDependencies<'vir, MirPureEnc>,
     visited: IndexVec<mir::BasicBlock, bool>,
@@ -183,8 +182,8 @@ struct Enc<'tcx, 'vir: 'enc, 'enc>
     phi_ctr: usize,
 }
 
-impl <'tcx: 'vir, 'vir, 'enc> PureFuncAppEnc<'tcx, 'vir, MirPureEnc> for Enc<'tcx, 'vir, 'enc> {
-    fn vcx(&self) -> &'vir vir::VirCtxt<'tcx> {
+impl <'vir, 'enc> PureFuncAppEnc<'vir, MirPureEnc> for Enc<'vir, 'enc> {
+    fn vcx(&self) -> &'vir vir::VirCtxt<'vir> {
         self.vcx
     }
 
@@ -194,7 +193,7 @@ impl <'tcx: 'vir, 'vir, 'enc> PureFuncAppEnc<'tcx, 'vir, MirPureEnc> for Enc<'tc
 
     type Next = vir::ExprKind<'vir>;
 
-    type LocalDeclsSrc = Body<'tcx>;
+    type LocalDeclsSrc = Body<'vir>;
 
     fn deps(&mut self) -> &mut TaskEncoderDependencies<'vir, MirPureEnc> {
         self.deps
@@ -207,7 +206,7 @@ impl <'tcx: 'vir, 'vir, 'enc> PureFuncAppEnc<'tcx, 'vir, MirPureEnc> for Enc<'tc
     fn encode_operand(
         &mut self,
         args: &Self::EncodeOperandArgs,
-        operand: &mir::Operand<'tcx>,
+        operand: &mir::Operand<'vir>,
     ) -> vir::ExprGen<'vir, Self::Curr, Self::Next> {
         self.encode_operand(args, operand)
     }
@@ -217,14 +216,13 @@ impl <'tcx: 'vir, 'vir, 'enc> PureFuncAppEnc<'tcx, 'vir, MirPureEnc> for Enc<'tc
     }
 }
 
-impl<'tcx, 'vir: 'enc, 'enc> Enc<'tcx, 'vir, 'enc>
-{
+impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
     fn new(
-        vcx: &'vir vir::VirCtxt<'tcx>,
+        vcx: &'vir vir::VirCtxt<'vir>,
         monomorphize: bool,
         encoding_depth: usize,
         def_id: DefId,
-        body: &'enc mir::Body<'tcx>,
+        body: &'enc mir::Body<'vir>,
         deps: &'enc mut TaskEncoderDependencies<'vir, MirPureEnc>,
     ) -> Self {
         assert!(!body.basic_blocks.is_cfg_cyclic(), "MIR pure encoding does not support loops");
@@ -532,7 +530,7 @@ impl<'tcx, 'vir: 'enc, 'enc> Enc<'tcx, 'vir, 'enc>
     fn encode_stmt(
         &mut self,
         curr_ver: &HashMap<mir::Local, usize>,
-        stmt: &mir::Statement<'tcx>,
+        stmt: &mir::Statement<'vir>,
     ) -> Update<'vir> {
         let mut update = Update::new();
         match &stmt.kind {
@@ -558,7 +556,7 @@ impl<'tcx, 'vir: 'enc, 'enc> Enc<'tcx, 'vir, 'enc>
     fn encode_rvalue(
         &mut self,
         curr_ver: &HashMap<mir::Local, usize>,
-        rvalue: &mir::Rvalue<'tcx>,
+        rvalue: &mir::Rvalue<'vir>,
     ) -> ExprRet<'vir> {
         let rvalue_ty = rvalue.ty(self.body, self.vcx.tcx());
         match rvalue {
@@ -713,7 +711,7 @@ impl<'tcx, 'vir: 'enc, 'enc> Enc<'tcx, 'vir, 'enc>
     fn encode_operand(
         &mut self,
         curr_ver: &HashMap<mir::Local, usize>,
-        operand: &mir::Operand<'tcx>,
+        operand: &mir::Operand<'vir>,
     ) -> ExprRet<'vir> {
         match operand {
             mir::Operand::Copy(place)
@@ -726,7 +724,7 @@ impl<'tcx, 'vir: 'enc, 'enc> Enc<'tcx, 'vir, 'enc>
     fn encode_place(
         &mut self,
         curr_ver: &HashMap<mir::Local, usize>,
-        place: &mir::Place<'tcx>,
+        place: &mir::Place<'vir>,
     ) -> ExprRet<'vir> {
         self.encode_place_with_ref(curr_ver, place).0
     }
@@ -734,7 +732,7 @@ impl<'tcx, 'vir: 'enc, 'enc> Enc<'tcx, 'vir, 'enc>
     fn encode_place_with_ref(
         &mut self,
         curr_ver: &HashMap<mir::Local, usize>,
-        place: &mir::Place<'tcx>,
+        place: &mir::Place<'vir>,
     ) -> (ExprRet<'vir>, Option<ExprRet<'vir>>) {
         // TODO: remove (debug)
         assert!(curr_ver.contains_key(&place.local));
@@ -754,8 +752,8 @@ impl<'tcx, 'vir: 'enc, 'enc> Enc<'tcx, 'vir, 'enc>
 
     fn encode_place_element(
         &mut self,
-        place_ty: mir::tcx::PlaceTy<'tcx>,
-        elem: mir::PlaceElem<'tcx>,
+        place_ty: mir::tcx::PlaceTy<'vir>,
+        elem: mir::PlaceElem<'vir>,
         expr: ExprRet<'vir>,
         place_ref: Option<ExprRet<'vir>>,
     ) -> (ExprRet<'vir>, Option<ExprRet<'vir>>) {
@@ -831,7 +829,7 @@ impl<'tcx, 'vir: 'enc, 'enc> Enc<'tcx, 'vir, 'enc>
         }
     }
 
-    fn encode_prusti_builtin(&mut self, curr_ver: &HashMap<mir::Local, usize>, def_id: DefId, arg_tys: ty::GenericArgsRef<'tcx>, args: &Vec<mir::Operand<'tcx>>) -> ExprRet<'vir> {
+    fn encode_prusti_builtin(&mut self, curr_ver: &HashMap<mir::Local, usize>, def_id: DefId, arg_tys: ty::GenericArgsRef<'vir>, args: &Vec<mir::Operand<'vir>>) -> ExprRet<'vir> {
         #[derive(Debug)]
         enum PrustiBuiltin {
             Forall,
@@ -980,7 +978,7 @@ mod rev_doms {
         pub end: mir::BasicBlock,
     }
     impl ReverseDominators {
-        pub fn new<'a, 'tcx>(blocks: &'a mir::BasicBlocks<'tcx>) -> Self {
+        pub fn new<'a, 'vir>(blocks: &'a mir::BasicBlocks<'vir>) -> Self {
             let no_succ_blocks = blocks.iter_enumerated().filter(|(_, data)|
                 data.terminator().successors().next().is_none()
             ).map(|(bb, _)| bb).collect();
@@ -1001,7 +999,7 @@ mod rev_doms {
 
     /// A wrapper around `mir::BasicBlocks` which reverses the direction of the
     /// edges. Implements `ControlFlowGraph` such that we can call `dominators`.
-    struct RevBasicBlocks<'a, 'tcx>(&'a mir::BasicBlocks<'tcx>, Vec<mir::BasicBlock>);
+    struct RevBasicBlocks<'a, 'vir>(&'a mir::BasicBlocks<'vir>, Vec<mir::BasicBlock>);
     impl DirectedGraph for RevBasicBlocks<'_, '_> {
         type Node = mir::BasicBlock;
     }

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -94,9 +94,9 @@ impl TaskEncoder for MirPureEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref::<Self>(*task_key, ());
+        deps.emit_output_ref(*task_key, ());
 
         let (_, kind, def_id, substs, caller_def_id) = *task_key;
 
@@ -177,13 +177,13 @@ struct Enc<'tcx, 'vir: 'enc, 'enc>
     def_id: DefId,
     body: &'enc mir::Body<'tcx>,
     rev_doms: rev_doms::ReverseDominators,
-    deps: &'enc mut TaskEncoderDependencies<'vir>,
+    deps: &'enc mut TaskEncoderDependencies<'vir, MirPureEnc>,
     visited: IndexVec<mir::BasicBlock, bool>,
     version_ctr: IndexVec<mir::Local, usize>,
     phi_ctr: usize,
 }
 
-impl <'tcx: 'vir, 'vir, 'enc> PureFuncAppEnc<'tcx, 'vir> for Enc<'tcx, 'vir, 'enc> {
+impl <'tcx: 'vir, 'vir, 'enc> PureFuncAppEnc<'tcx, 'vir, MirPureEnc> for Enc<'tcx, 'vir, 'enc> {
     fn vcx(&self) -> &'vir vir::VirCtxt<'tcx> {
         self.vcx
     }
@@ -196,7 +196,7 @@ impl <'tcx: 'vir, 'vir, 'enc> PureFuncAppEnc<'tcx, 'vir> for Enc<'tcx, 'vir, 'en
 
     type LocalDeclsSrc = Body<'tcx>;
 
-    fn deps(&mut self) -> &mut TaskEncoderDependencies<'vir> {
+    fn deps(&mut self) -> &mut TaskEncoderDependencies<'vir, MirPureEnc> {
         self.deps
     }
 
@@ -225,7 +225,7 @@ impl<'tcx, 'vir: 'enc, 'enc> Enc<'tcx, 'vir, 'enc>
         encoding_depth: usize,
         def_id: DefId,
         body: &'enc mir::Body<'tcx>,
-        deps: &'enc mut TaskEncoderDependencies<'vir>,
+        deps: &'enc mut TaskEncoderDependencies<'vir, MirPureEnc>,
     ) -> Self {
         assert!(!body.basic_blocks.is_cfg_cyclic(), "MIR pure encoding does not support loops");
         let rev_doms = rev_doms::ReverseDominators::new(&body.basic_blocks);

--- a/prusti-encoder/src/encoders/mir_pure_function.rs
+++ b/prusti-encoder/src/encoders/mir_pure_function.rs
@@ -40,8 +40,8 @@ impl TaskEncoder for MirFunctionEnc {
         task.def_id
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         Ok((<Self as PureFunctionEnc>::encode(*task_key, deps), ()))

--- a/prusti-encoder/src/encoders/mir_pure_function.rs
+++ b/prusti-encoder/src/encoders/mir_pure_function.rs
@@ -42,7 +42,7 @@ impl TaskEncoder for MirFunctionEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         Ok((<Self as PureFunctionEnc>::encode(*task_key, deps), ()))
     }

--- a/prusti-encoder/src/encoders/mir_pure_function.rs
+++ b/prusti-encoder/src/encoders/mir_pure_function.rs
@@ -1,6 +1,6 @@
 use prusti_rustc_interface::span::def_id::DefId;
 
-use task_encoder::{TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies, EncodeFullResult};
 
 use crate::encoder_traits::pure_function_enc::{
     MirFunctionEncOutput, MirFunctionEncOutputRef, PureFunctionEnc
@@ -43,16 +43,7 @@ impl TaskEncoder for MirFunctionEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         Ok((<Self as PureFunctionEnc>::encode(*task_key, deps), ()))
     }
 }

--- a/prusti-encoder/src/encoders/mono/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mono/mir_impure.rs
@@ -66,8 +66,8 @@ impl TaskEncoder for MirMonoImpureEnc {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         <Self as ImpureFunctionEnc>::encode(*task_key, deps)

--- a/prusti-encoder/src/encoders/mono/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mono/mir_impure.rs
@@ -1,5 +1,5 @@
 use prusti_rustc_interface::{middle::ty::GenericArgs, span::def_id::DefId};
-use task_encoder::{TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies, EncodeFullResult};
 use vir::{MethodIdent, UnknownArity};
 /// Encodes a Rust function as a Viper method using the monomorphic encoding of generics.
 pub struct MirMonoImpureEnc;
@@ -69,16 +69,7 @@ impl TaskEncoder for MirMonoImpureEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         Ok((<Self as ImpureFunctionEnc>::encode(*task_key, deps), ()))
     }
 }

--- a/prusti-encoder/src/encoders/mono/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mono/mir_impure.rs
@@ -68,7 +68,7 @@ impl TaskEncoder for MirMonoImpureEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         Ok((<Self as ImpureFunctionEnc>::encode(*task_key, deps), ()))
     }

--- a/prusti-encoder/src/encoders/mono/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mono/mir_impure.rs
@@ -70,6 +70,7 @@ impl TaskEncoder for MirMonoImpureEnc {
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        Ok((<Self as ImpureFunctionEnc>::encode(*task_key, deps), ()))
+        <Self as ImpureFunctionEnc>::encode(*task_key, deps)
+            .map(|r| (r, ()))
     }
 }

--- a/prusti-encoder/src/encoders/mono/mir_pure_function.rs
+++ b/prusti-encoder/src/encoders/mono/mir_pure_function.rs
@@ -59,8 +59,8 @@ impl TaskEncoder for MirMonoFunctionEnc {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         Ok((<Self as PureFunctionEnc>::encode(*task_key, deps), ()))

--- a/prusti-encoder/src/encoders/mono/mir_pure_function.rs
+++ b/prusti-encoder/src/encoders/mono/mir_pure_function.rs
@@ -1,5 +1,5 @@
 use prusti_rustc_interface::{middle::ty::GenericArgs, span::def_id::DefId};
-use task_encoder::{TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies, EncodeFullResult};
 
 use crate::{
     encoder_traits::{function_enc::FunctionEnc, pure_function_enc::{MirFunctionEncOutput, MirFunctionEncOutputRef, PureFunctionEnc}},
@@ -62,16 +62,7 @@ impl TaskEncoder for MirMonoFunctionEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         Ok((<Self as PureFunctionEnc>::encode(*task_key, deps), ()))
     }
 }

--- a/prusti-encoder/src/encoders/mono/mir_pure_function.rs
+++ b/prusti-encoder/src/encoders/mono/mir_pure_function.rs
@@ -61,7 +61,7 @@ impl TaskEncoder for MirMonoFunctionEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         Ok((<Self as PureFunctionEnc>::encode(*task_key, deps), ()))
     }

--- a/prusti-encoder/src/encoders/pure/spec.rs
+++ b/prusti-encoder/src/encoders/pure/spec.rs
@@ -37,10 +37,10 @@ impl TaskEncoder for MirSpecEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let (def_id, substs, caller_def_id, pure) = *task_key;
-        deps.emit_output_ref::<Self>(*task_key, ());
+        deps.emit_output_ref(*task_key, ());
 
         let local_defs = deps
             .require_local::<crate::encoders::local_def::MirLocalDefEnc>((

--- a/prusti-encoder/src/encoders/pure/spec.rs
+++ b/prusti-encoder/src/encoders/pure/spec.rs
@@ -3,7 +3,7 @@ use prusti_rustc_interface::{
     span::def_id::DefId,
 };
 
-use task_encoder::{TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies, EncodeFullResult};
 use vir::Reify;
 
 use crate::encoders::{mir_pure::PureKind, rust_ty_predicates::RustTyPredicatesEnc, MirPureEnc};
@@ -38,16 +38,7 @@ impl TaskEncoder for MirSpecEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         let (def_id, substs, caller_def_id, pure) = *task_key;
         deps.emit_output_ref::<Self>(*task_key, ());
 

--- a/prusti-encoder/src/encoders/pure/spec.rs
+++ b/prusti-encoder/src/encoders/pure/spec.rs
@@ -35,8 +35,8 @@ impl TaskEncoder for MirSpecEnc {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let (def_id, substs, caller_def_id, pure) = *task_key;

--- a/prusti-encoder/src/encoders/pure/spec.rs
+++ b/prusti-encoder/src/encoders/pure/spec.rs
@@ -47,11 +47,9 @@ impl TaskEncoder for MirSpecEnc {
                 def_id,
                 substs,
                 caller_def_id,
-            ))
-            .unwrap();
+            ))?;
         let specs = deps
-            .require_local::<crate::encoders::SpecEnc>(crate::encoders::SpecEncTask { def_id })
-            .unwrap();
+            .require_local::<crate::encoders::SpecEnc>(crate::encoders::SpecEncTask { def_id })?;
 
         vir::with_vcx(|vcx| {
             let local_iter = (1..=local_defs.arg_count).map(mir::Local::from);
@@ -79,8 +77,7 @@ impl TaskEncoder for MirSpecEnc {
             };
 
             let to_bool = deps
-                .require_ref::<RustTyPredicatesEnc>(vcx.tcx().types.bool)
-                .unwrap()
+                .require_ref::<RustTyPredicatesEnc>(vcx.tcx().types.bool)?
                 .generic_predicate
                 .expect_prim()
                 .snap_to_prim;

--- a/prusti-encoder/src/encoders/pure/spec.rs
+++ b/prusti-encoder/src/encoders/pure/spec.rs
@@ -40,7 +40,7 @@ impl TaskEncoder for MirSpecEnc {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let (def_id, substs, caller_def_id, pure) = *task_key;
-        deps.emit_output_ref(*task_key, ());
+        deps.emit_output_ref(*task_key, ())?;
 
         let local_defs = deps
             .require_local::<crate::encoders::local_def::MirLocalDefEnc>((

--- a/prusti-encoder/src/encoders/spec.rs
+++ b/prusti-encoder/src/encoders/spec.rs
@@ -6,6 +6,7 @@ use prusti_interface::specs::typed::{DefSpecificationMap, ProcedureSpecification
 use task_encoder::{
     TaskEncoder,
     TaskEncoderDependencies,
+    EncodeFullResult,
 };
 
 pub struct SpecEnc;
@@ -78,13 +79,7 @@ impl TaskEncoder for SpecEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<(
-        Self::OutputFullLocal<'vir>,
-        Self::OutputFullDependency<'vir>,
-    ), (
-        Self::EncodingError,
-        Option<Self::OutputFullDependency<'vir>>,
-    )> {
+    ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref::<Self>(task_key.clone(), ());
         vir::with_vcx(|vcx| {
             with_def_spec(|def_spec| {

--- a/prusti-encoder/src/encoders/spec.rs
+++ b/prusti-encoder/src/encoders/spec.rs
@@ -76,8 +76,8 @@ impl TaskEncoder for SpecEnc {
         )
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(task_key.clone(), ());

--- a/prusti-encoder/src/encoders/spec.rs
+++ b/prusti-encoder/src/encoders/spec.rs
@@ -78,9 +78,9 @@ impl TaskEncoder for SpecEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref::<Self>(task_key.clone(), ());
+        deps.emit_output_ref(task_key.clone(), ());
         vir::with_vcx(|vcx| {
             with_def_spec(|def_spec| {
                 let specs = def_spec.get_proc_spec(&task_key.0);

--- a/prusti-encoder/src/encoders/spec.rs
+++ b/prusti-encoder/src/encoders/spec.rs
@@ -80,7 +80,7 @@ impl TaskEncoder for SpecEnc {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref(task_key.clone(), ());
+        deps.emit_output_ref(task_key.clone(), ())?;
         vir::with_vcx(|vcx| {
             with_def_spec(|def_spec| {
                 let specs = def_spec.get_proc_spec(&task_key.0);

--- a/prusti-encoder/src/encoders/type/domain.rs
+++ b/prusti-encoder/src/encoders/type/domain.rs
@@ -178,7 +178,7 @@ impl TaskEncoder for DomainEnc {
                                 // extern spec in the future)
                                 vec![
                                     FieldTy {
-                                        ty: enc.deps.require_ref::<GenericEnc>(()).unwrap().param_snapshot,
+                                        ty: enc.deps.require_ref::<GenericEnc>(())?.param_snapshot,
                                         rust_ty_data: None
                                     }
                                 ]
@@ -201,8 +201,7 @@ impl TaskEncoder for DomainEnc {
                                     .any(|v| matches!(v.discr, ty::VariantDiscr::Explicit(_)));
                                 let discr_ty = adt.repr().discr_type().to_ty(vcx.tcx());
                                 let discr_ty = enc.deps
-                                    .require_local::<RustTySnapshotsEnc>(discr_ty)
-                                    .unwrap()
+                                    .require_local::<RustTySnapshotsEnc>(discr_ty)?
                                     .generic_snapshot;
                                 Some(VariantData {
                                     discr_ty: discr_ty.snapshot,
@@ -235,7 +234,7 @@ impl TaskEncoder for DomainEnc {
                     Ok((Some(enc.finalize(task_key)), specifics))
                 }
                 &TyKind::Ref(_, inner, _) => {
-                    let generics = vec![deps.require_local::<LiftedTyEnc<EncodeGenericsAsParamTy>>(inner).unwrap().expect_generic()];
+                    let generics = vec![deps.require_local::<LiftedTyEnc<EncodeGenericsAsParamTy>>(inner)?.expect_generic()];
                     let mut enc = DomainEncData::new(vcx, task_key, generics, deps);
                     enc.deps.emit_output_ref(*task_key, enc.output_ref(base_name));
                     let field_tys = vec![FieldTy::from_ty(vcx, enc.deps, inner)];
@@ -243,7 +242,7 @@ impl TaskEncoder for DomainEnc {
                     Ok((Some(enc.finalize(task_key)), specifics))
                 }
                 &TyKind::Param(_) => {
-                    let out = deps.require_ref::<GenericEnc>(()).unwrap();
+                    let out = deps.require_ref::<GenericEnc>(())?;
                     deps.emit_output_ref(
                         *task_key,
                         DomainEncOutputRef {

--- a/prusti-encoder/src/encoders/type/domain.rs
+++ b/prusti-encoder/src/encoders/type/domain.rs
@@ -798,7 +798,7 @@ struct LiftedRustTyData<'vir> {
 
 impl <'vir> FieldTy<'vir> {
     fn from_ty<'tcx: 'vir>(vcx: &'vir vir::VirCtxt<'tcx>, deps: &mut TaskEncoderDependencies, ty: ty::Ty<'tcx>) -> FieldTy<'vir> {
-        let vir_ty = deps.require_local::<RustTySnapshotsEnc>(ty)
+        let vir_ty = deps.require_ref::<RustTySnapshotsEnc>(ty)
             .unwrap()
             .generic_snapshot
             .snapshot;

--- a/prusti-encoder/src/encoders/type/domain.rs
+++ b/prusti-encoder/src/encoders/type/domain.rs
@@ -7,6 +7,7 @@ use rustc_middle::ty::ParamTy;
 use task_encoder::{
     TaskEncoder,
     TaskEncoderDependencies,
+    EncodeFullResult,
 };
 use vir::{
     BinaryArity, CallableIdent, DomainParamData, FunctionIdent, NullaryArityAny, ToKnownArity, UnaryArity, UnknownArity
@@ -138,13 +139,7 @@ impl TaskEncoder for DomainEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<(
-        Self::OutputFullLocal<'vir>,
-        Self::OutputFullDependency<'vir>,
-    ), (
-        Self::EncodingError,
-        Option<Self::OutputFullDependency<'vir>>,
-    )> {
+    ) -> EncodeFullResult<'vir, Self> {
         vir::with_vcx(|vcx| {
             let base_name = task_key.get_vir_base_name(vcx);
             match task_key.kind() {

--- a/prusti-encoder/src/encoders/type/lifted/aggregate_cast.rs
+++ b/prusti-encoder/src/encoders/type/lifted/aggregate_cast.rs
@@ -3,7 +3,7 @@ use prusti_rustc_interface::{
     middle::{mir, ty::{GenericArgs, Ty}},
     span::def_id::DefId,
 };
-use task_encoder::TaskEncoder;
+use task_encoder::{TaskEncoder, EncodeFullResult};
 
 use crate::encoders::lifted::cast::{CastArgs, CastToEnc};
 
@@ -82,16 +82,7 @@ impl TaskEncoder for AggregateSnapArgsCastEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref::<AggregateSnapArgsCastEnc>(task_key.clone(), ());
         vir::with_vcx(|vcx| {
             let cast_functions: Vec<Option<PureCast<'vir>>> =

--- a/prusti-encoder/src/encoders/type/lifted/aggregate_cast.rs
+++ b/prusti-encoder/src/encoders/type/lifted/aggregate_cast.rs
@@ -79,8 +79,8 @@ impl TaskEncoder for AggregateSnapArgsCastEnc {
         task.clone()
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(task_key.clone(), ());

--- a/prusti-encoder/src/encoders/type/lifted/aggregate_cast.rs
+++ b/prusti-encoder/src/encoders/type/lifted/aggregate_cast.rs
@@ -83,7 +83,7 @@ impl TaskEncoder for AggregateSnapArgsCastEnc {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref(task_key.clone(), ());
+        deps.emit_output_ref(task_key.clone(), ())?;
         vir::with_vcx(|vcx| {
             let cast_functions: Vec<Option<PureCast<'vir>>> =
                 match task_key.aggregate_type {

--- a/prusti-encoder/src/encoders/type/lifted/aggregate_cast.rs
+++ b/prusti-encoder/src/encoders/type/lifted/aggregate_cast.rs
@@ -81,9 +81,9 @@ impl TaskEncoder for AggregateSnapArgsCastEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
+        deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref::<AggregateSnapArgsCastEnc>(task_key.clone(), ());
+        deps.emit_output_ref(task_key.clone(), ());
         vir::with_vcx(|vcx| {
             let cast_functions: Vec<Option<PureCast<'vir>>> =
                 match task_key.aggregate_type {

--- a/prusti-encoder/src/encoders/type/lifted/cast.rs
+++ b/prusti-encoder/src/encoders/type/lifted/cast.rs
@@ -1,5 +1,5 @@
 use prusti_rustc_interface::middle::ty;
-use task_encoder::{TaskEncoder, TaskEncoderDependencies, TaskEncoderError};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies, TaskEncoderError, EncodeFullResult};
 use vir::{FunctionIdent, MethodIdent, StmtGen, UnknownArity, VirCtxt};
 
 use super::{
@@ -213,16 +213,7 @@ impl TaskEncoder for CastToEnc<CastTypePure> {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         let output_ref = Self::encode_cast(*task_key, deps);
         deps.emit_output_ref::<Self>(*task_key, output_ref);
         Ok(((), ()))
@@ -243,16 +234,7 @@ impl TaskEncoder for CastToEnc<CastTypeImpure> {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         let output_ref = Self::encode_cast(*task_key, deps);
         deps.emit_output_ref::<Self>(*task_key, output_ref);
         Ok(((), ()))

--- a/prusti-encoder/src/encoders/type/lifted/cast.rs
+++ b/prusti-encoder/src/encoders/type/lifted/cast.rs
@@ -159,14 +159,14 @@ pub struct CastToEnc<T>(std::marker::PhantomData<T>);
 impl<T: CastType + 'static> CastToEnc<T>
 where
     Self: TaskEncoder,
-    RustTyCastersEnc<T>: for<'tcx, 'vir> TaskEncoder<
-        TaskDescription<'tcx> = ty::Ty<'tcx>,
+    RustTyCastersEnc<T>: for<'vir> TaskEncoder<
+        TaskDescription<'vir> = ty::Ty<'vir>,
         OutputFullLocal<'vir> = RustTyGenericCastEncOutput<'vir, Casters<'vir, T>>,
     >,
     TaskEncoderError<RustTyCastersEnc<T>>: Sized,
 {
-    fn encode_cast<'tcx: 'vir, 'vir>(
-        task_key: CastArgs<'tcx>,
+    fn encode_cast<'vir>(
+        task_key: CastArgs<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> GenericCastOutputRef<'vir, T::CastApplicator<'vir>> {
         let expected_is_param = matches!(task_key.expected.kind(), ty::Param(_));
@@ -211,8 +211,8 @@ impl TaskEncoder for CastToEnc<CastTypePure> {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let output_ref = Self::encode_cast(*task_key, deps);
@@ -232,8 +232,8 @@ impl TaskEncoder for CastToEnc<CastTypeImpure> {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let output_ref = Self::encode_cast(*task_key, deps);

--- a/prusti-encoder/src/encoders/type/lifted/cast.rs
+++ b/prusti-encoder/src/encoders/type/lifted/cast.rs
@@ -216,7 +216,7 @@ impl TaskEncoder for CastToEnc<CastTypePure> {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let output_ref = Self::encode_cast(*task_key, deps);
-        deps.emit_output_ref(*task_key, output_ref);
+        deps.emit_output_ref(*task_key, output_ref)?;
         Ok(((), ()))
     }
 }
@@ -237,7 +237,7 @@ impl TaskEncoder for CastToEnc<CastTypeImpure> {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let output_ref = Self::encode_cast(*task_key, deps);
-        deps.emit_output_ref(*task_key, output_ref);
+        deps.emit_output_ref(*task_key, output_ref)?;
         Ok(((), ()))
     }
 }

--- a/prusti-encoder/src/encoders/type/lifted/cast.rs
+++ b/prusti-encoder/src/encoders/type/lifted/cast.rs
@@ -158,6 +158,7 @@ pub struct CastToEnc<T>(std::marker::PhantomData<T>);
 
 impl<T: CastType + 'static> CastToEnc<T>
 where
+    Self: TaskEncoder,
     RustTyCastersEnc<T>: for<'tcx, 'vir> TaskEncoder<
         TaskDescription<'tcx> = ty::Ty<'tcx>,
         OutputFullLocal<'vir> = RustTyGenericCastEncOutput<'vir, Casters<'vir, T>>,
@@ -166,7 +167,7 @@ where
 {
     fn encode_cast<'tcx: 'vir, 'vir>(
         task_key: CastArgs<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> GenericCastOutputRef<'vir, T::CastApplicator<'vir>> {
         let expected_is_param = matches!(task_key.expected.kind(), ty::Param(_));
         let actual_is_param = matches!(task_key.actual.kind(), ty::Param(_));
@@ -212,10 +213,10 @@ impl TaskEncoder for CastToEnc<CastTypePure> {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let output_ref = Self::encode_cast(*task_key, deps);
-        deps.emit_output_ref::<Self>(*task_key, output_ref);
+        deps.emit_output_ref(*task_key, output_ref);
         Ok(((), ()))
     }
 }
@@ -233,10 +234,10 @@ impl TaskEncoder for CastToEnc<CastTypeImpure> {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let output_ref = Self::encode_cast(*task_key, deps);
-        deps.emit_output_ref::<Self>(*task_key, output_ref);
+        deps.emit_output_ref(*task_key, output_ref);
         Ok(((), ()))
     }
 }

--- a/prusti-encoder/src/encoders/type/lifted/cast_functions.rs
+++ b/prusti-encoder/src/encoders/type/lifted/cast_functions.rs
@@ -109,13 +109,12 @@ impl TaskEncoder for CastFunctionsEnc {
             return Ok((&[], ()));
         }
         vir::with_vcx(|vcx| {
-            let domain_ref = deps.require_ref::<DomainEnc>(*ty).unwrap();
-            let generic_ref = deps.require_ref::<GenericEnc>(()).unwrap();
+            let domain_ref = deps.require_ref::<DomainEnc>(*ty)?;
+            let generic_ref = deps.require_ref::<GenericEnc>(())?;
             let self_ty = domain_ref.domain.apply(vcx, []);
             let base_name = &domain_ref.base_name;
             let ty_constructor = deps
-                .require_ref::<TyConstructorEnc>(*ty)
-                .unwrap()
+                .require_ref::<TyConstructorEnc>(*ty)?
                 .ty_constructor;
 
             let make_generic_arg_tys = [self_ty];

--- a/prusti-encoder/src/encoders/type/lifted/cast_functions.rs
+++ b/prusti-encoder/src/encoders/type/lifted/cast_functions.rs
@@ -102,10 +102,10 @@ impl TaskEncoder for CastFunctionsEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         ty: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         if ty.is_generic() {
-            deps.emit_output_ref::<Self>(*ty, CastFunctionsOutputRef::AlreadyGeneric);
+            deps.emit_output_ref(*ty, CastFunctionsOutputRef::AlreadyGeneric);
             return Ok((&[], ()));
         }
         vir::with_vcx(|vcx| {
@@ -140,7 +140,7 @@ impl TaskEncoder for CastFunctionsEnc {
                 self_ty,
             );
 
-            deps.emit_output_ref::<Self>(
+            deps.emit_output_ref(
                 *ty,
                 CastFunctionsOutputRef::CastFunctions {
                     make_generic: make_generic_ident,

--- a/prusti-encoder/src/encoders/type/lifted/cast_functions.rs
+++ b/prusti-encoder/src/encoders/type/lifted/cast_functions.rs
@@ -100,8 +100,8 @@ impl TaskEncoder for CastFunctionsEnc {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        ty: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        ty: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         if ty.is_generic() {

--- a/prusti-encoder/src/encoders/type/lifted/cast_functions.rs
+++ b/prusti-encoder/src/encoders/type/lifted/cast_functions.rs
@@ -1,4 +1,4 @@
-use task_encoder::{TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies, EncodeFullResult};
 use vir::{CallableIdent, FunctionIdent, UnaryArity, UnknownArity};
 
 use crate::encoders::{
@@ -103,16 +103,7 @@ impl TaskEncoder for CastFunctionsEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         ty: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         if ty.is_generic() {
             deps.emit_output_ref::<Self>(*ty, CastFunctionsOutputRef::AlreadyGeneric);
             return Ok((&[], ()));

--- a/prusti-encoder/src/encoders/type/lifted/cast_functions.rs
+++ b/prusti-encoder/src/encoders/type/lifted/cast_functions.rs
@@ -105,7 +105,7 @@ impl TaskEncoder for CastFunctionsEnc {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         if ty.is_generic() {
-            deps.emit_output_ref(*ty, CastFunctionsOutputRef::AlreadyGeneric);
+            deps.emit_output_ref(*ty, CastFunctionsOutputRef::AlreadyGeneric)?;
             return Ok((&[], ()));
         }
         vir::with_vcx(|vcx| {
@@ -145,7 +145,7 @@ impl TaskEncoder for CastFunctionsEnc {
                     make_generic: make_generic_ident,
                     make_concrete: make_concrete_ident,
                 },
-            );
+            )?;
             let make_generic_arg = vcx.mk_local_decl("self", self_ty);
             let make_generic_expr = vcx.mk_local_ex(make_generic_arg.name, make_generic_arg.ty);
 

--- a/prusti-encoder/src/encoders/type/lifted/casters.rs
+++ b/prusti-encoder/src/encoders/type/lifted/casters.rs
@@ -223,10 +223,10 @@ impl TaskEncoder for CastersEnc<CastTypePure> {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         ty: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         if ty.is_generic() {
-            deps.emit_output_ref::<Self>(*ty, CastFunctionsOutputRef::AlreadyGeneric);
+            deps.emit_output_ref(*ty, CastFunctionsOutputRef::AlreadyGeneric);
             return Ok((&[], ()));
         }
         vir::with_vcx(|vcx| {
@@ -262,7 +262,7 @@ impl TaskEncoder for CastersEnc<CastTypePure> {
                 self_ty,
             );
 
-            deps.emit_output_ref::<Self>(
+            deps.emit_output_ref(
                 *ty,
                 CastFunctionsOutputRef::Casters {
                     make_generic: make_generic_ident,
@@ -367,10 +367,10 @@ impl TaskEncoder for CastersEnc<CastTypeImpure> {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         ty: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         if ty.is_generic() {
-            deps.emit_output_ref::<Self>(*ty, CastMethodsOutputRef::AlreadyGeneric);
+            deps.emit_output_ref(*ty, CastMethodsOutputRef::AlreadyGeneric);
             return Ok((&[], ()));
         }
         vir::with_vcx(|vcx| {
@@ -395,7 +395,7 @@ impl TaskEncoder for CastersEnc<CastTypeImpure> {
                 UnknownArity::new(arg_tys),
             );
 
-            deps.emit_output_ref::<Self>(
+            deps.emit_output_ref(
                 *ty,
                 CastMethodsOutputRef::Casters {
                     make_generic: make_generic_ident,

--- a/prusti-encoder/src/encoders/type/lifted/casters.rs
+++ b/prusti-encoder/src/encoders/type/lifted/casters.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use task_encoder::{TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies, EncodeFullResult};
 use vir::{Arity, CallableIdent, FunctionIdent, MethodIdent, TypeData, UnaryArity, UnknownArity};
 
 use crate::encoders::{
@@ -224,16 +224,7 @@ impl TaskEncoder for CastersEnc<CastTypePure> {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         ty: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         if ty.is_generic() {
             deps.emit_output_ref::<Self>(*ty, CastFunctionsOutputRef::AlreadyGeneric);
             return Ok((&[], ()));
@@ -377,16 +368,7 @@ impl TaskEncoder for CastersEnc<CastTypeImpure> {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         ty: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         if ty.is_generic() {
             deps.emit_output_ref::<Self>(*ty, CastMethodsOutputRef::AlreadyGeneric);
             return Ok((&[], ()));

--- a/prusti-encoder/src/encoders/type/lifted/casters.rs
+++ b/prusti-encoder/src/encoders/type/lifted/casters.rs
@@ -221,8 +221,8 @@ impl TaskEncoder for CastersEnc<CastTypePure> {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        ty: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        ty: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         if ty.is_generic() {
@@ -365,8 +365,8 @@ impl TaskEncoder for CastersEnc<CastTypeImpure> {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        ty: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        ty: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         if ty.is_generic() {

--- a/prusti-encoder/src/encoders/type/lifted/func_app_ty_params.rs
+++ b/prusti-encoder/src/encoders/type/lifted/func_app_ty_params.rs
@@ -32,7 +32,7 @@ impl TaskEncoder for LiftedFuncAppTyParamsEnc {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref(*task_key, ());
+        deps.emit_output_ref(*task_key, ())?;
         vir::with_vcx(|vcx| {
             let (monomorphize, substs) = task_key;
             let tys = substs.iter().filter_map(|arg| arg.as_type());

--- a/prusti-encoder/src/encoders/type/lifted/func_app_ty_params.rs
+++ b/prusti-encoder/src/encoders/type/lifted/func_app_ty_params.rs
@@ -28,8 +28,8 @@ impl TaskEncoder for LiftedFuncAppTyParamsEnc {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(*task_key, ());

--- a/prusti-encoder/src/encoders/type/lifted/func_app_ty_params.rs
+++ b/prusti-encoder/src/encoders/type/lifted/func_app_ty_params.rs
@@ -30,9 +30,9 @@ impl TaskEncoder for LiftedFuncAppTyParamsEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
+        deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref::<Self>(*task_key, ());
+        deps.emit_output_ref(*task_key, ());
         vir::with_vcx(|vcx| {
             let (monomorphize, substs) = task_key;
             let tys = substs.iter().filter_map(|arg| arg.as_type());

--- a/prusti-encoder/src/encoders/type/lifted/func_app_ty_params.rs
+++ b/prusti-encoder/src/encoders/type/lifted/func_app_ty_params.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use prusti_rustc_interface::middle::ty::{GenericArgsRef, Ty, TyKind};
-use task_encoder::TaskEncoder;
+use task_encoder::{TaskEncoder, EncodeFullResult};
 
 use super::{
     generic::LiftedGeneric,
@@ -31,16 +31,7 @@ impl TaskEncoder for LiftedFuncAppTyParamsEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref::<Self>(*task_key, ());
         vir::with_vcx(|vcx| {
             let (monomorphize, substs) = task_key;

--- a/prusti-encoder/src/encoders/type/lifted/func_def_ty_params.rs
+++ b/prusti-encoder/src/encoders/type/lifted/func_def_ty_params.rs
@@ -1,6 +1,6 @@
 use prusti_rustc_interface::middle::ty::{self, ParamTy, Ty, TyKind};
 use std::collections::HashSet;
-use task_encoder::TaskEncoder;
+use task_encoder::{TaskEncoder, EncodeFullResult};
 
 use super::generic::{LiftedGeneric, LiftedGenericEnc};
 
@@ -28,16 +28,7 @@ impl TaskEncoder for LiftedTyParamsEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref::<Self>(*task_key, ());
         vir::with_vcx(|vcx| {
             let ty_args = task_key

--- a/prusti-encoder/src/encoders/type/lifted/func_def_ty_params.rs
+++ b/prusti-encoder/src/encoders/type/lifted/func_def_ty_params.rs
@@ -25,8 +25,8 @@ impl TaskEncoder for LiftedTyParamsEnc {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(*task_key, ());

--- a/prusti-encoder/src/encoders/type/lifted/func_def_ty_params.rs
+++ b/prusti-encoder/src/encoders/type/lifted/func_def_ty_params.rs
@@ -27,9 +27,9 @@ impl TaskEncoder for LiftedTyParamsEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
+        deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref::<Self>(*task_key, ());
+        deps.emit_output_ref(*task_key, ());
         vir::with_vcx(|vcx| {
             let ty_args = task_key
                 .iter()

--- a/prusti-encoder/src/encoders/type/lifted/func_def_ty_params.rs
+++ b/prusti-encoder/src/encoders/type/lifted/func_def_ty_params.rs
@@ -29,7 +29,7 @@ impl TaskEncoder for LiftedTyParamsEnc {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref(*task_key, ());
+        deps.emit_output_ref(*task_key, ())?;
         vir::with_vcx(|vcx| {
             let ty_args = task_key
                 .iter()

--- a/prusti-encoder/src/encoders/type/lifted/generic.rs
+++ b/prusti-encoder/src/encoders/type/lifted/generic.rs
@@ -44,8 +44,8 @@ impl TaskEncoder for LiftedGenericEnc {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         with_vcx(|vcx| {

--- a/prusti-encoder/src/encoders/type/lifted/generic.rs
+++ b/prusti-encoder/src/encoders/type/lifted/generic.rs
@@ -46,14 +46,14 @@ impl TaskEncoder for LiftedGenericEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
+        deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         with_vcx(|vcx| {
             let output_ref = vcx.mk_local_decl(
-                task_key.name.as_str(),
+                vcx.alloc_str(task_key.name.as_str()),
                 deps.require_ref::<GenericEnc>(()).unwrap().type_snapshot,
             );
-            deps.emit_output_ref::<Self>(*task_key, LiftedGeneric(output_ref));
+            deps.emit_output_ref(*task_key, LiftedGeneric(output_ref));
             Ok(((), ()))
         })
     }

--- a/prusti-encoder/src/encoders/type/lifted/generic.rs
+++ b/prusti-encoder/src/encoders/type/lifted/generic.rs
@@ -51,7 +51,7 @@ impl TaskEncoder for LiftedGenericEnc {
         with_vcx(|vcx| {
             let output_ref = vcx.mk_local_decl(
                 vcx.alloc_str(task_key.name.as_str()),
-                deps.require_ref::<GenericEnc>(()).unwrap().type_snapshot,
+                deps.require_ref::<GenericEnc>(())?.type_snapshot,
             );
             deps.emit_output_ref(*task_key, LiftedGeneric(output_ref));
             Ok(((), ()))

--- a/prusti-encoder/src/encoders/type/lifted/generic.rs
+++ b/prusti-encoder/src/encoders/type/lifted/generic.rs
@@ -1,5 +1,5 @@
 use prusti_rustc_interface::middle::ty;
-use task_encoder::{OutputRefAny, TaskEncoder};
+use task_encoder::{OutputRefAny, TaskEncoder, EncodeFullResult};
 use vir::with_vcx;
 
 use crate::encoders::GenericEnc;
@@ -47,16 +47,7 @@ impl TaskEncoder for LiftedGenericEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         with_vcx(|vcx| {
             let output_ref = vcx.mk_local_decl(
                 task_key.name.as_str(),

--- a/prusti-encoder/src/encoders/type/lifted/generic.rs
+++ b/prusti-encoder/src/encoders/type/lifted/generic.rs
@@ -53,7 +53,7 @@ impl TaskEncoder for LiftedGenericEnc {
                 vcx.alloc_str(task_key.name.as_str()),
                 deps.require_ref::<GenericEnc>(())?.type_snapshot,
             );
-            deps.emit_output_ref(*task_key, LiftedGeneric(output_ref));
+            deps.emit_output_ref(*task_key, LiftedGeneric(output_ref))?;
             Ok(((), ()))
         })
     }

--- a/prusti-encoder/src/encoders/type/lifted/rust_ty_cast.rs
+++ b/prusti-encoder/src/encoders/type/lifted/rust_ty_cast.rs
@@ -70,14 +70,14 @@ impl<'vir, T> task_encoder::OutputRefAny for RustTyGenericCastEncOutput<'vir, T>
 impl<T: CastType + 'static> RustTyCastersEnc<T>
 where
     Self: TaskEncoder,
-    CastersEnc<T>: for<'vir, 'tcx> TaskEncoder<
-        TaskDescription<'tcx> = MostGenericTy<'tcx>,
+    CastersEnc<T>: for<'vir> TaskEncoder<
+        TaskDescription<'vir> = MostGenericTy<'vir>,
         OutputRef<'vir> = Casters<'vir, T>,
     >,
     TaskEncoderError<CastersEnc<T>>: Sized,
 {
-    fn encode<'tcx: 'vir, 'vir>(
-        task_key: &ty::Ty<'tcx>,
+    fn encode<'vir>(
+        task_key: &ty::Ty<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> RustTyGenericCastEncOutput<'vir, Casters<'vir, T>> {
         with_vcx(|vcx| {
@@ -113,8 +113,8 @@ impl TaskEncoder for RustTyCastersEnc<CastTypePure> {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(*task_key, ());
@@ -137,8 +137,8 @@ impl TaskEncoder for RustTyCastersEnc<CastTypeImpure> {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(*task_key, ());

--- a/prusti-encoder/src/encoders/type/lifted/rust_ty_cast.rs
+++ b/prusti-encoder/src/encoders/type/lifted/rust_ty_cast.rs
@@ -117,7 +117,7 @@ impl TaskEncoder for RustTyCastersEnc<CastTypePure> {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref(*task_key, ());
+        deps.emit_output_ref(*task_key, ())?;
         Ok((Self::encode(task_key, deps), ()))
     }
 }
@@ -141,7 +141,7 @@ impl TaskEncoder for RustTyCastersEnc<CastTypeImpure> {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref(*task_key, ());
+        deps.emit_output_ref(*task_key, ())?;
         Ok((Self::encode(task_key, deps), ()))
     }
 }

--- a/prusti-encoder/src/encoders/type/lifted/rust_ty_cast.rs
+++ b/prusti-encoder/src/encoders/type/lifted/rust_ty_cast.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use prusti_rustc_interface::middle::ty;
-use task_encoder::{TaskEncoder, TaskEncoderError};
+use task_encoder::{TaskEncoder, TaskEncoderError, EncodeFullResult};
 use vir::with_vcx;
 
 use crate::encoders::most_generic_ty::{extract_type_params, MostGenericTy};
@@ -115,16 +115,7 @@ impl TaskEncoder for RustTyCastersEnc<CastTypePure> {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref::<Self>(*task_key, ());
         Ok((Self::encode(task_key, deps), ()))
     }
@@ -148,16 +139,7 @@ impl TaskEncoder for RustTyCastersEnc<CastTypeImpure> {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref::<Self>(*task_key, ());
         Ok((Self::encode(task_key, deps), ()))
     }

--- a/prusti-encoder/src/encoders/type/lifted/rust_ty_cast.rs
+++ b/prusti-encoder/src/encoders/type/lifted/rust_ty_cast.rs
@@ -69,6 +69,7 @@ impl<'vir, T> task_encoder::OutputRefAny for RustTyGenericCastEncOutput<'vir, T>
 
 impl<T: CastType + 'static> RustTyCastersEnc<T>
 where
+    Self: TaskEncoder,
     CastersEnc<T>: for<'vir, 'tcx> TaskEncoder<
         TaskDescription<'tcx> = MostGenericTy<'tcx>,
         OutputRef<'vir> = Casters<'vir, T>,
@@ -77,7 +78,7 @@ where
 {
     fn encode<'tcx: 'vir, 'vir>(
         task_key: &ty::Ty<'tcx>,
-        deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
+        deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> RustTyGenericCastEncOutput<'vir, Casters<'vir, T>> {
         with_vcx(|vcx| {
             let (generic_ty, args) = extract_type_params(vcx.tcx(), *task_key);
@@ -114,9 +115,9 @@ impl TaskEncoder for RustTyCastersEnc<CastTypePure> {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
+        deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref::<Self>(*task_key, ());
+        deps.emit_output_ref(*task_key, ());
         Ok((Self::encode(task_key, deps), ()))
     }
 }
@@ -138,9 +139,9 @@ impl TaskEncoder for RustTyCastersEnc<CastTypeImpure> {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
+        deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref::<Self>(*task_key, ());
+        deps.emit_output_ref(*task_key, ());
         Ok((Self::encode(task_key, deps), ()))
     }
 }

--- a/prusti-encoder/src/encoders/type/lifted/ty.rs
+++ b/prusti-encoder/src/encoders/type/lifted/ty.rs
@@ -131,8 +131,7 @@ impl TaskEncoder for LiftedTyEnc<EncodeGenericsAsLifted> {
         deps.emit_output_ref(*task_key, ());
         with_vcx(|vcx| {
             let result = deps
-                .require_local::<LiftedTyEnc<EncodeGenericsAsParamTy>>(*task_key)
-                .unwrap();
+                .require_local::<LiftedTyEnc<EncodeGenericsAsParamTy>>(*task_key)?;
             let result = result.map(vcx, &mut |g| {
                 deps.require_ref::<LiftedGenericEnc>(g).unwrap()
             });
@@ -169,8 +168,7 @@ impl TaskEncoder for LiftedTyEnc<EncodeGenericsAsParamTy> {
             }
             let (ty_constructor, args) = extract_type_params(vcx.tcx(), *task_key);
             let ty_constructor = deps
-                .require_ref::<TyConstructorEnc>(ty_constructor)
-                .unwrap()
+                .require_ref::<TyConstructorEnc>(ty_constructor)?
                 .ty_constructor;
             let args = args
                 .into_iter()

--- a/prusti-encoder/src/encoders/type/lifted/ty.rs
+++ b/prusti-encoder/src/encoders/type/lifted/ty.rs
@@ -126,9 +126,9 @@ impl TaskEncoder for LiftedTyEnc<EncodeGenericsAsLifted> {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
+        deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref::<Self>(*task_key, ());
+        deps.emit_output_ref(*task_key, ());
         with_vcx(|vcx| {
             let result = deps
                 .require_local::<LiftedTyEnc<EncodeGenericsAsParamTy>>(*task_key)
@@ -160,9 +160,9 @@ impl TaskEncoder for LiftedTyEnc<EncodeGenericsAsParamTy> {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
+        deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref::<Self>(*task_key, ());
+        deps.emit_output_ref(*task_key, ());
         with_vcx(|vcx| {
             if let TyKind::Param(p) = task_key.kind() {
                 return Ok((LiftedTy::Generic(*p), ()));

--- a/prusti-encoder/src/encoders/type/lifted/ty.rs
+++ b/prusti-encoder/src/encoders/type/lifted/ty.rs
@@ -124,8 +124,8 @@ impl TaskEncoder for LiftedTyEnc<EncodeGenericsAsLifted> {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(*task_key, ());
@@ -157,8 +157,8 @@ impl TaskEncoder for LiftedTyEnc<EncodeGenericsAsParamTy> {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(*task_key, ());

--- a/prusti-encoder/src/encoders/type/lifted/ty.rs
+++ b/prusti-encoder/src/encoders/type/lifted/ty.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use prusti_rustc_interface::middle::ty::{self, ParamTy, TyKind};
-use task_encoder::TaskEncoder;
+use task_encoder::{TaskEncoder, EncodeFullResult};
 use vir::{with_vcx, FunctionIdent, UnknownArity};
 
 use crate::encoders::{
@@ -127,16 +127,7 @@ impl TaskEncoder for LiftedTyEnc<EncodeGenericsAsLifted> {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref::<Self>(*task_key, ());
         with_vcx(|vcx| {
             let result = deps
@@ -170,16 +161,7 @@ impl TaskEncoder for LiftedTyEnc<EncodeGenericsAsParamTy> {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref::<Self>(*task_key, ());
         with_vcx(|vcx| {
             if let TyKind::Param(p) = task_key.kind() {

--- a/prusti-encoder/src/encoders/type/lifted/ty.rs
+++ b/prusti-encoder/src/encoders/type/lifted/ty.rs
@@ -128,7 +128,7 @@ impl TaskEncoder for LiftedTyEnc<EncodeGenericsAsLifted> {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref(*task_key, ());
+        deps.emit_output_ref(*task_key, ())?;
         with_vcx(|vcx| {
             let result = deps
                 .require_local::<LiftedTyEnc<EncodeGenericsAsParamTy>>(*task_key)?;
@@ -161,7 +161,7 @@ impl TaskEncoder for LiftedTyEnc<EncodeGenericsAsParamTy> {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref(*task_key, ());
+        deps.emit_output_ref(*task_key, ())?;
         with_vcx(|vcx| {
             if let TyKind::Param(p) = task_key.kind() {
                 return Ok((LiftedTy::Generic(*p), ()));

--- a/prusti-encoder/src/encoders/type/lifted/ty_constructor.rs
+++ b/prusti-encoder/src/encoders/type/lifted/ty_constructor.rs
@@ -55,7 +55,7 @@ impl TaskEncoder for TyConstructorEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
+        deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let generic_ref = deps.require_ref::<GenericEnc>(()).unwrap();
         let mut functions = vec![];
@@ -102,7 +102,7 @@ impl TaskEncoder for TyConstructorEnc {
                     )
                 })
                 .collect::<Vec<_>>();
-            deps.emit_output_ref::<Self>(
+            deps.emit_output_ref(
                 *task_key,
                 TyConstructorEncOutputRef {
                     ty_constructor: type_function_ident,

--- a/prusti-encoder/src/encoders/type/lifted/ty_constructor.rs
+++ b/prusti-encoder/src/encoders/type/lifted/ty_constructor.rs
@@ -53,8 +53,8 @@ impl TaskEncoder for TyConstructorEnc {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let generic_ref = deps.require_ref::<GenericEnc>(())?;

--- a/prusti-encoder/src/encoders/type/lifted/ty_constructor.rs
+++ b/prusti-encoder/src/encoders/type/lifted/ty_constructor.rs
@@ -108,7 +108,7 @@ impl TaskEncoder for TyConstructorEnc {
                     ty_constructor: type_function_ident,
                     ty_param_accessors: vcx.alloc_slice(&ty_accessor_functions),
                 },
-            );
+            )?;
 
             let axiom_qvars = vcx.alloc_slice(&ty_arg_decls);
             let axiom_triggers = vcx.alloc_slice(

--- a/prusti-encoder/src/encoders/type/lifted/ty_constructor.rs
+++ b/prusti-encoder/src/encoders/type/lifted/ty_constructor.rs
@@ -1,4 +1,4 @@
-use task_encoder::{OutputRefAny, TaskEncoder};
+use task_encoder::{OutputRefAny, TaskEncoder, EncodeFullResult};
 use vir::{
     vir_format_identifier, CallableIdent, FunctionIdent, UnaryArity, UnknownArity
 };
@@ -56,16 +56,7 @@ impl TaskEncoder for TyConstructorEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         let generic_ref = deps.require_ref::<GenericEnc>(()).unwrap();
         let mut functions = vec![];
         let mut axioms = vec![];

--- a/prusti-encoder/src/encoders/type/lifted/ty_constructor.rs
+++ b/prusti-encoder/src/encoders/type/lifted/ty_constructor.rs
@@ -57,7 +57,7 @@ impl TaskEncoder for TyConstructorEnc {
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        let generic_ref = deps.require_ref::<GenericEnc>(()).unwrap();
+        let generic_ref = deps.require_ref::<GenericEnc>(())?;
         let mut functions = vec![];
         let mut axioms = vec![];
         vir::with_vcx(|vcx| {

--- a/prusti-encoder/src/encoders/type/predicate.rs
+++ b/prusti-encoder/src/encoders/type/predicate.rs
@@ -198,8 +198,8 @@ impl TaskEncoder for PredicateEnc {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let snap = deps.require_local::<SnapshotEnc>(*task_key)?;

--- a/prusti-encoder/src/encoders/type/predicate.rs
+++ b/prusti-encoder/src/encoders/type/predicate.rs
@@ -2,7 +2,7 @@ use prusti_rustc_interface::{
     abi,
     middle::ty::{self, TyKind},
 };
-use task_encoder::{TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies, EncodeFullResult};
 use vir::{
     add_debug_note, CallableIdent, FunctionIdent, MethodIdent, NullaryArity, PredicateIdent,
     TypeData, UnaryArity, UnknownArity, VirCtxt,
@@ -201,16 +201,7 @@ impl TaskEncoder for PredicateEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         let snap = deps.require_local::<SnapshotEnc>(*task_key).unwrap();
         let generic_output_ref = deps.require_ref::<GenericEnc>(()).unwrap();
         let mut enc = vir::with_vcx(|vcx| {

--- a/prusti-encoder/src/encoders/type/predicate.rs
+++ b/prusti-encoder/src/encoders/type/predicate.rs
@@ -202,8 +202,8 @@ impl TaskEncoder for PredicateEnc {
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        let snap = deps.require_local::<SnapshotEnc>(*task_key).unwrap();
-        let generic_output_ref = deps.require_ref::<GenericEnc>(()).unwrap();
+        let snap = deps.require_local::<SnapshotEnc>(*task_key)?;
+        let generic_output_ref = deps.require_ref::<GenericEnc>(())?;
         let mut enc = vir::with_vcx(|vcx| {
             PredicateEncValues::new(vcx, &snap.base_name, snap.snapshot, snap.generics)
         });
@@ -231,7 +231,7 @@ impl TaskEncoder for PredicateEnc {
                         generics: &[],
                     },
                 );
-                let dep = deps.require_local::<GenericEnc>(()).unwrap();
+                let dep = deps.require_local::<GenericEnc>(())?;
                 vir::with_vcx(|vcx| {
                     let method_assign = mk_method_assign(
                         vcx,
@@ -356,8 +356,7 @@ impl TaskEncoder for PredicateEnc {
 
                 let lifted_ty = deps.require_local::<LiftedTyEnc<EncodeGenericsAsLifted>>(inner).unwrap();
                 let inner = deps
-                    .require_ref::<RustTyPredicatesEnc>(inner)
-                    .unwrap()
+                    .require_ref::<RustTyPredicatesEnc>(inner)?
                     .generic_predicate;
                 Ok((enc.mk_ref(inner, lifted_ty, specifics), ()))
             }

--- a/prusti-encoder/src/encoders/type/predicate.rs
+++ b/prusti-encoder/src/encoders/type/predicate.rs
@@ -200,7 +200,7 @@ impl TaskEncoder for PredicateEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         let snap = deps.require_local::<SnapshotEnc>(*task_key).unwrap();
         let generic_output_ref = deps.require_ref::<GenericEnc>(()).unwrap();
@@ -219,7 +219,7 @@ impl TaskEncoder for PredicateEnc {
                         ])),
                     )
                 });
-                deps.emit_output_ref::<Self>(
+                deps.emit_output_ref(
                     *task_key,
                     PredicateEncOutputRef {
                         ref_to_pred: generic_output_ref.ref_to_pred.as_unknown_arity(),
@@ -256,13 +256,13 @@ impl TaskEncoder for PredicateEnc {
             }
             TyKind::Bool | TyKind::Char | TyKind::Int(_) | TyKind::Uint(_) | TyKind::Float(_) => {
                 let specifics = PredicateEncData::Primitive(snap.specifics.expect_primitive());
-                deps.emit_output_ref::<Self>(*task_key, enc.output_ref(specifics));
+                deps.emit_output_ref(*task_key, enc.output_ref(specifics));
                 Ok((enc.mk_prim(&snap.base_name), ()))
             }
             TyKind::Tuple(tys) => {
                 let snap_data = snap.specifics.expect_structlike();
                 let specifics = enc.mk_struct_ref(None, snap_data);
-                deps.emit_output_ref::<Self>(
+                deps.emit_output_ref(
                     *task_key,
                     enc.output_ref(PredicateEncData::StructLike(specifics)),
                 );
@@ -280,7 +280,7 @@ impl TaskEncoder for PredicateEnc {
                 ty::AdtKind::Struct => {
                     let snap_data = snap.specifics.expect_structlike();
                     let specifics = enc.mk_struct_ref(None, snap_data);
-                    deps.emit_output_ref::<Self>(
+                    deps.emit_output_ref(
                         *task_key,
                         enc.output_ref(PredicateEncData::StructLike(specifics)),
                     );
@@ -307,7 +307,7 @@ impl TaskEncoder for PredicateEnc {
                 }
                 ty::AdtKind::Enum => {
                     let specifics = enc.mk_enum_ref(snap.specifics.expect_enumlike());
-                    deps.emit_output_ref::<Self>(
+                    deps.emit_output_ref(
                         *task_key,
                         enc.output_ref(PredicateEncData::EnumLike(specifics)),
                     );
@@ -339,7 +339,7 @@ impl TaskEncoder for PredicateEnc {
             TyKind::Never => {
                 let specifics = enc.mk_enum_ref(snap.specifics.expect_enumlike());
                 assert!(specifics.is_none());
-                deps.emit_output_ref::<Self>(
+                deps.emit_output_ref(
                     *task_key,
                     enc.output_ref(PredicateEncData::EnumLike(None)),
                 );
@@ -349,7 +349,7 @@ impl TaskEncoder for PredicateEnc {
             &TyKind::Ref(_, inner, m) => {
                 let snap_data = snap.specifics.expect_structlike();
                 let specifics = enc.mk_ref_ref(snap_data, m.is_mut());
-                deps.emit_output_ref::<Self>(
+                deps.emit_output_ref(
                     *task_key,
                     enc.output_ref(PredicateEncData::Ref(specifics)),
                 );
@@ -364,7 +364,7 @@ impl TaskEncoder for PredicateEnc {
             TyKind::Str => {
                 let specifics = enc.mk_struct_ref(None, snap.specifics.expect_structlike());
 
-                deps.emit_output_ref::<Self>(
+                deps.emit_output_ref(
                     *task_key,
                     enc.output_ref(PredicateEncData::StructLike(specifics)),
                 );

--- a/prusti-encoder/src/encoders/type/rust_ty_predicates.rs
+++ b/prusti-encoder/src/encoders/type/rust_ty_predicates.rs
@@ -95,10 +95,9 @@ impl TaskEncoder for RustTyPredicatesEnc {
     ) -> EncodeFullResult<'vir, Self> {
         with_vcx(|vcx| {
             let (generic_ty, args) = extract_type_params(vcx.tcx(), *task_key);
-            let generic_predicate = deps.require_ref::<PredicateEnc>(generic_ty).unwrap();
+            let generic_predicate = deps.require_ref::<PredicateEnc>(generic_ty)?;
             let ty = deps
-                .require_local::<LiftedTyEnc<EncodeGenericsAsLifted>>(*task_key)
-                .unwrap();
+                .require_local::<LiftedTyEnc<EncodeGenericsAsLifted>>(*task_key)?;
             deps.emit_output_ref(
                 *task_key,
                 RustTyPredicatesEncOutputRef {
@@ -107,7 +106,7 @@ impl TaskEncoder for RustTyPredicatesEnc {
                 },
             );
             for arg in args {
-                deps.require_ref::<RustTyPredicatesEnc>(arg).unwrap();
+                deps.require_ref::<RustTyPredicatesEnc>(arg)?;
             }
             Ok(((), ()))
         })

--- a/prusti-encoder/src/encoders/type/rust_ty_predicates.rs
+++ b/prusti-encoder/src/encoders/type/rust_ty_predicates.rs
@@ -89,8 +89,8 @@ impl TaskEncoder for RustTyPredicatesEnc {
     type OutputRef<'vir> = RustTyPredicatesEncOutputRef<'vir>;
     type OutputFullLocal<'vir> = ();
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         with_vcx(|vcx| {

--- a/prusti-encoder/src/encoders/type/rust_ty_predicates.rs
+++ b/prusti-encoder/src/encoders/type/rust_ty_predicates.rs
@@ -104,7 +104,7 @@ impl TaskEncoder for RustTyPredicatesEnc {
                     generic_predicate,
                     ty,
                 },
-            );
+            )?;
             for arg in args {
                 deps.require_ref::<RustTyPredicatesEnc>(arg)?;
             }

--- a/prusti-encoder/src/encoders/type/rust_ty_predicates.rs
+++ b/prusti-encoder/src/encoders/type/rust_ty_predicates.rs
@@ -91,7 +91,7 @@ impl TaskEncoder for RustTyPredicatesEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         with_vcx(|vcx| {
             let (generic_ty, args) = extract_type_params(vcx.tcx(), *task_key);
@@ -99,7 +99,7 @@ impl TaskEncoder for RustTyPredicatesEnc {
             let ty = deps
                 .require_local::<LiftedTyEnc<EncodeGenericsAsLifted>>(*task_key)
                 .unwrap();
-            deps.emit_output_ref::<RustTyPredicatesEnc>(
+            deps.emit_output_ref(
                 *task_key,
                 RustTyPredicatesEncOutputRef {
                     generic_predicate,

--- a/prusti-encoder/src/encoders/type/rust_ty_predicates.rs
+++ b/prusti-encoder/src/encoders/type/rust_ty_predicates.rs
@@ -1,5 +1,5 @@
 use prusti_rustc_interface::middle::ty::{self};
-use task_encoder::{TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies, EncodeFullResult};
 use vir::{with_vcx, Type, TypeData};
 
 use crate::encoders::{PredicateEnc, PredicateEncOutputRef};
@@ -92,16 +92,7 @@ impl TaskEncoder for RustTyPredicatesEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         with_vcx(|vcx| {
             let (generic_ty, args) = extract_type_params(vcx.tcx(), *task_key);
             let generic_predicate = deps.require_ref::<PredicateEnc>(generic_ty).unwrap();

--- a/prusti-encoder/src/encoders/type/rust_ty_snapshots.rs
+++ b/prusti-encoder/src/encoders/type/rust_ty_snapshots.rs
@@ -46,7 +46,7 @@ impl TaskEncoder for RustTySnapshotsEnc {
             deps.emit_output_ref(
                 *task_key,
                 RustTySnapshotsEncOutputRef { generic_snapshot },
-            );
+            )?;
             for arg in args {
                 deps.require_ref::<RustTySnapshotsEnc>(arg)?;
             }

--- a/prusti-encoder/src/encoders/type/rust_ty_snapshots.rs
+++ b/prusti-encoder/src/encoders/type/rust_ty_snapshots.rs
@@ -36,8 +36,8 @@ impl TaskEncoder for RustTySnapshotsEnc {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         with_vcx(|vcx| {

--- a/prusti-encoder/src/encoders/type/rust_ty_snapshots.rs
+++ b/prusti-encoder/src/encoders/type/rust_ty_snapshots.rs
@@ -38,12 +38,12 @@ impl TaskEncoder for RustTySnapshotsEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
+        deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         with_vcx(|vcx| {
             let (generic_ty, args) = extract_type_params(vcx.tcx(), *task_key);
             let generic_snapshot = deps.require_ref::<SnapshotEnc>(generic_ty).unwrap();
-            deps.emit_output_ref::<RustTySnapshotsEnc>(
+            deps.emit_output_ref(
                 *task_key,
                 RustTySnapshotsEncOutputRef { generic_snapshot },
             );

--- a/prusti-encoder/src/encoders/type/rust_ty_snapshots.rs
+++ b/prusti-encoder/src/encoders/type/rust_ty_snapshots.rs
@@ -1,5 +1,5 @@
 use prusti_rustc_interface::middle::ty;
-use task_encoder::TaskEncoder;
+use task_encoder::{TaskEncoder, EncodeFullResult};
 use vir::with_vcx;
 
 use crate::encoders::SnapshotEnc;
@@ -39,16 +39,7 @@ impl TaskEncoder for RustTySnapshotsEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         with_vcx(|vcx| {
             let (generic_ty, args) = extract_type_params(vcx.tcx(), *task_key);
             let generic_snapshot = deps.require_ref::<SnapshotEnc>(generic_ty).unwrap();

--- a/prusti-encoder/src/encoders/type/rust_ty_snapshots.rs
+++ b/prusti-encoder/src/encoders/type/rust_ty_snapshots.rs
@@ -42,17 +42,16 @@ impl TaskEncoder for RustTySnapshotsEnc {
     ) -> EncodeFullResult<'vir, Self> {
         with_vcx(|vcx| {
             let (generic_ty, args) = extract_type_params(vcx.tcx(), *task_key);
-            let generic_snapshot = deps.require_ref::<SnapshotEnc>(generic_ty).unwrap();
+            let generic_snapshot = deps.require_ref::<SnapshotEnc>(generic_ty)?;
             deps.emit_output_ref(
                 *task_key,
                 RustTySnapshotsEncOutputRef { generic_snapshot },
             );
             for arg in args {
-                deps.require_ref::<RustTySnapshotsEnc>(arg).unwrap();
+                deps.require_ref::<RustTySnapshotsEnc>(arg)?;
             }
             let generic_snapshot = deps
-                .require_local::<SnapshotEnc>(generic_ty)
-                .unwrap();
+                .require_local::<SnapshotEnc>(generic_ty)?;
             Ok((RustTySnapshotsEncOutput { generic_snapshot }, ()))
         })
     }

--- a/prusti-encoder/src/encoders/type/snapshot.rs
+++ b/prusti-encoder/src/encoders/type/snapshot.rs
@@ -35,12 +35,12 @@ impl TaskEncoder for SnapshotEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         ty: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         vir::with_vcx(|vcx| {
             let out = deps.require_ref::<DomainEnc>(*ty).unwrap();
             let snapshot = out.domain.apply(vcx, []);
-            deps.emit_output_ref::<Self>(
+            deps.emit_output_ref(
                 *ty,
                 SnapshotEncOutputRef {
                     snapshot,

--- a/prusti-encoder/src/encoders/type/snapshot.rs
+++ b/prusti-encoder/src/encoders/type/snapshot.rs
@@ -1,4 +1,4 @@
-use task_encoder::{TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{TaskEncoder, TaskEncoderDependencies, EncodeFullResult};
 
 use super::{domain::{DomainEnc, DomainEncSpecifics}, lifted::generic::{LiftedGeneric, LiftedGenericEnc}, most_generic_ty::MostGenericTy};
 
@@ -36,16 +36,7 @@ impl TaskEncoder for SnapshotEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         ty: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<
-        (
-            Self::OutputFullLocal<'vir>,
-            Self::OutputFullDependency<'vir>,
-        ),
-        (
-            Self::EncodingError,
-            Option<Self::OutputFullDependency<'vir>>,
-        ),
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         vir::with_vcx(|vcx| {
             let out = deps.require_ref::<DomainEnc>(*ty).unwrap();
             let snapshot = out.domain.apply(vcx, []);

--- a/prusti-encoder/src/encoders/type/snapshot.rs
+++ b/prusti-encoder/src/encoders/type/snapshot.rs
@@ -38,7 +38,7 @@ impl TaskEncoder for SnapshotEnc {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         vir::with_vcx(|vcx| {
-            let out = deps.require_ref::<DomainEnc>(*ty).unwrap();
+            let out = deps.require_ref::<DomainEnc>(*ty)?;
             let snapshot = out.domain.apply(vcx, []);
             deps.emit_output_ref(
                 *ty,
@@ -46,7 +46,7 @@ impl TaskEncoder for SnapshotEnc {
                     snapshot,
                 },
             );
-            let specifics = deps.require_dep::<DomainEnc>(*ty).unwrap();
+            let specifics = deps.require_dep::<DomainEnc>(*ty)?;
             let generics = vcx.alloc_slice(
                 &ty.generics()
                     .into_iter()

--- a/prusti-encoder/src/encoders/type/snapshot.rs
+++ b/prusti-encoder/src/encoders/type/snapshot.rs
@@ -45,7 +45,7 @@ impl TaskEncoder for SnapshotEnc {
                 SnapshotEncOutputRef {
                     snapshot,
                 },
-            );
+            )?;
             let specifics = deps.require_dep::<DomainEnc>(*ty)?;
             let generics = vcx.alloc_slice(
                 &ty.generics()

--- a/prusti-encoder/src/encoders/type/snapshot.rs
+++ b/prusti-encoder/src/encoders/type/snapshot.rs
@@ -33,8 +33,8 @@ impl TaskEncoder for SnapshotEnc {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        ty: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        ty: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         vir::with_vcx(|vcx| {

--- a/prusti-encoder/src/encoders/type/viper_tuple.rs
+++ b/prusti-encoder/src/encoders/type/viper_tuple.rs
@@ -50,9 +50,9 @@ impl TaskEncoder for ViperTupleEnc {
 
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
-        deps: &mut TaskEncoderDependencies<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref::<Self>(*task_key, ());
+        deps.emit_output_ref(*task_key, ());
         if *task_key == 1 {
             Ok((ViperTupleEncOutput { tuple: None }, ()))
         } else {

--- a/prusti-encoder/src/encoders/type/viper_tuple.rs
+++ b/prusti-encoder/src/encoders/type/viper_tuple.rs
@@ -1,6 +1,7 @@
 use task_encoder::{
     TaskEncoder,
     TaskEncoderDependencies,
+    EncodeFullResult,
 };
 
 use super::{domain::{DomainDataStruct, DomainEnc}, most_generic_ty::MostGenericTy};
@@ -50,13 +51,7 @@ impl TaskEncoder for ViperTupleEnc {
     fn do_encode_full<'tcx: 'vir, 'vir>(
         task_key: &Self::TaskKey<'tcx>,
         deps: &mut TaskEncoderDependencies<'vir>,
-    ) -> Result<(
-        Self::OutputFullLocal<'vir>,
-        Self::OutputFullDependency<'vir>,
-    ), (
-        Self::EncodingError,
-        Option<Self::OutputFullDependency<'vir>>,
-    )> {
+    ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref::<Self>(*task_key, ());
         if *task_key == 1 {
             Ok((ViperTupleEncOutput { tuple: None }, ()))

--- a/prusti-encoder/src/encoders/type/viper_tuple.rs
+++ b/prusti-encoder/src/encoders/type/viper_tuple.rs
@@ -52,7 +52,7 @@ impl TaskEncoder for ViperTupleEnc {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref(*task_key, ());
+        deps.emit_output_ref(*task_key, ())?;
         if *task_key == 1 {
             Ok((ViperTupleEncOutput { tuple: None }, ()))
         } else {

--- a/prusti-encoder/src/encoders/type/viper_tuple.rs
+++ b/prusti-encoder/src/encoders/type/viper_tuple.rs
@@ -56,7 +56,7 @@ impl TaskEncoder for ViperTupleEnc {
         if *task_key == 1 {
             Ok((ViperTupleEncOutput { tuple: None }, ()))
         } else {
-            let ret = deps.require_dep::<DomainEnc>(MostGenericTy::tuple(*task_key)).unwrap();
+            let ret = deps.require_dep::<DomainEnc>(MostGenericTy::tuple(*task_key))?;
             Ok((ViperTupleEncOutput { tuple: Some(ret.expect_structlike()) }, ()))
         }
     }

--- a/prusti-encoder/src/encoders/type/viper_tuple.rs
+++ b/prusti-encoder/src/encoders/type/viper_tuple.rs
@@ -48,8 +48,8 @@ impl TaskEncoder for ViperTupleEnc {
         *task
     }
 
-    fn do_encode_full<'tcx: 'vir, 'vir>(
-        task_key: &Self::TaskKey<'tcx>,
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(*task_key, ());

--- a/prusti-encoder/src/lib.rs
+++ b/prusti-encoder/src/lib.rs
@@ -52,7 +52,7 @@ pub fn test_entrypoint<'tcx>(
                 }).unwrap_or_default();
 
                 if !(is_trusted && is_pure) {
-                    let res = MirPolyImpureEnc::encode(def_id);
+                    let res = MirPolyImpureEnc::encode(def_id, false);
                     assert!(res.is_ok());
                 }
             }


### PR DESCRIPTION
The task encoder framework now supports cyclic dependencies (better).

Previously, requesting the same task key that is already higher up the call stack would crash with a "cyclic error". There are situations (as happened with a recursive type) where this is not good enough.

Now, the repeated request will restart the encoder. The inner invocation should be able to progress further due to the intermediate dependency calls, since additional output refs will be available. The outer invocation will be aborted. This may result in some data being allocated multiple times, but it is hard to measure the cost here. However, the overhead in implementation is minor: `deps.emit_ouput_ref` and any `deps.require_*` call simply needs to be handled with a try operator `?` to propagate errors.

Other changes:

- There is now a type alias for the return type of `do_encode_full`, called `EncodeFullResult<'vir, E>`, where the generic type parameter is the encoder itself.
- Got rid of the `'tcx` lifetime, `'vir` suffices.