### PR TITLE
Add type parameters to pure make_generic method for consistency

### DIFF
--- a/prusti-encoder/src/encoders/type/lifted/cast.rs
+++ b/prusti-encoder/src/encoders/type/lifted/cast.rs
@@ -192,7 +192,7 @@ where
                 .require_local::<RustTyCastersEnc<T>>(task_key.actual)
                 .unwrap();
             if let CastersEncOutputRef::Casters { make_generic, .. } = generic_cast.cast {
-                GenericCastOutputRef::Cast(Cast::new(T::to_generic_applicator(make_generic), &[]))
+                GenericCastOutputRef::Cast(Cast::new(T::to_generic_applicator(make_generic), generic_cast.ty_args))
             } else {
                 unreachable!()
             }

--- a/prusti-encoder/src/encoders/type/lifted/rust_ty_cast.rs
+++ b/prusti-encoder/src/encoders/type/lifted/rust_ty_cast.rs
@@ -61,7 +61,7 @@ impl<'vir> RustTyGenericCastEncOutput<'vir, CastFunctionsOutputRef<'vir>> {
         vcx: &'vir vir::VirCtxt<'tcx>,
         snap: vir::ExprGen<'vir, Curr, Next>,
     ) -> vir::ExprGen<'vir, Curr, Next> {
-        CastTypePure::cast_to_generic_if_necessary(&self.cast, vcx, snap)
+        CastTypePure::cast_to_generic_if_necessary(&self.cast, vcx, snap, self.ty_args)
     }
 }
 


### PR DESCRIPTION
This changes the `make_generic` casting functions in pure contexts to also take the casted type's type parameters as additional arguments in order to match the other casting functions. This way, the casters using these functions can continue not distinguishing between the type of cast (generic or concrete) and the context (pure or impure), which otherwise leads to a signature mismatch when casting to generic in a pure context.