### PR TITLE
Collect postconditions for async fns

### DIFF
--- a/prusti-contracts/prusti-contracts-proc-macros/src/lib.rs
+++ b/prusti-contracts/prusti-contracts-proc-macros/src/lib.rs
@@ -24,6 +24,12 @@ pub fn ensures(_attr: TokenStream, tokens: TokenStream) -> TokenStream {
 
 #[cfg(not(feature = "prusti"))]
 #[proc_macro_attribute]
+pub fn async_invariant(_attr: TokenStream, tokens: TokenStream) -> TokenStream {
+    tokens
+}
+
+#[cfg(not(feature = "prusti"))]
+#[proc_macro_attribute]
 pub fn after_expiry(_attr: TokenStream, tokens: TokenStream) -> TokenStream {
     tokens
 }
@@ -152,6 +158,12 @@ pub fn requires(attr: TokenStream, tokens: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn ensures(attr: TokenStream, tokens: TokenStream) -> TokenStream {
     rewrite_prusti_attributes(SpecAttributeKind::Ensures, attr.into(), tokens.into()).into()
+}
+
+#[cfg(feature = "prusti")]
+#[proc_macro_attribute]
+pub fn async_invariant(attr: TokenStream, tokens: TokenStream) -> TokenStream {
+    rewrite_prusti_attributes(SpecAttributeKind::AsyncInvariant, attr.into(), tokens.into()).into()
 }
 
 #[cfg(feature = "prusti")]

--- a/prusti-contracts/prusti-contracts-proc-macros/src/lib.rs
+++ b/prusti-contracts/prusti-contracts-proc-macros/src/lib.rs
@@ -130,6 +130,12 @@ pub fn body_variant(_tokens: TokenStream) -> TokenStream {
     TokenStream::new()
 }
 
+#[cfg(not(feature = "prusti"))]
+#[proc_macro]
+pub fn suspension_point(tokens: TokenStream) -> TokenStream {
+    tokens
+}
+
 // ----------------------
 // --- PRUSTI ENABLED ---
 
@@ -271,6 +277,12 @@ pub fn terminates(attr: TokenStream, tokens: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn body_variant(tokens: TokenStream) -> TokenStream {
     prusti_specs::body_variant(tokens.into()).into()
+}
+
+#[cfg(feature = "prusti")]
+#[proc_macro]
+pub fn suspension_point(tokens: TokenStream) -> TokenStream {
+    prusti_specs::suspension_point(tokens.into()).into()
 }
 
 // Ensure that you've also crated a transparent `#[cfg(not(feature = "prusti"))]`

--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -345,8 +345,9 @@ pub fn old<T>(arg: T) -> T {
     arg
 }
 
-pub fn suspension_point_on_exit_marker<L, T>(_label: L, _closures: T) {}
-pub fn suspension_point_on_entry_marker<L, T>(_label: L, _closures: T) {}
+pub fn suspension_point_on_exit_marker<T>(_label: u32, _closures: T) {}
+
+pub fn suspension_point_on_entry_marker<T>(_label: u32, _closures: T) {}
 
 /// Universal quantifier.
 ///

--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -69,6 +69,9 @@ pub use prusti_contracts_proc_macros::body_variant;
 /// A macro to annotate suspension points inside async constructs
 pub use prusti_contracts_proc_macros::suspension_point;
 
+/// A macro for writing async invariants on an async function
+pub use prusti_contracts_proc_macros::async_invariant;
+
 #[cfg(not(feature = "prusti"))]
 mod private {
     use core::marker::PhantomData;

--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -66,6 +66,9 @@ pub use prusti_contracts_proc_macros::terminates;
 /// A macro to annotate body variant of a loop to prove termination
 pub use prusti_contracts_proc_macros::body_variant;
 
+/// A macro to annotate suspension points inside async constructs
+pub use prusti_contracts_proc_macros::suspension_point;
+
 #[cfg(not(feature = "prusti"))]
 mod private {
     use core::marker::PhantomData;
@@ -338,6 +341,9 @@ pub fn before_expiry<T>(arg: T) -> T {
 pub fn old<T>(arg: T) -> T {
     arg
 }
+
+pub fn suspension_point_on_exit_marker<L, T>(_label: L, _closures: T) {}
+pub fn suspension_point_on_entry_marker<L, T>(_label: L, _closures: T) {}
 
 /// Universal quantifier.
 ///

--- a/prusti-contracts/prusti-specs/src/lib.rs
+++ b/prusti-contracts/prusti-specs/src/lib.rs
@@ -536,7 +536,7 @@ pub fn suspension_point(tokens: TokenStream) -> TokenStream {
     };
     let future = &await_expr.base;
 
-    let mut label: Option<usize> = None;
+    let mut label: Option<u32> = None;
     let mut on_exit: Vec<TokenStream> = Vec::new();
     let mut on_entry: Vec<TokenStream> = Vec::new();
 
@@ -567,7 +567,7 @@ pub fn suspension_point(tokens: TokenStream) -> TokenStream {
             else {
                 return syn::Error::new(
                     attr_span,
-                    "expected group with a single integer as label",
+                    "expected group with a single positive integer as label",
                 ).to_compile_error();
             };
             let [proc_macro2::TokenTree::Literal(lit)] =
@@ -575,13 +575,19 @@ pub fn suspension_point(tokens: TokenStream) -> TokenStream {
             else {
                 return syn::Error::new(
                     attr_span,
-                    "expected single integer as label",
+                    "expected single positive integer as label",
                 ).to_compile_error();
             };
-            let lbl_num: usize = lit
+            let lbl_num: u32 = lit
                 .to_string()
                 .parse()
-                .expect("expected single integer as label");
+                .expect("expected single positive integer as label");
+            if lbl_num == 0 {
+                return syn::Error::new(
+                    attr_span,
+                    "suspension-point label must be a positive integer",
+                ).to_compile_error();
+            }
             if label.replace(lbl_num).is_some() {
                 return syn::Error::new(
                     attr_span,

--- a/prusti-contracts/prusti-specs/src/lib.rs
+++ b/prusti-contracts/prusti-specs/src/lib.rs
@@ -495,6 +495,7 @@ pub fn suspension_point(tokens: TokenStream) -> TokenStream {
         // TODO: more precise error message with span?
         panic!("suspension-point must contain a single await-expression");
     };
+    let future = &await_expr.base;
 
     let mut label: Option<usize> = None;
     let mut on_exit: Vec<TokenStream> = Vec::new();
@@ -579,9 +580,10 @@ pub fn suspension_point(tokens: TokenStream) -> TokenStream {
     await_expr.attrs = Vec::new();
     quote_spanned! { await_expr.span()=>
         {
+            let fut = #future;
             #[allow(unused_parens)]
             ::prusti_contracts::suspension_point_on_exit_marker(#label, (#(#on_exit),*,));
-            let res = #await_expr;
+            let res = fut.await;
             #[allow(unused_parens)]
             ::prusti_contracts::suspension_point_on_entry_marker(#label, (#(#on_entry),*,));
             res

--- a/prusti-contracts/prusti-specs/src/lib.rs
+++ b/prusti-contracts/prusti-specs/src/lib.rs
@@ -580,10 +580,10 @@ pub fn suspension_point(tokens: TokenStream) -> TokenStream {
     quote_spanned! { await_expr.span()=>
         {
             #[allow(unused_parens)]
-            ::prusti_contracts::suspension_point_on_exit_marker(#label, (#(#on_exit),*));
+            ::prusti_contracts::suspension_point_on_exit_marker(#label, (#(#on_exit),*,));
             let res = #await_expr;
             #[allow(unused_parens)]
-            ::prusti_contracts::suspension_point_on_entry_marker(#label, (#(#on_entry),*));
+            ::prusti_contracts::suspension_point_on_entry_marker(#label, (#(#on_entry),*,));
             res
         }
     }

--- a/prusti-contracts/prusti-specs/src/lib.rs
+++ b/prusti-contracts/prusti-specs/src/lib.rs
@@ -70,8 +70,6 @@ fn extract_prusti_attributes(
                 let tokens = match attr_kind {
                     SpecAttributeKind::Requires
                     | SpecAttributeKind::Ensures
-                    // technically, this won't appear as such at this stage
-                    | SpecAttributeKind::AsyncEnsures
                     | SpecAttributeKind::AfterExpiry
                     | SpecAttributeKind::AssertOnExpiry
                     | SpecAttributeKind::RefineSpec => {
@@ -83,6 +81,10 @@ fn extract_prusti_attributes(
                         assert!(iter.next().is_none(), "Unexpected shape of an attribute.");
                         group.stream()
                     }
+                    // these cannot appear here, as postconditions are only marked as async
+                    // at a later stage
+                    SpecAttributeKind::AsyncEnsures =>
+                        unreachable!("SpecAttributeKind::AsyncEnsures should not appear at this stage"),
                     // Nothing to do for attributes without arguments.
                     SpecAttributeKind::Pure
                     | SpecAttributeKind::Terminates

--- a/prusti-contracts/prusti-specs/src/spec_attribute_kind.rs
+++ b/prusti-contracts/prusti-specs/src/spec_attribute_kind.rs
@@ -19,6 +19,7 @@ pub enum SpecAttributeKind {
     PrintCounterexample = 11,
     Verified = 12,
     AsyncEnsures = 13,
+    AsyncInvariant = 14,
 }
 
 impl TryFrom<String> for SpecAttributeKind {
@@ -38,6 +39,7 @@ impl TryFrom<String> for SpecAttributeKind {
             "model" => Ok(SpecAttributeKind::Model),
             "print_counterexample" => Ok(SpecAttributeKind::PrintCounterexample),
             "verified" => Ok(SpecAttributeKind::Verified),
+            "async_invariant" => Ok(SpecAttributeKind::AsyncInvariant),
             _ => Err(name),
         }
     }

--- a/prusti-contracts/prusti-specs/src/spec_attribute_kind.rs
+++ b/prusti-contracts/prusti-specs/src/spec_attribute_kind.rs
@@ -18,6 +18,7 @@ pub enum SpecAttributeKind {
     Terminates = 10,
     PrintCounterexample = 11,
     Verified = 12,
+    AsyncEnsures = 13,
 }
 
 impl TryFrom<String> for SpecAttributeKind {

--- a/prusti-contracts/prusti-specs/src/specifications/common.rs
+++ b/prusti-contracts/prusti-specs/src/specifications/common.rs
@@ -56,6 +56,9 @@ pub struct SpecificationId(Uuid);
 pub enum SpecIdRef {
     Precondition(SpecificationId),
     Postcondition(SpecificationId),
+    AsyncPostcondition(SpecificationId),
+    AsyncStubPostcondition(SpecificationId),
+    AsyncInvariant(SpecificationId),
     Purity(SpecificationId),
     Pledge {
         lhs: Option<SpecificationId>,

--- a/prusti-interface/src/specs/mod.rs
+++ b/prusti-interface/src/specs/mod.rs
@@ -211,7 +211,6 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
                 .get_mut(&parent_id.to_def_id())
                 .expect("async parent must have entry in DefSpecMap")
                 .set_proc_kind(ProcedureKind::AsyncConstructor);
-            println!("Marking:\n\t* {local_id:?} as Poll\n\t* {parent_id:?} as Constructor\n");
 
             // the spec is then essentially inherited from the parent,
             // but for now, only postconditions and trusted are allowed

--- a/prusti-interface/src/specs/mod.rs
+++ b/prusti-interface/src/specs/mod.rs
@@ -37,11 +37,10 @@ use crate::specs::{
 };
 use prusti_specs::specifications::common::SpecificationId;
 
+
 #[derive(Debug)]
 struct ProcedureSpecRefs {
     spec_id_refs: Vec<SpecIdRef>,
-    async_post_spec_id_refs: Vec<SpecIdRef>,
-    async_stub_post_spec_id_refs: Vec<SpecIdRef>,
     pure: bool,
     abstract_predicate: bool,
     trusted: bool,
@@ -156,6 +155,12 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
                             self.env,
                         );
                     }
+                    // both async postconditions and async invariants are not added to the method
+                    // they were attached to (which ends up being the future constructor) but to
+                    // the poll method, which is determined elsewhere
+                    SpecIdRef::AsyncPostcondition(_)
+                    | SpecIdRef::AsyncStubPostcondition(_)
+                    | SpecIdRef::AsyncInvariant(_) => {},
                     SpecIdRef::Purity(spec_id) => {
                         spec.add_purity(*self.spec_functions.get(spec_id).unwrap(), self.env);
                     }
@@ -198,7 +203,8 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
             }
         }
 
-        // add postconditions to all async fn poll-methods
+        // attach async specifications to the future's poll-methods instead of the future
+        // constructor
         for (local_id, parent_id) in self.async_parent.iter() {
             // look up parent's spec and skip this method if the parent doesn't have one
             let Some(parent_spec) = self.procedure_specs.get(parent_id) else {
@@ -218,23 +224,20 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
             spec.set_proc_kind(ProcedureKind::AsyncPoll);
             spec.set_kind(parent_spec.into());
             spec.set_trusted(parent_spec.trusted);
-            for postcondition in &parent_spec.async_post_spec_id_refs {
-                let SpecIdRef::Postcondition(spec_id) = postcondition else {
-                    panic!("only postconditions allowed here");
-                };
-                spec.add_postcondition(
-                    *self.spec_functions.get(spec_id).unwrap(),
-                    self.env
-                );
-            }
-            for stub_postcondition in &parent_spec.async_stub_post_spec_id_refs {
-                let SpecIdRef::Postcondition(spec_id) = stub_postcondition else {
-                    panic!("only postconditions allowed here");
-                };
-                spec.add_async_stub_postcondition(
-                    *self.spec_functions.get(spec_id).unwrap(),
-                    self.env
-                );
+            for spec_id_ref in &parent_spec.spec_id_refs {
+                match spec_id_ref {
+                    SpecIdRef::AsyncPostcondition(spec_id) => {
+                        spec.add_postcondition(*self.spec_functions.get(spec_id).unwrap(), self.env);
+                    }
+                    SpecIdRef::AsyncStubPostcondition(spec_id) => {
+                        spec.add_async_stub_postcondition(*self.spec_functions.get(spec_id).unwrap(), self.env);
+                    }
+                    SpecIdRef::AsyncInvariant(spec_id) => {
+                        spec.add_async_invariant(*self.spec_functions.get(spec_id).unwrap(), self.env);
+                    }
+                    // all other spec items should stay attached to the original method
+                    _ => {},
+                }
             }
             // poll methods should not already be covered by the existing code,
             // as they cannot be annotated by the user
@@ -433,14 +436,21 @@ fn get_procedure_spec_ids(def_id: DefId, attrs: &[ast::Attribute]) -> Option<Pro
             .into_iter()
             .map(|raw_spec_id| SpecIdRef::Postcondition(parse_spec_id(raw_spec_id, def_id))),
     );
-    let async_post_spec_id_refs: Vec<_> = read_prusti_attrs("async_post_spec_id_ref", attrs)
-        .into_iter()
-        .map(|raw_spec_id| SpecIdRef::Postcondition(parse_spec_id(raw_spec_id, def_id)))
-        .collect();
-    let async_stub_post_spec_id_refs: Vec<_> = read_prusti_attrs("async_stub_post_spec_id_ref", attrs)
-        .into_iter()
-        .map(|raw_spec_id| SpecIdRef::Postcondition(parse_spec_id(raw_spec_id, def_id)))
-        .collect();
+    spec_id_refs.extend(
+        read_prusti_attrs("async_post_spec_id_ref", attrs)
+            .into_iter()
+            .map(|raw_spec_id| SpecIdRef::AsyncPostcondition(parse_spec_id(raw_spec_id, def_id))),
+    );
+    spec_id_refs.extend(
+         read_prusti_attrs("async_stub_post_spec_id_ref", attrs)
+            .into_iter()
+            .map(|raw_spec_id| SpecIdRef::AsyncStubPostcondition(parse_spec_id(raw_spec_id, def_id)))
+    );
+    spec_id_refs.extend(
+        read_prusti_attrs("async_inv_spec_id_ref", attrs)
+            .into_iter()
+            .map(|raw_spec_id| SpecIdRef::AsyncInvariant(parse_spec_id(raw_spec_id, def_id)))
+    );
     spec_id_refs.extend(
         read_prusti_attrs("pure_spec_id_ref", attrs)
             .into_iter()
@@ -489,11 +499,9 @@ fn get_procedure_spec_ids(def_id: DefId, attrs: &[ast::Attribute]) -> Option<Pro
         || (!is_predicate && config::opt_in_verification() && !has_prusti_attr(attrs, "verified"));
     let abstract_predicate = has_abstract_predicate_attr(attrs);
 
-    if abstract_predicate || pure || trusted || !spec_id_refs.is_empty() || !async_post_spec_id_refs.is_empty() {
+    if abstract_predicate || pure || trusted || !spec_id_refs.is_empty() {
         Some(ProcedureSpecRefs {
             spec_id_refs,
-            async_post_spec_id_refs,
-            async_stub_post_spec_id_refs,
             pure,
             abstract_predicate,
             trusted,


### PR DESCRIPTION
Create two specification functions for postconditions on async fn (one for the poll implementation and a wrapped one for the poll call stub) and collect them into the spec-graph.