### PR TITLE
Wrap fold result for GotoIf in Seqn

### DIFF
--- a/prusti-viper/src/lib.rs
+++ b/prusti-viper/src/lib.rs
@@ -322,14 +322,15 @@ impl<'vir, 'v> ToViperVec<'vir, 'v> for vir::GotoIf<'vir> {
                 target.statements.iter()
                     .for_each(|v| vec_then.push(v.to_viper(ctx)));
                 vec_then.push(ctx.ast.goto(&target.label.name()));
-                ctx.ast.if_stmt(
+                let stmt = ctx.ast.if_stmt(
                     ctx.ast.eq_cmp(
                         value,
                         target.value.to_viper(ctx),
                     ),
                     ctx.ast.seqn(&vec_then, &[]),
                     else_,
-                )
+                );
+                ctx.ast.seqn(&[stmt], &[])
             }))
     }
 }


### PR DESCRIPTION
This avoids a crash when folding more than two `GotoIf` arms to a single statement, as the `if_stmt` method requires both of its branches to be `Seqn`'s, so the fold's result needs to be wrapped for potential further iterations.