### PR TITLE
WIP: type encoder cleanup

### DIFF
--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -668,7 +668,9 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
 
                         match ty.generic_predicate.get_enumlike().filter(|_| place_ty.variant_index.is_none()) {
                             Some(el) => {
-                                let discr_expr = self.vcx.mk_field_expr(place_expr, el.as_ref().unwrap().discr);
+                                let discr_ty = place_ty.ty.discriminant_ty(self.vcx.tcx());
+                                let discr_ty_out = self.deps.require_ref::<RustTyPredicatesEnc>(discr_ty).unwrap();
+                                let discr_expr = discr_ty_out.ref_to_snap(self.vcx, el.as_ref().unwrap().discr.apply(self.vcx, [place_expr]));
                                 self.vcx.mk_unfolding_expr(ty.ref_to_pred_app(self.vcx, place_expr, Some(self.vcx.mk_wildcard())), discr_expr)
                             }
                             None => {

--- a/prusti-encoder/src/encoders/type/domain.rs
+++ b/prusti-encoder/src/encoders/type/domain.rs
@@ -9,7 +9,7 @@ use prusti_rustc_interface::{
 };
 use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 use vir::{
-    BinaryArity, CallableIdent, DomainAxiomData, DomainFunction, DomainFunctionData, DomainIdent, DomainParamData, FunctionIdent, NullaryArityAny, ToKnownArity, UnaryArity, UnknownArity
+    BinaryArity, CallableIdent, DomainAxiomData, DomainFunctionData, DomainIdent, DomainParamData, FunctionIdent, NullaryArityAny, UnaryArity, UnknownArity
 };
 
 /// You probably never want to use this, use `SnapshotEnc` instead.
@@ -33,6 +33,13 @@ pub struct DomainDataPrim<'vir> {
     pub snap_to_prim: FunctionIdent<'vir, UnaryArity<'vir>>,
     /// Viper primitive value as argument. Returns domain.
     pub prim_to_snap: FunctionIdent<'vir, UnaryArity<'vir>>,
+}
+#[derive(Clone, Copy, Debug)]
+pub struct DomainDataRef<'vir> {
+    /// Construct domain from a `Ref` value.
+    pub snap_to_prim: FunctionIdent<'vir, UnaryArity<'vir>>,
+    /// Function to access the referee.
+    pub deref_access: FunctionIdent<'vir, UnaryArity<'vir>>,
 }
 #[derive(Clone, Copy, Debug)]
 pub struct DomainDataStruct<'vir> {
@@ -71,6 +78,7 @@ pub enum DiscrBounds<'vir> {
 pub enum DomainEncSpecifics<'vir> {
     Param,
     Primitive(DomainDataPrim<'vir>),
+    Ref(DomainDataRef<'vir>),
     // structs, tuples
     StructLike(DomainDataStruct<'vir>),
     EnumLike(Option<DomainDataEnum<'vir>>),
@@ -80,7 +88,7 @@ pub enum DomainEncSpecifics<'vir> {
 pub struct DomainEncOutputRef<'vir> {
     pub base_name: String,
     pub domain: vir::DomainIdent<'vir, NullaryArityAny<'vir, DomainParamData<'vir>>>,
-    ty_param_accessors: &'vir [FunctionIdent<'vir, UnaryArity<'vir>>],
+    pub(super) ty_param_accessors: &'vir [FunctionIdent<'vir, UnaryArity<'vir>>],
     /// Returns the Viper representation of the type of a snapshot-encoded value
     pub typeof_function: FunctionIdent<'vir, UnaryArity<'vir>>,
 }
@@ -100,13 +108,8 @@ impl<'vir> DomainEncOutputRef<'vir> {
 
 impl<'vir> task_encoder::OutputRefAny for DomainEncOutputRef<'vir> {}
 
-use crate::encoders::GenericEnc;
-
 use super::{
-    lifted::{
-        ty::{EncodeGenericsAsParamTy, LiftedTy, LiftedTyEnc},
-        ty_constructor::{TyConstructorEnc, TyConstructorEncOutputRef},
-    },
+    lifted::ty::{EncodeGenericsAsParamTy, LiftedTy, LiftedTyEnc},
     most_generic_ty::{extract_type_params, MostGenericTy},
     rust_ty_snapshots::RustTySnapshotsEnc,
 };
@@ -140,179 +143,23 @@ impl TaskEncoder for DomainEnc {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         vir::with_vcx(|vcx| {
-            let base_name = task_key.get_vir_base_name(vcx);
-            let ty_kind = task_key.kind();
             let mut builder = DomainBuilder::new(vcx);
-            match ty_kind {
+            let specifics = match task_key.kind() {
                 TyKind::Bool
                 | TyKind::Char
                 | TyKind::Int(_)
                 | TyKind::Uint(_)
-                | TyKind::Float(_) => {
-                    let specifics = super::kinds::primitive::domain(*task_key, deps, &mut builder)?;
-                    Ok((Some(builder.build()), specifics))
-
-                    /*
-                    let prim_type = match ty_kind {
-                        TyKind::Bool => &vir::TypeData::Bool,
-                        TyKind::Int(_) => &vir::TypeData::Int,
-                        TyKind::Uint(_) => &vir::TypeData::Int,
-                        _ => todo!(),
-                    };
-
-                    let mut enc = DomainEncData::new(vcx, task_key, vec![], deps);
-                    enc.deps
-                        .emit_output_ref(*task_key, enc.output_ref(base_name))?;
-                    let specifics = enc.mk_prim_specifics(task_key.ty(), prim_type);
-                    Ok((Some(enc.finalize(task_key)), specifics))
-                    */
-                }
-                TyKind::Closure(_def_id, args) => {
-                    let cl_args = args.as_closure();
-                    let params = cl_args.parent_args();
-                    let generics = params
-                        .iter()
-                        .filter_map(|p| p.as_type())
-                        .map(|ty| {
-                            deps.require_local::<LiftedTyEnc<EncodeGenericsAsParamTy>>(ty)
-                                .unwrap()
-                                .expect_generic()
-                        })
-                        .collect();
-                    let fields = cl_args
-                        .upvar_tys()
-                        .iter()
-                        .map(|ty| FieldTy::from_ty(vcx, deps, ty))
-                        .collect::<Result<Vec<_>, _>>()?;
-                    let mut enc = DomainEncData::new(vcx, task_key, generics, deps);
-                    enc.deps
-                        .emit_output_ref(*task_key, enc.output_ref(base_name))?;
-                    let specifics = enc.mk_struct_specifics(fields);
-                    Ok((Some(enc.finalize(task_key)), specifics))
-                }
-                TyKind::Adt(adt, params) => {
-                    let generics = params
-                        .iter()
-                        .filter_map(|p| p.as_type())
-                        .map(|ty| {
-                            deps.require_local::<LiftedTyEnc<EncodeGenericsAsParamTy>>(ty)
-                                .unwrap()
-                                .expect_generic()
-                        })
-                        .collect();
-                    let mut enc = DomainEncData::new(vcx, task_key, generics, deps);
-                    enc.deps
-                        .emit_output_ref(*task_key, enc.output_ref(base_name))?;
-                    match adt.adt_kind() {
-                        ty::AdtKind::Struct => {
-                            let fields = if !adt.is_box() {
-                                let variant = adt.non_enum_variant();
-                                enc.mk_field_tys(variant, params)?
-                            } else {
-                                // Box special case (this should be replaced by an
-                                // extern spec in the future)
-                                vec![FieldTy {
-                                    ty: enc.deps.require_ref::<GenericEnc>(())?.param_snapshot,
-                                    rust_ty_data: None,
-                                }]
-                            };
-                            let specifics = enc.mk_struct_specifics(fields);
-                            Ok((Some(enc.finalize(task_key)), specifics))
-                        }
-                        ty::AdtKind::Enum => {
-                            let variants: Vec<_> = adt
-                                .discriminants(vcx.tcx())
-                                .map(|(v, d)| {
-                                    let variant = adt.variant(v);
-                                    let field_tys = enc.mk_field_tys(variant, params)?;
-                                    Ok((variant.name, v, field_tys, d))
-                                })
-                                .collect::<Result<Vec<_>, _>>()?;
-                            let variants = if variants.is_empty() {
-                                None
-                            } else {
-                                let has_explicit = adt
-                                    .variants()
-                                    .iter()
-                                    .any(|v| matches!(v.discr, ty::VariantDiscr::Explicit(_)));
-                                let discr_ty = adt.repr().discr_type().to_ty(vcx.tcx());
-                                let discr_ty = enc
-                                    .deps
-                                    .require_local::<RustTySnapshotsEnc>(discr_ty)?
-                                    .generic_snapshot;
-                                Some(VariantData {
-                                    discr_ty: discr_ty.snapshot,
-                                    discr_prim: discr_ty.specifics.expect_primitive(),
-                                    has_explicit,
-                                    variants,
-                                })
-                            };
-                            let specifics = enc.mk_enum_specifics(variants);
-                            Ok((Some(enc.finalize(task_key)), specifics))
-                        }
-                        ty::AdtKind::Union => todo!(),
-                    }
-                }
-                TyKind::Tuple(params) => {
-                    let generics = params
-                        .iter()
-                        .map(|ty| {
-                            deps.require_local::<LiftedTyEnc<EncodeGenericsAsParamTy>>(ty)
-                                .unwrap()
-                                .expect_generic()
-                        })
-                        .collect();
-                    let mut enc = DomainEncData::new(vcx, task_key, generics, deps);
-                    enc.deps
-                        .emit_output_ref(*task_key, enc.output_ref(base_name))?;
-                    let field_tys = params
-                        .iter()
-                        .map(|ty| FieldTy::from_ty(vcx, enc.deps, ty))
-                        .collect::<Result<Vec<_>, _>>()?;
-                    let specifics = enc.mk_struct_specifics(field_tys);
-                    Ok((Some(enc.finalize(task_key)), specifics))
-                }
-                TyKind::Never => {
-                    let mut enc = DomainEncData::new(vcx, task_key, vec![], deps);
-                    enc.deps
-                        .emit_output_ref(*task_key, enc.output_ref(base_name))?;
-                    let specifics = enc.mk_enum_specifics(None);
-                    Ok((Some(enc.finalize(task_key)), specifics))
-                }
-                &TyKind::Ref(_, inner, _) => {
-                    let generics = vec![deps
-                        .require_local::<LiftedTyEnc<EncodeGenericsAsParamTy>>(inner)?
-                        .expect_generic()];
-                    let mut enc = DomainEncData::new(vcx, task_key, generics, deps);
-                    enc.deps
-                        .emit_output_ref(*task_key, enc.output_ref(base_name))?;
-                    let field_tys = vec![FieldTy::from_ty(vcx, enc.deps, inner)?];
-                    let specifics = enc.mk_struct_specifics(field_tys);
-                    Ok((Some(enc.finalize(task_key)), specifics))
-                }
-                &TyKind::Param(_) => {
-                    let out = deps.require_ref::<GenericEnc>(())?;
-                    deps.emit_output_ref(
-                        *task_key,
-                        DomainEncOutputRef {
-                            base_name,
-                            domain: out.domain_param_name,
-                            ty_param_accessors: &[],
-                            typeof_function: out.param_type_function,
-                        },
-                    )?;
-                    Ok((None, DomainEncSpecifics::Param))
-                }
-                &TyKind::Str => {
-                    let mut enc = DomainEncData::new(vcx, task_key, vec![], deps);
-                    let base_name = String::from("String");
-                    enc.deps
-                        .emit_output_ref(*task_key, enc.output_ref(base_name))?;
-                    let specifics = enc.mk_struct_specifics(vec![]);
-                    Ok((Some(enc.finalize(task_key)), specifics))
-                }
+                | TyKind::Float(_) => super::kinds::primitive::domain(*task_key, deps, &mut builder)?,
+                TyKind::Closure(..) => super::kinds::closure::domain(*task_key, deps, &mut builder)?,
+                TyKind::Adt(..) => super::kinds::adt::domain(*task_key, deps, &mut builder)?,
+                TyKind::Tuple(..) => super::kinds::tuple::domain(*task_key, deps, &mut builder)?,
+                TyKind::Never => super::kinds::never::domain(*task_key, deps, &mut builder)?,
+                TyKind::Ref(..) => super::kinds::reference::domain(*task_key, deps, &mut builder)?,
+                TyKind::Param(_) => super::kinds::param::domain(*task_key, deps, &mut builder)?,
+                TyKind::Str => super::kinds::str::domain(*task_key, deps, &mut builder)?,
                 kind => todo!("{kind:?}"),
-            }
+            };
+            Ok((builder.build(), specifics))
         })
     }
 }
@@ -339,7 +186,6 @@ impl<'vir> DomainBuilder<'vir> {
             functions: Vec::new(),
         }
     }
-    pub(crate) fn emit_output_ref(&mut self) {}
 
     pub(crate) fn set_name(&mut self, name: &str) {
         let name = vir::vir_format!(self.vcx, "s_{name}");
@@ -403,527 +249,13 @@ impl<'vir> DomainBuilder<'vir> {
         }
     }
 
-    pub(crate) fn build(self) -> vir::Domain<'vir> {
-        self.vcx.mk_domain(
-            self.domain_ident.expect("name should be set").name(),
+    pub(crate) fn build(self) -> Option<vir::Domain<'vir>> {
+        Some(self.vcx.mk_domain(
+            self.domain_ident?.name(),
             &[],
             self.vcx.alloc_slice(&self.axioms),
             self.vcx.alloc_slice(&self.functions),
-        )
-    }
-}
-
-pub struct VariantData<'vir> {
-    discr_ty: vir::Type<'vir>,
-    discr_prim: DomainDataPrim<'vir>,
-    /// Do any of the variants have an explicit discriminant value?
-    has_explicit: bool,
-    variants: Vec<(
-        symbol::Symbol,
-        abi::VariantIdx,
-        Vec<FieldTy<'vir>>,
-        ty::util::Discr<'vir>,
-    )>,
-}
-
-struct DomainEncData<'vir, 'enc> {
-    vcx: &'vir vir::VirCtxt<'vir>,
-    domain: vir::DomainIdent<'vir, NullaryArityAny<'vir, DomainParamData<'vir>>>,
-    generics: Vec<(ParamTy, vir::FunctionIdent<'vir, UnaryArity<'vir>>)>,
-    typeof_function: vir::FunctionIdent<'vir, UnaryArity<'vir>>,
-    self_ty: vir::Type<'vir>,
-    self_ex: vir::Expr<'vir>,
-    self_decl: &'vir [vir::LocalDecl<'vir>; 1],
-    axioms: Vec<vir::DomainAxiom<'vir>>,
-    functions: Vec<vir::DomainFunction<'vir>>,
-    // generic_enc: GenericEncOutputRef<'vir>,
-    deps: &'enc mut TaskEncoderDependencies<'vir, DomainEnc>,
-}
-impl<'vir, 'enc> DomainEncData<'vir, 'enc> {
-    // Creation
-    fn new(
-        vcx: &'vir vir::VirCtxt<'vir>,
-        ty: &MostGenericTy<'vir>,
-        generics: Vec<ParamTy>,
-        deps: &'enc mut TaskEncoderDependencies<'vir, DomainEnc>,
-    ) -> Self {
-        let domain = ty.get_vir_domain_ident(vcx);
-        let self_ty = domain.apply(vcx, []);
-
-        let self_local = vcx.mk_local("self", self_ty);
-        let self_ex = vcx.mk_local_ex_local(self_local);
-        let self_decl = vcx.alloc_array(&[vcx.mk_local_decl_local(self_local)]);
-
-        let generic_enc = deps.require_ref::<GenericEnc>(()).unwrap();
-
-        let ty_param_accessors = deps
-            .require_ref::<TyConstructorEnc>(*ty)
-            .unwrap()
-            .ty_param_accessors;
-        let generics: Vec<_> = generics
-            .into_iter()
-            .zip(ty_param_accessors.iter().copied())
-            .collect();
-
-        let mut functions = vec![];
-
-        let typeof_function = if !ty.is_generic() {
-            let typeof_function = vir::FunctionIdent::new(
-                vir::vir_format_identifier!(vcx, "typeof_{}", domain.name()),
-                UnaryArity::new(vcx.alloc_array(&[self_ty])),
-                generic_enc.type_snapshot,
-            );
-            functions.push(vcx.mk_domain_function(typeof_function, false));
-            typeof_function
-        } else {
-            generic_enc.param_type_function
-        };
-
-        Self {
-            vcx,
-            domain,
-            self_ty,
-            self_ex,
-            self_decl,
-            generics,
-            axioms: Vec::new(),
-            functions,
-            deps,
-            typeof_function,
-            // generic_enc,
-        }
-    }
-
-    // Intermediate values
-    pub fn mk_field_tys(
-        &mut self,
-        variant: &ty::VariantDef,
-        params: ty::GenericArgsRef<'vir>,
-    ) -> Result<Vec<FieldTy<'vir>>, EncodeFullError<'vir, DomainEnc>> {
-        variant
-            .fields
-            .iter()
-            .map(|f| f.ty(self.vcx.tcx(), params))
-            .map(|ty| FieldTy::from_ty(self.vcx, self.deps, ty))
-            .collect::<Result<Vec<_>, _>>()
-    }
-
-    // Creating specifics
-    pub fn mk_prim_specifics(
-        &mut self,
-        ty: ty::Ty<'vir>,
-        prim_type: vir::Type<'vir>,
-    ) -> DomainEncSpecifics<'vir> {
-        let prim_type_args = vec![FieldTy {
-            ty: prim_type,
-            rust_ty_data: None,
-        }];
-        let data = self.mk_field_functions(&prim_type_args, None, ty.is_integral());
-        // TODO: what to do about write?
-        let snap_to_prim = data.field_access[0].read;
-        let specifics = DomainDataPrim {
-            prim_type,
-            snap_to_prim,
-            prim_to_snap: data.field_snaps_to_snap.to_known(),
-        };
-        if let Some((lower, upper)) = specifics.bounds(ty) {
-            let exp = snap_to_prim.apply(self.vcx, [self.self_ex]);
-            let axiom = self.mk_bounds_axiom(self.domain.name_str(), exp, lower, upper);
-            self.axioms.push(axiom);
-        }
-        DomainEncSpecifics::Primitive(specifics)
-    }
-    pub fn mk_struct_specifics(&mut self, fields: Vec<FieldTy<'vir>>) -> DomainEncSpecifics<'vir> {
-        let specifics = self.mk_field_functions(&fields, None, false);
-        DomainEncSpecifics::StructLike(specifics)
-    }
-    pub fn mk_enum_specifics(
-        &mut self,
-        data: Option<VariantData<'vir>>,
-    ) -> DomainEncSpecifics<'vir> {
-        let specifics = data.map(|data| {
-            let discr_vals: Vec<_> = data
-                .variants
-                .iter()
-                .map(|(_, _, _, discr)| data.discr_prim.expr_from_bits(discr.ty, discr.val))
-                .collect();
-            let snap_to_discr_snap = self.mk_discr_function(data.discr_ty);
-            let variants = self.vcx.alloc_slice(
-                &data
-                    .variants
-                    .iter()
-                    .enumerate()
-                    .map(|(idx, (name, vid, fields, _))| {
-                        let discr = (
-                            snap_to_discr_snap,
-                            data.discr_prim
-                                .prim_to_snap
-                                .apply(self.vcx, [discr_vals[idx]]),
-                            *name,
-                        );
-                        let fields = self.mk_field_functions(fields, Some(discr), false);
-                        DomainDataVariant {
-                            name: *name,
-                            vid: *vid,
-                            discr: discr_vals[idx],
-                            fields,
-                        }
-                    })
-                    .collect::<Vec<_>>(),
-            );
-            let discr_bounds = self.mk_discr_bounds_axioms(
-                data.discr_prim,
-                snap_to_discr_snap,
-                discr_vals,
-                data.has_explicit,
-            );
-            DomainDataEnum {
-                discr_ty: data.discr_ty,
-                discr_prim: data.discr_prim,
-                discr_bounds,
-                snap_to_discr_snap,
-                variants,
-            }
-        });
-        DomainEncSpecifics::EnumLike(specifics)
-    }
-
-    fn push_function(&mut self, func: FunctionIdent<'vir, UnknownArity<'vir>>, unique: bool) {
-        self.functions
-            .push(self.vcx.mk_domain_function(func, unique));
-    }
-
-    // Helper functions
-    fn mk_field_functions(
-        &mut self,
-        field_tys: &[FieldTy<'vir>],
-        discr: Option<(
-            FunctionIdent<'vir, UnaryArity<'vir>>,
-            vir::Expr<'vir>,
-            symbol::Symbol,
-        )>,
-        stronger_cons_axiom: bool,
-    ) -> DomainDataStruct<'vir> {
-        let name = self.domain.name();
-        let base = discr
-            .map(|(_, _, v)| format!("{name}_{v}"))
-            .unwrap_or_else(|| name.to_string());
-        // Constructor
-        let field_snaps_to_snap = {
-            let name = vir::vir_format_identifier!(self.vcx, "{base}_cons");
-            let ident = FunctionIdent::new(
-                name,
-                UnknownArity::new(
-                    self.vcx
-                        .alloc_slice(&field_tys.iter().map(|fty| fty.ty).collect::<Vec<_>>()),
-                ),
-                self.self_ty,
-            );
-            self.push_function(ident, false);
-            ident
-        };
-
-        // Variables and definitions useful for axioms
-        let fnames = field_tys
-            .iter()
-            .enumerate()
-            .map(|(idx, ty)| {
-                self.vcx
-                    .mk_local(vir::vir_format!(self.vcx, "f{idx}"), ty.ty)
-            })
-            .collect::<Vec<_>>();
-        let cons_qvars: Vec<_> = field_tys
-            .iter()
-            .enumerate()
-            .map(|(idx, _)| self.vcx.mk_local_decl_local(fnames[idx]))
-            .collect();
-        let cons_qvars = self.vcx.alloc_slice(&cons_qvars);
-        let cons_args: Vec<_> = fnames
-            .into_iter()
-            .map(|fname| self.vcx.mk_local_ex_local(fname))
-            .collect();
-        let cons_call_with_qvars = field_snaps_to_snap.apply(self.vcx, &cons_args);
-
-        // Discriminant axioms
-        if let Some((get_discr, val, _)) = discr {
-            let discr = get_discr.apply(self.vcx, [cons_call_with_qvars]);
-            let mut expr = self.vcx.mk_bin_op_expr(vir::BinOpKind::CmpEq, discr, val);
-            if !field_tys.is_empty() {
-                expr = self.vcx.mk_forall_expr(
-                    cons_qvars,
-                    self.vcx.alloc_slice(&[self.vcx.mk_trigger(&[discr])]),
-                    expr,
-                );
-            }
-            self.axioms.push(self.vcx.mk_domain_axiom(
-                vir::vir_format_identifier!(self.vcx, "ax_{base}_cons_discr"),
-                expr,
-            ));
-        }
-
-        // Accessors
-        let field_access = {
-            field_tys
-                .iter()
-                .enumerate()
-                .map(|(idx, field_ty)| {
-                    // Read
-                    let name = vir::vir_format_identifier!(self.vcx, "{base}_read_{idx}");
-                    let args = self.vcx.alloc_array(&[self.self_ty]);
-                    let read = FunctionIdent::new(name, UnaryArity::new(args), field_ty.ty);
-
-                    // Add axiom that connects the type of the field to the type of `self`
-                    // e.g type of (t: (T1,T2)).0 should be T1
-                    let self_ty = self.typeof_function.apply(self.vcx, [self.self_ex]);
-
-                    if let Some(lifted) = &field_ty.rust_ty_data {
-                        // Lookup the encoding of the generic from a rust `ParamTy`
-                        let mut generic_to_getter = |p: ParamTy| {
-                            self.generics
-                                .iter()
-                                .find_map(|(g, ident)| if g == &p { Some(ident) } else { None })
-                                .unwrap()
-                                .apply(self.vcx, [self_ty])
-                        };
-
-                        self.axioms.push(
-                            self.vcx.mk_domain_axiom(
-                                vir::vir_format_identifier!(self.vcx, "ax_{base}_read_{idx}_type"),
-                                self.vcx.mk_forall_expr(
-                                    self.vcx.alloc_slice(self.self_decl),
-                                    self.vcx.alloc_slice(&[self
-                                        .vcx
-                                        .mk_trigger(&[read.apply(self.vcx, [self.self_ex])])]),
-                                    self.vcx.mk_eq_expr(
-                                        lifted.typeof_function.apply(
-                                            self.vcx,
-                                            [read.apply(self.vcx, [self.self_ex])],
-                                        ),
-                                        lifted
-                                            .lifted_ty
-                                            .map(self.vcx, &mut generic_to_getter)
-                                            .expr(self.vcx),
-                                    ),
-                                ),
-                            ),
-                        );
-                    }
-
-                    self.functions
-                        .push(self.vcx.mk_domain_function(read, false));
-
-                    let cons_read = read.apply(self.vcx, [cons_call_with_qvars]);
-                    self.axioms.push(
-                        self.vcx.mk_domain_axiom(
-                            vir::vir_format_identifier!(self.vcx, "ax_{base}_cons_read_{idx}"),
-                            self.vcx.mk_forall_expr(
-                                cons_qvars,
-                                self.vcx
-                                    .alloc_slice(&[self.vcx.mk_trigger(&[cons_call_with_qvars])]),
-                                self.vcx.mk_bin_op_expr(
-                                    vir::BinOpKind::CmpEq,
-                                    cons_read,
-                                    cons_args[idx],
-                                ),
-                            ),
-                        ),
-                    );
-
-                    // Write
-                    let name = vir::vir_format_identifier!(self.vcx, "{base}_write_{idx}");
-                    let args = self.vcx.alloc_array(&[self.self_ty, field_ty.ty]);
-                    let write = FunctionIdent::new(name, BinaryArity::new(args), self.self_ty);
-                    self.functions
-                        .push(self.vcx.mk_domain_function(write, false));
-                    FieldFunctions { read, write }
-                })
-                .collect::<Vec<_>>()
-        };
-
-        {
-            // Other axioms
-            // TODO: this axiom seems useful even when there are no fields, but
-            // I can't figure out which triggers it would have. Is it ok to skip
-            // it?
-            if !field_access.is_empty() {
-                // Constructing from reads leads to same result
-                let all_reads: Vec<_> = field_access
-                    .iter()
-                    .map(|field_access| field_access.read.apply(self.vcx, [self.self_ex]))
-                    .collect();
-                let cons_call_with_reads = field_snaps_to_snap.apply(self.vcx, &all_reads);
-                let trigger = if stronger_cons_axiom {
-                    // Integer types require a simpler trigger to be complete
-                    // when snapshot equality may be used on them.
-                    assert_eq!(all_reads.len(), 1);
-                    all_reads[0]
-                } else {
-                    cons_call_with_reads
-                };
-                self.axioms.push(self.vcx.mk_domain_axiom(
-                    vir::vir_format_identifier!(self.vcx, "ax_{base}_cons"),
-                    self.vcx.mk_forall_expr(
-                        self.self_decl,
-                        self.vcx.alloc_slice(&[self.vcx.mk_trigger(&[trigger])]),
-                        self.vcx.mk_bin_op_expr(
-                            vir::BinOpKind::CmpEq,
-                            cons_call_with_reads,
-                            self.self_ex,
-                        ),
-                    ),
-                ));
-            };
-
-            // Write and read to different fields change nothing, write and read to
-            // the same field sees the new value.
-            for (wi, write) in field_access.iter().enumerate() {
-                let val_local = self.vcx.mk_local("val", field_tys[wi].ty);
-                let val = self.vcx.mk_local_ex_local(val_local);
-                let decl = self.vcx.mk_local_decl_local(val_local);
-                let write = write.write.apply(self.vcx, [self.self_ex, val]);
-                for (ri, read) in field_access.iter().enumerate() {
-                    let write_read = read.read.apply(self.vcx, [write]);
-                    let rhs = if wi == ri {
-                        val
-                    } else {
-                        read.read.apply(self.vcx, [self.self_ex])
-                    };
-                    self.axioms.push(
-                        self.vcx.mk_domain_axiom(
-                            vir::vir_format_identifier!(self.vcx, "ax_{base}_write_{wi}_read_{ri}"),
-                            self.vcx.mk_forall_expr(
-                                self.vcx.alloc_slice(&[self.self_decl[0], decl]),
-                                self.vcx.alloc_slice(&[self.vcx.mk_trigger(&[write_read])]),
-                                self.vcx
-                                    .mk_bin_op_expr(vir::BinOpKind::CmpEq, write_read, rhs),
-                            ),
-                        ),
-                    );
-                }
-            }
-        }
-
-        DomainDataStruct {
-            field_snaps_to_snap,
-            field_access: self.vcx.alloc_slice(&field_access),
-        }
-    }
-    fn mk_discr_function(
-        &mut self,
-        discr_ty: vir::Type<'vir>,
-    ) -> FunctionIdent<'vir, UnaryArity<'vir>> {
-        let name = vir::vir_format_identifier!(self.vcx, "{}_discr", self.domain.name());
-        let types = self.vcx.alloc_array(&[self.self_ty]);
-        let snap_to_discr_snap = FunctionIdent::new(name, UnaryArity::new(types), discr_ty);
-        self.functions
-            .push(self.vcx.mk_domain_function(snap_to_discr_snap, false));
-        snap_to_discr_snap
-    }
-    fn mk_discr_bounds_axioms(
-        &mut self,
-        discr_prim: DomainDataPrim<'vir>,
-        snap_to_discr_snap: FunctionIdent<'vir, UnaryArity<'vir>>,
-        discr_vals: Vec<vir::Expr<'vir>>,
-        has_explicit: bool,
-    ) -> DiscrBounds<'vir> {
-        let discr = snap_to_discr_snap.apply(self.vcx, [self.self_ex]);
-        let discr_prim = discr_prim.snap_to_prim.apply(self.vcx, [discr]);
-        if has_explicit {
-            let discr_vals_eq: Vec<_> = discr_vals
-                .iter()
-                .map(|val| self.vcx.mk_eq_expr(discr_prim, *val))
-                .collect();
-            let body = self.vcx.mk_disj(&discr_vals_eq);
-            self.axioms.push(self.vcx.mk_domain_axiom(
-                vir::vir_format_identifier!(self.vcx, "{}_discr_values", self.domain.name()),
-                self.vcx.mk_forall_expr(
-                    self.self_decl,
-                    // TODO: should we use `discr` instead of `discr_prim` here?
-                    self.vcx.alloc_slice(&[self.vcx.mk_trigger(&[discr_prim])]),
-                    body,
-                ),
-            ));
-            DiscrBounds::Explicit(self.vcx.alloc_slice(&discr_vals))
-        } else {
-            let base = format!("{}_discr", self.domain.name());
-            let lower = discr_vals.first().unwrap();
-            let upper = discr_vals.last().unwrap();
-            let axiom = self.mk_bounds_axiom(&base, discr_prim, lower, upper);
-            self.axioms.push(axiom);
-            DiscrBounds::Range { lower, upper }
-        }
-    }
-    fn mk_bounds_axiom(
-        &self,
-        base: &str,
-        exp: vir::Expr<'vir>,
-        lower: vir::Expr<'vir>,
-        upper: vir::Expr<'vir>,
-    ) -> vir::DomainAxiom<'vir> {
-        let lower = self.vcx.mk_bin_op_expr(vir::BinOpKind::CmpLe, lower, exp);
-        let upper = self.vcx.mk_bin_op_expr(vir::BinOpKind::CmpLe, exp, upper);
-        self.vcx.mk_domain_axiom(
-            vir::vir_format_identifier!(self.vcx, "{base}_bounds"),
-            self.vcx.mk_forall_expr(
-                self.self_decl,
-                self.vcx.alloc_slice(&[self.vcx.mk_trigger(&[exp])]),
-                self.vcx.mk_bin_op_expr(vir::BinOpKind::And, lower, upper),
-            ),
-        )
-    }
-
-    // Final results
-    fn output_ref(&self, base_name: String) -> DomainEncOutputRef<'vir> {
-        DomainEncOutputRef {
-            base_name,
-            domain: self.domain,
-            typeof_function: self.typeof_function,
-            ty_param_accessors: self.vcx.alloc_slice(
-                &self
-                    .generics
-                    .iter()
-                    .map(|(_, ident)| *ident)
-                    .collect::<Vec<_>>(),
-            ),
-        }
-    }
-    fn finalize(mut self, ty: &MostGenericTy<'vir>) -> vir::Domain<'vir> {
-        // If this type has generics, assert a bijectivity axiom on the type
-        // constructor: For any value of type T, with type parameters T1, ...,
-        // Tn, the type T is exactly the application of C to those type
-        // parameters.
-        if !ty.generics().is_empty() {
-            let typeof_applied_to_self = self.typeof_function.apply(self.vcx, [self.self_ex]);
-
-            let TyConstructorEncOutputRef {
-                ty_constructor,
-                ty_param_accessors,
-                ..
-            } = self.deps.require_ref::<TyConstructorEnc>(*ty).unwrap();
-
-            let ty_params = ty_param_accessors
-                .iter()
-                .map(|ident| ident.apply(self.vcx, [typeof_applied_to_self]))
-                .collect::<Vec<_>>();
-
-            self.axioms.push(self.vcx.mk_domain_axiom(
-                vir::vir_format_identifier!(self.vcx, "ax_typeof_{}", self.domain.name()),
-                self.vcx.mk_forall_expr(
-                    self.self_decl,
-                    self.vcx.alloc_slice(&[self.vcx.mk_trigger(&ty_params)]),
-                    self.vcx.mk_eq_expr(
-                        typeof_applied_to_self,
-                        ty_constructor.apply(self.vcx, &ty_params),
-                    ),
-                ),
-            ));
-        }
-        self.vcx.mk_domain(
-            self.domain.name(),
-            &[],
-            self.vcx.alloc_slice(&self.axioms),
-            self.vcx.alloc_slice(&self.functions),
-        )
+        ))
     }
 }
 
@@ -936,10 +268,16 @@ impl<'vir> DomainEncSpecifics<'vir> {
             _ => panic!("expected primitive"),
         }
     }
+    pub fn expect_ref(self) -> DomainDataRef<'vir> {
+        match self {
+            Self::Ref(data) => data,
+            _ => panic!("expected ref"),
+        }
+    }
     pub fn expect_structlike(self) -> DomainDataStruct<'vir> {
         match self {
             Self::StructLike(data) => data,
-            _ => panic!("expected struct-like"),
+            _ => panic!("expected struct-like (was {self:?}"),
         }
     }
     pub fn get_enumlike(self) -> Option<Option<DomainDataEnum<'vir>>> {
@@ -949,7 +287,10 @@ impl<'vir> DomainEncSpecifics<'vir> {
         }
     }
     pub fn expect_enumlike(self) -> Option<DomainDataEnum<'vir>> {
-        self.get_enumlike().expect("expected enum-like")
+        match self {
+            Self::EnumLike(data) => data,
+            _ => panic!("expected enum-like, was {self:?}"),
+        }
     }
 }
 impl<'vir> DomainDataPrim<'vir> {
@@ -986,31 +327,19 @@ impl<'vir> DomainDataPrim<'vir> {
             ref k => unreachable!("{k:?}"),
         }
     }
-    fn bounds(&self, ty: ty::Ty<'vir>) -> Option<(vir::Expr<'vir>, vir::Expr<'vir>)> {
-        match *self.prim_type {
-            vir::TypeData::Bool => None,
-            vir::TypeData::Int { .. } => {
-                let rust_ty = ty.kind();
-                Some(vir::with_vcx(|vcx| {
-                    (vcx.get_min_int(rust_ty), vcx.get_max_int(rust_ty))
-                }))
-            }
-            ref k => todo!("{k:?}"),
-        }
-    }
 }
 
 /// Data for encoding field access functions and axioms
 #[derive(Clone)]
-struct FieldTy<'vir> {
+pub(super) struct FieldTy<'vir> {
     /// The type of encoded field
-    ty: vir::Type<'vir>,
+    pub(super) ty: vir::Type<'vir>,
 
     /// Information about the Rust type, only defined for fields that correspond
     /// to actual Rust types. For example, this will be `None` for a Viper
     /// `Bool` field encoded as part of the snapshot encoding of the rust bool
     /// type.
-    rust_ty_data: Option<LiftedRustTyData<'vir>>,
+    pub(super) rust_ty_data: Option<LiftedRustTyData<'vir>>,
 }
 
 #[derive(Clone)]
@@ -1022,7 +351,21 @@ struct LiftedRustTyData<'vir> {
 }
 
 impl<'vir> FieldTy<'vir> {
-    fn from_ty(
+    pub fn mk_field_tys(
+        vcx: &'vir vir::VirCtxt<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, DomainEnc>,
+        variant: &ty::VariantDef,
+        params: ty::GenericArgsRef<'vir>,
+    ) -> Result<Vec<Self>, EncodeFullError<'vir, DomainEnc>> {
+        variant
+            .fields
+            .iter()
+            .map(|f| f.ty(vcx.tcx(), params))
+            .map(|ty| Self::from_ty(vcx, deps, ty))
+            .collect::<Result<Vec<_>, _>>()
+    }
+
+    pub(super) fn from_ty(
         vcx: &'vir vir::VirCtxt<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, DomainEnc>,
         ty: ty::Ty<'vir>,

--- a/prusti-encoder/src/encoders/type/domain.rs
+++ b/prusti-encoder/src/encoders/type/domain.rs
@@ -53,7 +53,7 @@ pub struct DomainDataStruct<'vir> {
 pub struct DomainDataEnum<'vir> {
     pub discr_ty: vir::Type<'vir>,
     pub discr_prim: DomainDataPrim<'vir>,
-    pub discr_bounds: DiscrBounds<'vir>,
+    //pub discr_bounds: DiscrBounds<'vir>,
     pub snap_to_discr_snap: FunctionIdent<'vir, UnaryArity<'vir>>,
     pub variants: &'vir [DomainDataVariant<'vir>],
 }
@@ -215,6 +215,7 @@ impl<'vir> DomainBuilder<'vir> {
         }));
         ident
     }
+
     pub(crate) fn axiom(
         &mut self,
         name: &str,
@@ -230,6 +231,7 @@ impl<'vir> DomainBuilder<'vir> {
     pub(crate) fn self_type(&self) -> vir::Type<'vir> {
         self.self_type.expect("name should be set")
     }
+
     pub(crate) fn type_type(&self) -> vir::Type<'vir> {
         &vir::TypeData::Domain("Type", &[]) // TODO: refer to something else
     }
@@ -262,18 +264,21 @@ impl<'vir> DomainBuilder<'vir> {
 // Utility functions
 
 impl<'vir> DomainEncSpecifics<'vir> {
+    #[track_caller]
     pub fn expect_primitive(self) -> DomainDataPrim<'vir> {
         match self {
             Self::Primitive(data) => data,
             _ => panic!("expected primitive"),
         }
     }
+    #[track_caller]
     pub fn expect_ref(self) -> DomainDataRef<'vir> {
         match self {
             Self::Ref(data) => data,
             _ => panic!("expected ref"),
         }
     }
+    #[track_caller]
     pub fn expect_structlike(self) -> DomainDataStruct<'vir> {
         match self {
             Self::StructLike(data) => data,
@@ -286,6 +291,7 @@ impl<'vir> DomainEncSpecifics<'vir> {
             _ => None,
         }
     }
+    #[track_caller]
     pub fn expect_enumlike(self) -> Option<DomainDataEnum<'vir>> {
         match self {
             Self::EnumLike(data) => data,
@@ -351,12 +357,12 @@ struct LiftedRustTyData<'vir> {
 }
 
 impl<'vir> FieldTy<'vir> {
-    pub fn mk_field_tys(
+    pub fn mk_field_tys<T: TaskEncoder>(
         vcx: &'vir vir::VirCtxt<'vir>,
-        deps: &mut TaskEncoderDependencies<'vir, DomainEnc>,
+        deps: &mut TaskEncoderDependencies<'vir, T>,
         variant: &ty::VariantDef,
         params: ty::GenericArgsRef<'vir>,
-    ) -> Result<Vec<Self>, EncodeFullError<'vir, DomainEnc>> {
+    ) -> Result<Vec<Self>, EncodeFullError<'vir, T>> {
         variant
             .fields
             .iter()
@@ -365,11 +371,11 @@ impl<'vir> FieldTy<'vir> {
             .collect::<Result<Vec<_>, _>>()
     }
 
-    pub(super) fn from_ty(
+    pub(super) fn from_ty<T: TaskEncoder>(
         vcx: &'vir vir::VirCtxt<'vir>,
-        deps: &mut TaskEncoderDependencies<'vir, DomainEnc>,
+        deps: &mut TaskEncoderDependencies<'vir, T>,
         ty: ty::Ty<'vir>,
-    ) -> Result<FieldTy<'vir>, EncodeFullError<'vir, DomainEnc>> {
+    ) -> Result<FieldTy<'vir>, EncodeFullError<'vir, T>> {
         let vir_ty = deps
             .require_ref::<RustTySnapshotsEnc>(ty)?
             .generic_snapshot

--- a/prusti-encoder/src/encoders/type/domain.rs
+++ b/prusti-encoder/src/encoders/type/domain.rs
@@ -9,8 +9,7 @@ use prusti_rustc_interface::{
 };
 use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 use vir::{
-    BinaryArity, CallableIdent, DomainParamData, FunctionIdent, NullaryArityAny, ToKnownArity,
-    UnaryArity, UnknownArity,
+    BinaryArity, CallableIdent, DomainAxiomData, DomainFunction, DomainFunctionData, DomainIdent, DomainParamData, FunctionIdent, NullaryArityAny, ToKnownArity, UnaryArity, UnknownArity
 };
 
 /// You probably never want to use this, use `SnapshotEnc` instead.
@@ -142,13 +141,19 @@ impl TaskEncoder for DomainEnc {
     ) -> EncodeFullResult<'vir, Self> {
         vir::with_vcx(|vcx| {
             let base_name = task_key.get_vir_base_name(vcx);
-            match task_key.kind() {
+            let ty_kind = task_key.kind();
+            let mut builder = DomainBuilder::new(vcx);
+            match ty_kind {
                 TyKind::Bool
                 | TyKind::Char
                 | TyKind::Int(_)
                 | TyKind::Uint(_)
                 | TyKind::Float(_) => {
-                    let prim_type = match task_key.kind() {
+                    let specifics = super::kinds::primitive::domain(*task_key, deps, &mut builder)?;
+                    Ok((Some(builder.build()), specifics))
+
+                    /*
+                    let prim_type = match ty_kind {
                         TyKind::Bool => &vir::TypeData::Bool,
                         TyKind::Int(_) => &vir::TypeData::Int,
                         TyKind::Uint(_) => &vir::TypeData::Int,
@@ -160,6 +165,7 @@ impl TaskEncoder for DomainEnc {
                         .emit_output_ref(*task_key, enc.output_ref(base_name))?;
                     let specifics = enc.mk_prim_specifics(task_key.ty(), prim_type);
                     Ok((Some(enc.finalize(task_key)), specifics))
+                    */
                 }
                 TyKind::Closure(_def_id, args) => {
                     let cl_args = args.as_closure();
@@ -308,6 +314,102 @@ impl TaskEncoder for DomainEnc {
                 kind => todo!("{kind:?}"),
             }
         })
+    }
+}
+
+pub(crate) struct DomainBuilder<'vir> {
+    pub(crate) vcx: &'vir vir::VirCtxt<'vir>,
+    name: Option<&'vir str>,
+    domain_ident: Option<vir::DomainIdent<'vir, NullaryArityAny<'vir, DomainParamData<'vir>>>>,
+    self_type: Option<vir::Type<'vir>>,
+    axioms: Vec<vir::DomainAxiom<'vir>>,
+    functions: Vec<vir::DomainFunction<'vir>>,
+}
+
+impl<'vir> DomainBuilder<'vir> {
+    pub(crate) fn new(
+        vcx: &'vir vir::VirCtxt<'vir>,
+    ) -> Self {
+        DomainBuilder {
+            vcx,
+            name: None,
+            domain_ident: None,
+            self_type: None,
+            axioms: Vec::new(),
+            functions: Vec::new(),
+        }
+    }
+    pub(crate) fn emit_output_ref(&mut self) {}
+
+    pub(crate) fn set_name(&mut self, name: &str) {
+        let name = vir::vir_format!(self.vcx, "s_{name}");
+        self.name = Some(name);
+        self.domain_ident = Some(DomainIdent::nullary(vir::ViperIdent::new(name)));
+        self.self_type = Some(self.vcx.alloc(vir::TypeData::Domain(self.name.expect("name should be set"), &[])));
+    }
+
+    pub(crate) fn function(
+        &mut self,
+        name: &str,
+        args: &[&'vir vir::TypeData],
+        ret: &'vir vir::TypeData,
+    ) -> FunctionIdent<'vir, UnknownArity<'vir>> {
+        let name = vir::vir_format!(self.vcx, "{}_{name}", self.name.expect("name should be set"));
+        let args = self.vcx.alloc_slice(args);
+        let ident = FunctionIdent::new(
+            vir::ViperIdent::new(name),
+            UnknownArity::new(args),
+            ret,
+        );
+        self.functions.push(self.vcx.alloc(DomainFunctionData {
+            unique: false,
+            name: ident.name(),
+            args,
+            ret,
+        }));
+        ident
+    }
+    pub(crate) fn axiom(
+        &mut self,
+        name: &str,
+        expr: vir::Expr<'vir>,
+    ) {
+        let name = vir::vir_format!(self.vcx, "{}_ax_{name}", self.name.expect("name should be set"));
+        self.axioms.push(self.vcx.alloc(DomainAxiomData {
+            name,
+            expr,
+        }));
+    }
+
+    pub(crate) fn self_type(&self) -> vir::Type<'vir> {
+        self.self_type.expect("name should be set")
+    }
+    pub(crate) fn type_type(&self) -> vir::Type<'vir> {
+        &vir::TypeData::Domain("Type", &[]) // TODO: refer to something else
+    }
+
+    pub(crate) fn output_ref(&self, base_name: String, typeof_function: FunctionIdent<'vir, UnaryArity<'vir>>) -> DomainEncOutputRef<'vir> {
+        DomainEncOutputRef {
+            base_name,
+            domain: self.domain_ident.expect("name should be set"),
+            typeof_function: typeof_function,
+            ty_param_accessors: &[], /*self.vcx.alloc_slice(
+                &self
+                    .generics
+                    .iter()
+                    .map(|(_, ident)| *ident)
+                    .collect::<Vec<_>>(),
+            ),*/
+        }
+    }
+
+    pub(crate) fn build(self) -> vir::Domain<'vir> {
+        self.vcx.mk_domain(
+            self.domain_ident.expect("name should be set").name(),
+            &[],
+            self.vcx.alloc_slice(&self.axioms),
+            self.vcx.alloc_slice(&self.functions),
+        )
     }
 }
 

--- a/prusti-encoder/src/encoders/type/kinds/adt.rs
+++ b/prusti-encoder/src/encoders/type/kinds/adt.rs
@@ -1,7 +1,7 @@
 use prusti_rustc_interface::middle::ty;
 use task_encoder::{EncodeFullError, TaskEncoder, TaskEncoderDependencies};
 use vir::{vir_format, ToKnownArity};
-use crate::encoders::{domain::{DomainBuilder, DomainDataStruct, DomainEnc, DomainEncSpecifics, FieldFunctions, FieldTy}, most_generic_ty::get_vir_base_name_kind};
+use crate::encoders::{domain::{DomainBuilder, DomainDataEnum, DomainDataStruct, DomainDataVariant, DomainEnc, DomainEncSpecifics, FieldFunctions, FieldTy}, most_generic_ty::get_vir_base_name_kind, predicate::{PredicateBuilder, PredicateEncData, PredicateEncDataEnum, PredicateEncDataStruct, PredicateEncDataVariant, PredicateEncOutput}, rust_ty_predicates::RustTyPredicatesEnc, rust_ty_snapshots::RustTySnapshotsEnc, snapshot::SnapshotEncOutput, PredicateEnc, PredicateEncOutputRef, SnapshotEnc};
 
 pub(crate) fn domain<'vir>(
     task_key: <DomainEnc as TaskEncoder>::TaskKey<'vir>,
@@ -18,6 +18,22 @@ pub(crate) fn domain<'vir>(
     let typeof_ident = builder.function("typeof", &[builder.self_type()], builder.type_type());
 
     deps.emit_output_ref(task_key, builder.output_ref(base_name, typeof_ident.to_known()))?;
+
+    // TODO: typeof and read_type axioms
+    /*
+    // for struct U<T> { x: T, y: i32 }
+    // this one forwards the generic
+    axiom ax_s_U_read_0_type {
+        forall self: s_U :: {s_U_read_0(self)} (typ(s_U_read_0(self))) == (s_U_typaram_T(typeof_s_U(self)))
+    }
+    // this one seems less useful: this could be an axiom over s_Int_i32_typeof generally?
+    axiom ax_s_U_read_1_type {
+        forall self: s_U :: {s_U_read_1(self)} (s_Int_i32_typeof(s_U_read_1(self))) == (s_Int_i32_type())
+    }
+    axiom ax_typeof_s_U {
+        forall self: s_U :: {s_U_typaram_T(typeof_s_U(self))} (typeof_s_U(self)) == (s_U_type(s_U_typaram_T(typeof_s_U(self))))
+    }
+    */
 
     match adt.adt_kind() {
         ty::AdtKind::Struct if adt.is_box() => {
@@ -53,22 +69,6 @@ pub(crate) fn domain<'vir>(
                 .enumerate()
                 .map(|(idx, ty)| builder.function(&format!("write_{idx}"), &[builder.self_type(), ty.ty], builder.self_type()))
                 .collect::<Vec<_>>();
-
-            // TODO: typeof and read_type axioms
-            /*
-            // for struct U<T> { x: T, y: i32 }
-            // this one forwards the generic
-            axiom ax_s_U_read_0_type {
-                forall self: s_U :: {s_U_read_0(self)} (typ(s_U_read_0(self))) == (s_U_typaram_T(typeof_s_U(self)))
-            }
-            // this one seems less useful: this could be an axiom over s_Int_i32_typeof generally?
-            axiom ax_s_U_read_1_type {
-                forall self: s_U :: {s_U_read_1(self)} (s_Int_i32_typeof(s_U_read_1(self))) == (s_Int_i32_type())
-            }
-            axiom ax_typeof_s_U {
-                forall self: s_U :: {s_U_typaram_T(typeof_s_U(self))} (typeof_s_U(self)) == (s_U_type(s_U_typaram_T(typeof_s_U(self))))
-            }
-            */
 
             // variables for quantifiers
             let field_vars = fields
@@ -118,16 +118,135 @@ pub(crate) fn domain<'vir>(
             }))
         }
         ty::AdtKind::Enum => {
-            todo!()
-            /*
-            let variants: Vec<_> = adt
-                .discriminants(vcx.tcx())
-                .map(|(v, d)| {
-                    let variant = adt.variant(v);
-                    let field_tys = enc.mk_field_tys(variant, params)?;
-                    Ok((variant.name, v, field_tys, d))
+            use prusti_rustc_interface::middle::ty::util::IntTypeExt;
+            //let has_explicit = adt
+            //    .variants()
+            //    .iter()
+            //    .any(|v| matches!(v.discr, ty::VariantDiscr::Explicit(_)));
+            let discr_ty = deps
+                .require_local::<RustTySnapshotsEnc>(adt.repr().discr_type().to_ty(builder.vcx.tcx()))?
+                .generic_snapshot;
+            let discr_prim = discr_ty.specifics.expect_primitive();
+
+            // discriminant
+            let discr_ident = builder.function(
+                "discr",
+                &[builder.self_type()],
+                discr_ty.snapshot,
+            );
+
+            let variants = adt
+                .variants()
+                .iter_enumerated()
+                .zip(adt.discriminants(builder.vcx.tcx()))
+                .map(|((var_idx, variant), (_, discr))| {
+                    let var_idx_num = var_idx.as_u32();
+                    let discr = discr_ty.specifics.expect_primitive().prim_to_snap.apply(
+                        builder.vcx,
+                        [discr_prim.expr_from_bits(discr.ty, discr.val)],
+                    );
+
+                    // TODO: code duplication
+                    let fields = FieldTy::mk_field_tys(builder.vcx, deps, variant, params)?;
+
+                    // constructor
+                    let cons_ident = builder.function(
+                        &format!("cons_{var_idx_num}"),
+                        builder.vcx.alloc_slice(&fields.iter().map(|fty| fty.ty).collect::<Vec<_>>()),
+                        builder.self_type(),
+                    );
+
+                    // field accessors
+                    let field_reads = fields
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, ty)| builder.function(&format!("read_{var_idx_num}_{idx}"), &[builder.self_type()], ty.ty))
+                        .collect::<Vec<_>>();
+                    let field_writes = fields
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, ty)| builder.function(&format!("write_{var_idx_num}_{idx}"), &[builder.self_type(), ty.ty], builder.self_type()))
+                        .collect::<Vec<_>>();
+
+                    // variables for quantifiers
+                    let field_vars = fields
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, ty)| builder.vcx.mk_local(&vir_format!(builder.vcx, "f{idx}"), ty.ty))
+                        .collect::<Vec<_>>();
+
+                    // discriminant of constructor is known
+                    builder.axiom(&format!("cons_discr_{var_idx_num}"), vir::expr! {
+                        forall ..[field_vars] ::
+                            {[cons_ident](..[field_vars])}
+                            ([discr_ident]([cons_ident](..[field_vars]))) == ([discr])
+                    });
+
+                    // field accessor axioms
+                    for idx in 0..fields.len() {
+                        builder.axiom(&format!("cons_read_{var_idx_num}_{idx}"), vir::expr! {
+                            forall ..[field_vars] ::
+                                {[cons_ident](..[field_vars])}
+                                ([field_reads[idx]]([cons_ident](..[field_vars]))) == ([field_vars[idx]])
+                        });
+                    }
+                    for write_idx in 0..fields.len() {
+                        for read_idx in 0..fields.len() {
+                            // TODO: is the trigger here too specific? we could trigger on the read already?
+                            builder.axiom(&format!("write_{var_idx_num}_{write_idx}_read_{read_idx}"), if read_idx == write_idx {
+                                vir::expr! {
+                                    forall s: [builder.self_type()], value: [fields[write_idx].ty] ::
+                                        {[field_reads[read_idx]]([field_writes[write_idx]](s, value))}
+                                        ([field_reads[read_idx]]([field_writes[write_idx]](s, value))) == (value)
+                                }
+                            } else {
+                                vir::expr! {
+                                    forall s: [builder.self_type()], value: [fields[write_idx].ty] ::
+                                        {[field_reads[read_idx]]([field_writes[write_idx]](s, value))}
+                                        ([field_reads[read_idx]]([field_writes[write_idx]](s, value))) == ([field_reads[read_idx]](s))
+                                }
+                            });
+                        }
+                    }
+
+                    let field_access = field_reads.into_iter()
+                        .zip(field_writes)
+                        .map(|(read, write)| FieldFunctions {
+                            read: read.to_known(),
+                            write: write.to_known(),
+                        })
+                        .collect::<Vec<_>>();
+
+                    Ok(DomainDataVariant {
+                        name: variant.name,
+                        vid: var_idx,
+                        discr,
+                        fields: DomainDataStruct {
+                            field_snaps_to_snap: cons_ident,
+                            field_access: builder.vcx.alloc_slice(&field_access),
+                        },
+                    })
                 })
                 .collect::<Result<Vec<_>, _>>()?;
+
+            // discriminant can only have the selected values
+            builder.axiom("discr_values", vir::expr! {
+                forall s: [builder.self_type()] :: {[discr_ident](s)} [builder.vcx.mk_disj(&variants.iter()
+                    .map(|variant| vir::expr! {
+                        ([discr_ident](s)) == ([variant.discr])
+                    })
+                    .collect::<Vec<_>>())]
+            });
+
+            Ok(DomainEncSpecifics::EnumLike(Some(DomainDataEnum {
+                discr_ty: discr_ty.snapshot,
+                discr_prim,
+                //pub discr_bounds: DiscrBounds<'vir>,
+                snap_to_discr_snap: discr_ident.to_known(),
+                variants: builder.vcx.alloc_slice(&variants), //pub variants: &'vir [DomainDataVariant<'vir>],
+            })))
+
+            /*
             let variants = if variants.is_empty() {
                 None
             } else {
@@ -154,3 +273,383 @@ pub(crate) fn domain<'vir>(
         ty::AdtKind::Union => todo!(),
     }
 }
+
+pub(crate) fn predicate<'vir>(
+    task_key: <PredicateEnc as TaskEncoder>::TaskKey<'vir>,
+    snap: SnapshotEncOutput<'vir>,
+    deps: &mut TaskEncoderDependencies<'vir, PredicateEnc>,
+    builder: &mut PredicateBuilder<'vir>,
+) -> Result<(usize, usize), EncodeFullError<'vir, PredicateEnc>> {
+    let ty = task_key.ty();
+    let ty_kind = ty.kind();
+    let ty::TyKind::Adt(adt, params) = ty_kind else { unreachable!(); };
+
+    let base_name = get_vir_base_name_kind(&ty_kind, builder.vcx);
+    builder.set_name(&base_name);
+
+    let snap_type = snap.snapshot;
+
+    let snap_self = builder.vcx.mk_local("self", snap_type);
+    let snap_self_decl = builder.vcx.mk_local_decl_local(snap_self);
+    let snap_self_ex: vir::Expr = builder.vcx.mk_local_ex_local(snap_self);
+
+    let ref_self = builder.vcx.mk_local("self", &vir::TypeData::Ref);
+    let ref_self_decl = builder.vcx.mk_local_decl_local(ref_self);
+    let ref_self_ex = builder.vcx.mk_local_ex_local(ref_self);
+
+    let self_pred_ident = builder.predicate_ident(
+        "owned",
+        &[ref_self_decl],
+    );
+    let snap_func_ident = builder.function_ident(
+        "snap",
+        &[ref_self_decl],
+        snap_type,
+    );
+
+    // unreachable (requires false) to snap (TODO: move to domain enc)
+    let unr_idx = builder.functions.len();
+    let unreachable_to_snap = builder.function(
+        "unreachable",
+        &[],
+        snap_type,
+        &[builder.vcx.mk_bool::<false>()],
+        &[builder.vcx.mk_bool::<false>()], // TODO: is this necessary?
+        None,
+    );
+
+    // assign method
+    let value = builder.vcx.mk_local("value", snap_type);
+    let method_assign = builder.method(
+        "assign",
+        &[
+            ref_self_decl,
+            builder.vcx.mk_local_decl_local(value),
+        ],
+        &[],
+        &[],
+        &[
+            vir::expr! { [self_pred_ident](ref_self) },
+            vir::expr! { ([snap_func_ident](ref_self)) == (value) },
+        ],
+    );
+
+    // TODO: we don't need to know that X is specifically a struct for:
+    // - p_X_unreachable
+    // - p_X_snap signature (but not body!)
+    // - assign_p_X
+
+    match adt.adt_kind() {
+        ty::AdtKind::Struct if adt.is_box() => {
+            todo!()
+        }
+        ty::AdtKind::Struct => {
+            let snap_data = snap.specifics.expect_structlike();
+
+            // for struct X<'a, 'b> {
+            //   o: i32,
+            //   a: &'a mut i32,
+            //   b: &'b mut i32,
+            // }
+            // we should emit:
+            // fields accessors
+            // - function p_X_field_0(self: Ref): Ref
+            // - function p_X_field_1(self: Ref): Ref
+            // - function p_X_field_2(self: Ref): Ref
+            // predicates
+            // - p_X(self: Ref) { // owned fields
+            //     p_Int_i32(p_X_field_0(self))
+            //     && p_Ref_mutable(p_X_field_1(self), s_Int_i32_type())
+            //     && p_Ref_mutable(p_X_field_2(self), s_Int_i32_type())
+            //   }
+            // - p_X_lft0(self: s_X) { // projection through 'a
+            //     p_Int_i32(s_Ref_deref(s_X_read_1(self)))
+            //   }
+            // - p_X_lft0(self: s_X) { // projection through 'a
+            //     p_Int_i32(s_Ref_deref(s_X_read_2(self)))
+            //   }
+            // functions
+            // - function p_X_unreachable(): s_X // for now; should be moved to domain encoder
+            // - function p_X_snap(self: Ref): s_X { .. }
+            // methods
+            // - method assign_p_X(self: Ref, value: s_X)
+
+            let variant = adt.non_enum_variant();
+            let fields = variant
+                .fields
+                .iter()
+                .map(|f| deps.require_ref::<RustTyPredicatesEnc>(f.ty(builder.vcx.tcx(), params)).unwrap())
+                .collect::<Vec<_>>();
+
+            // Ref-to-Ref function for every field
+            let f0_idx = builder.functions.len();
+            let field_accessors = fields.iter()
+                .enumerate()
+                .map(|(idx, _field)| builder.function(
+                    &format!("field_{idx}"),
+                    &[ref_self_decl],
+                    &vir::TypeData::Ref,
+                    &[],
+                    &[
+                        vir::expr! { ((ref_self) == (null)) == (([builder.vcx.mk_result(&vir::TypeData::Ref)]) == (null)) },
+                    ],
+                    None,
+                ))
+                .collect::<Vec<_>>();
+            let fn_idx = builder.functions.len();
+
+            // main predicate
+            let self_pred = builder.predicate(
+                "owned",
+                &[ref_self_decl],
+                Some(builder.vcx.mk_conj(&fields.iter()
+                    .zip(&field_accessors)
+                    .map(|(field, accessor)| field.ref_to_pred(builder.vcx, accessor.apply(builder.vcx, &[ref_self_ex]), None))
+                    .collect::<Vec<_>>())),
+            );
+
+            // Ref-to-snap
+            let snap_args = fields.iter()
+                .zip(&field_accessors)
+                .map(|(field, accessor)| field.ref_to_snap(builder.vcx, accessor.apply(builder.vcx, &[ref_self_ex])))
+                .collect::<Vec<_>>();
+            let snap_idx = builder.functions.len();
+            let snap_func = builder.function(
+                "snap",
+                &[ref_self_decl],
+                snap_type,
+                &[vir::expr! { acc_wildcard([self_pred](ref_self)) }],
+                &[],
+                Some(vir::expr! {
+                    unfolding_wildcard ([self_pred](ref_self)) in ([snap_data.field_snaps_to_snap](..[snap_args]))
+                }),
+            );
+
+            // lifetime projection predicates
+            let lft_predicates = params.iter()
+                .enumerate()
+                .flat_map(|(reg_idx, arg)| Some((reg_idx, arg.as_region()?)))
+                .map(|(reg_idx, reg)| builder.predicate(
+                        &format!("lft_{reg_idx}"),
+                        &[snap_self_decl],
+                        Some(builder.vcx.mk_conj(&fields.iter()
+                            .zip(&variant.fields)
+                            .enumerate()
+                            .filter_map(|(field_idx, (field, rust_field))| match rust_field.ty(builder.vcx.tcx(), params).kind() {
+                                ty::TyKind::Ref(field_reg, inner_ty, ty::Mutability::Mut) => {
+                                    if *field_reg != reg {
+                                        return None;
+                                    }
+                                    let inner_ty_enc = deps.require_ref::<RustTyPredicatesEnc>(*inner_ty).unwrap();
+                                    Some(inner_ty_enc.ref_to_pred(
+                                        builder.vcx,
+                                        field.generic_predicate.expect_ref().snap_data.deref_access.apply(builder.vcx, [
+                                            snap_data.field_access[field_idx].read.apply(builder.vcx, [snap_self_ex]),
+                                        ]),
+                                        None,
+                                    ))
+                                }
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()))
+                    ))
+                .collect::<Vec<_>>();
+
+            deps.emit_output_ref(
+                task_key,
+                PredicateEncOutputRef {
+                    ref_to_pred: self_pred,
+                    ref_to_snap: snap_func,
+                    unreachable_to_snap: unreachable_to_snap.to_known(),
+                    method_assign,
+                    snapshot: snap_type,
+                    specifics: PredicateEncData::StructLike(PredicateEncDataStruct {
+                        snap_data,
+                        ref_to_field_refs: builder.vcx.alloc_slice(&field_accessors.iter()
+                            .map(|f| f.to_known())
+                            .collect::<Vec<_>>()),
+                    }),
+                    generics: builder.vcx.alloc_slice(&snap.generics.iter().map(|g| g.decl()).collect::<Vec<_>>()),
+                },
+            )?;
+
+            Ok((unr_idx, snap_idx))
+        }
+        ty::AdtKind::Enum => {
+            let snap_data = snap.specifics.expect_enumlike().unwrap();
+
+            // first encode the discriminant's type
+            let discr_ty = ty.discriminant_ty(builder.vcx.tcx());
+            let discr_ty_snap = deps.require_local::<RustTySnapshotsEnc>(discr_ty)?;
+            let discr_ty_snap_prim = discr_ty_snap.generic_snapshot.specifics.expect_primitive();
+            let discr_ty_out = deps.require_ref::<RustTyPredicatesEnc>(discr_ty)?;
+
+            // Ref-to-Ref function for the discriminant field
+            let fdisc_idx = builder.functions.len();
+            let fdisc_func = builder.function(
+                &format!("field_discr"),
+                &[ref_self_decl],
+                &vir::TypeData::Ref,
+                &[],
+                &[
+                    vir::expr! { ((ref_self) == (null)) == (([builder.vcx.mk_result(&vir::TypeData::Ref)]) == (null)) },
+                ],
+                None,
+            );
+
+            let mut ref_to_field_refs = Vec::new();
+            ref_to_field_refs.push(builder.functions[fdisc_idx]);
+
+            let variants = adt
+                .variants()
+                .iter_enumerated()
+                .zip(adt.discriminants(builder.vcx.tcx()))
+                .zip(snap_data.variants)
+                .map(|(((var_idx, variant), (_, discr)), snap_variant)| {
+                    let var_idx_num = var_idx.as_u32();
+
+                    // TODO: code duplication
+                    let fields = variant
+                        .fields
+                        .iter()
+                        .map(|f| deps.require_ref::<RustTyPredicatesEnc>(f.ty(builder.vcx.tcx(), params)).unwrap())
+                        .collect::<Vec<_>>();
+
+                    // Ref-to-Ref function for every field
+                    let f0_idx = builder.functions.len();
+                    let field_accessors = fields.iter()
+                        .enumerate()
+                        .map(|(idx, _field)| builder.function(
+                            &format!("field_{var_idx_num}_{idx}"),
+                            &[ref_self_decl],
+                            &vir::TypeData::Ref,
+                            &[],
+                            &[
+                                vir::expr! { ((ref_self) == (null)) == (([builder.vcx.mk_result(&vir::TypeData::Ref)]) == (null)) },
+                            ],
+                            None,
+                        ))
+                        .collect::<Vec<_>>();
+                    let fn_idx = builder.functions.len();
+                    ref_to_field_refs.extend(builder.functions[f0_idx..fn_idx].iter().cloned());
+
+                    // main variant predicate
+                    let variant_pred = builder.predicate(
+                        &format!("owned_{var_idx_num}"),
+                        &[ref_self_decl],
+                        Some(builder.vcx.mk_conj(&fields.iter()
+                            .zip(&field_accessors)
+                            .map(|(field, accessor)| field.ref_to_pred(builder.vcx, accessor.apply(builder.vcx, &[ref_self_ex]), None))
+                            .collect::<Vec<_>>())),
+                    );
+
+                    // Ref-to-snap
+                    let snap_args = fields.iter()
+                        .zip(&field_accessors)
+                        .map(|(field, accessor)| field.ref_to_snap(builder.vcx, accessor.apply(builder.vcx, &[ref_self_ex])))
+                        .collect::<Vec<_>>();
+                    let variant_snap_expr = vir::expr! {
+                        unfolding_wildcard ([variant_pred](ref_self)) in ([snap_variant.fields.field_snaps_to_snap](..[snap_args]))
+                    };
+                    let variant_pred_expr = vir::expr! {
+                        (([discr_ty_out.ref_to_snap(builder.vcx, fdisc_func.apply(builder.vcx, &[ref_self_ex]))])
+                            == ([snap_variant.discr])) => ([variant_pred](ref_self))
+                    };
+
+                    // TODO: lifetime projection predicates
+
+                    Ok((
+                        variant_snap_expr,
+                        variant_pred_expr,
+                        PredicateEncDataVariant {
+                            predicate: variant_pred,
+                            vid: var_idx,
+                            discr: snap_variant.discr,
+                            fields: PredicateEncDataStruct {
+                                snap_data: snap_variant.fields,
+                                ref_to_field_refs: builder.vcx.alloc_slice(&field_accessors.iter()
+                                    .map(|f| f.to_known())
+                                    .collect::<Vec<_>>()),
+                            },
+                        },
+                    ))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            // main predicate
+            let discr_app = discr_ty_out.ref_to_snap(builder.vcx, fdisc_func.apply(builder.vcx, &[ref_self_ex]));
+            let self_pred = builder.predicate(
+                &format!("owned"),
+                &[ref_self_decl],
+                Some(vir::expr! {
+                    ([discr_ty_out.ref_to_pred(builder.vcx, fdisc_func.apply(builder.vcx, &[ref_self_ex]), None)])
+                    && (([builder.vcx.mk_disj(&variants.iter()
+                        .map(|variant| vir::expr! { ([discr_app]) == ([variant.2.discr]) })
+                        .collect::<Vec<_>>())])
+                    && ([builder.vcx.mk_conj(&variants.iter()
+                        .map(|v| v.1)
+                        .collect::<Vec<_>>())]))
+                }),
+            );
+
+            // Ref-to-snap
+            let snap_idx = builder.functions.len();
+            let snap_func = builder.function(
+                "snap",
+                &[ref_self_decl],
+                snap_type,
+                &[vir::expr! { acc_wildcard([self_pred](ref_self)) }],
+                &[],
+                Some(vir::expr! {
+                    unfolding_wildcard ([self_pred](ref_self)) in ([variants.iter()
+                        .fold(unreachable_to_snap.apply(builder.vcx, &[]), |else_, variant| builder.vcx.mk_ternary_expr(
+                            vir::expr! { ([discr_app]) == ([variant.2.discr]) },
+                            variant.0,
+                            else_,
+                        ))])
+                }),
+            );
+
+            deps.emit_output_ref(
+                task_key,
+                PredicateEncOutputRef {
+                    ref_to_pred: self_pred,
+                    ref_to_snap: snap_func,
+                    unreachable_to_snap: unreachable_to_snap.to_known(),
+                    method_assign,
+                    snapshot: snap_type,
+                    specifics: PredicateEncData::EnumLike(Some(PredicateEncDataEnum {
+                        discr: fdisc_func.to_known(),
+                        discr_prim: discr_ty_snap_prim,
+                        //discr_bounds: (),
+                        variants: builder.vcx.alloc_slice(&variants.iter().map(|v| v.2).collect::<Vec<_>>()),
+                    })),
+                    /*
+                    specifics: PredicateEncData::StructLike(PredicateEncDataStruct {
+                        snap_data,
+                        ref_to_field_refs: builder.vcx.alloc_slice(&field_accessors.iter()
+                            .map(|f| f.to_known())
+                            .collect::<Vec<_>>()),
+                    }),
+                    */
+                    generics: builder.vcx.alloc_slice(&snap.generics.iter().map(|g| g.decl()).collect::<Vec<_>>()),
+                },
+            )?;
+
+            Ok((unr_idx, snap_idx))
+        }
+        ty::AdtKind::Union => todo!(),
+    }
+}
+
+/*
+pub(crate) fn project_to_lifetimes(
+    task_key: <DomainEnc as TaskEncoder>::TaskKey<'vir>,
+) {
+    let ty = task_key.ty();
+    let ty_kind = ty.kind();
+    let ty::TyKind::Adt(adt, params) = ty_kind else { unreachable!(); };
+
+
+}
+*/

--- a/prusti-encoder/src/encoders/type/kinds/adt.rs
+++ b/prusti-encoder/src/encoders/type/kinds/adt.rs
@@ -1,0 +1,156 @@
+use prusti_rustc_interface::middle::ty;
+use task_encoder::{EncodeFullError, TaskEncoder, TaskEncoderDependencies};
+use vir::{vir_format, ToKnownArity};
+use crate::encoders::{domain::{DomainBuilder, DomainDataStruct, DomainEnc, DomainEncSpecifics, FieldFunctions, FieldTy}, most_generic_ty::get_vir_base_name_kind};
+
+pub(crate) fn domain<'vir>(
+    task_key: <DomainEnc as TaskEncoder>::TaskKey<'vir>,
+    deps: &mut TaskEncoderDependencies<'vir, DomainEnc>,
+    builder: &mut DomainBuilder<'vir>,
+) -> Result<DomainEncSpecifics<'vir>, EncodeFullError<'vir, DomainEnc>> {
+    let ty = task_key.ty();
+    let ty_kind = ty.kind();
+    let ty::TyKind::Adt(adt, params) = ty_kind else { unreachable!(); };
+
+    let base_name = get_vir_base_name_kind(&ty_kind, builder.vcx);
+    builder.set_name(&base_name);
+
+    let typeof_ident = builder.function("typeof", &[builder.self_type()], builder.type_type());
+
+    deps.emit_output_ref(task_key, builder.output_ref(base_name, typeof_ident.to_known()))?;
+
+    match adt.adt_kind() {
+        ty::AdtKind::Struct if adt.is_box() => {
+            /*
+                // Box special case (this should be replaced by an
+                // extern spec in the future)
+                vec![FieldTy {
+                    ty: enc.deps.require_ref::<GenericEnc>(())?.param_snapshot,
+                    rust_ty_data: None,
+                }]
+            */
+            todo!()
+        }
+        ty::AdtKind::Struct => {
+            let variant = adt.non_enum_variant();
+            let fields = FieldTy::mk_field_tys(builder.vcx, deps, variant, params)?;
+
+            // constructor
+            let cons_ident = builder.function(
+                "cons",
+                builder.vcx.alloc_slice(&fields.iter().map(|fty| fty.ty).collect::<Vec<_>>()),
+                builder.self_type(),
+            );
+
+            // field accessors
+            let field_reads = fields
+                .iter()
+                .enumerate()
+                .map(|(idx, ty)| builder.function(&format!("read_{idx}"), &[builder.self_type()], ty.ty))
+                .collect::<Vec<_>>();
+            let field_writes = fields
+                .iter()
+                .enumerate()
+                .map(|(idx, ty)| builder.function(&format!("write_{idx}"), &[builder.self_type(), ty.ty], builder.self_type()))
+                .collect::<Vec<_>>();
+
+            // TODO: typeof and read_type axioms
+            /*
+            // for struct U<T> { x: T, y: i32 }
+            // this one forwards the generic
+            axiom ax_s_U_read_0_type {
+                forall self: s_U :: {s_U_read_0(self)} (typ(s_U_read_0(self))) == (s_U_typaram_T(typeof_s_U(self)))
+            }
+            // this one seems less useful: this could be an axiom over s_Int_i32_typeof generally?
+            axiom ax_s_U_read_1_type {
+                forall self: s_U :: {s_U_read_1(self)} (s_Int_i32_typeof(s_U_read_1(self))) == (s_Int_i32_type())
+            }
+            axiom ax_typeof_s_U {
+                forall self: s_U :: {s_U_typaram_T(typeof_s_U(self))} (typeof_s_U(self)) == (s_U_type(s_U_typaram_T(typeof_s_U(self))))
+            }
+            */
+
+            // variables for quantifiers
+            let field_vars = fields
+                .iter()
+                .enumerate()
+                .map(|(idx, ty)| builder.vcx.mk_local(&vir_format!(builder.vcx, "f{idx}"), ty.ty))
+                .collect::<Vec<_>>();
+
+            // field accessor axioms
+            for idx in 0..fields.len() {
+                builder.axiom(&format!("cons_read_{idx}"), vir::expr! {
+                    forall ..[field_vars] ::
+                        {[cons_ident](..[field_vars])}
+                        ([field_reads[idx]]([cons_ident](..[field_vars]))) == ([field_vars[idx]])
+                });
+            }
+            for write_idx in 0..fields.len() {
+                for read_idx in 0..fields.len() {
+                    // TODO: is the trigger here too specific? we could trigger on the read already?
+                    builder.axiom(&format!("write_{write_idx}_read_{read_idx}"), if read_idx == write_idx {
+                        vir::expr! {
+                            forall s: [builder.self_type()], value: [fields[write_idx].ty] ::
+                                {[field_reads[read_idx]]([field_writes[write_idx]](s, value))}
+                                ([field_reads[read_idx]]([field_writes[write_idx]](s, value))) == (value)
+                        }
+                    } else {
+                        vir::expr! {
+                            forall s: [builder.self_type()], value: [fields[write_idx].ty] ::
+                                {[field_reads[read_idx]]([field_writes[write_idx]](s, value))}
+                                ([field_reads[read_idx]]([field_writes[write_idx]](s, value))) == ([field_reads[read_idx]](s))
+                        }
+                    });
+                }
+            }
+
+            let field_access = field_reads.into_iter()
+                .zip(field_writes)
+                .map(|(read, write)| FieldFunctions {
+                    read: read.to_known(),
+                    write: write.to_known(),
+                })
+                .collect::<Vec<_>>();
+
+            Ok(DomainEncSpecifics::StructLike(DomainDataStruct {
+                field_snaps_to_snap: cons_ident,
+                field_access: builder.vcx.alloc_slice(&field_access),
+            }))
+        }
+        ty::AdtKind::Enum => {
+            todo!()
+            /*
+            let variants: Vec<_> = adt
+                .discriminants(vcx.tcx())
+                .map(|(v, d)| {
+                    let variant = adt.variant(v);
+                    let field_tys = enc.mk_field_tys(variant, params)?;
+                    Ok((variant.name, v, field_tys, d))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let variants = if variants.is_empty() {
+                None
+            } else {
+                let has_explicit = adt
+                    .variants()
+                    .iter()
+                    .any(|v| matches!(v.discr, ty::VariantDiscr::Explicit(_)));
+                let discr_ty = adt.repr().discr_type().to_ty(vcx.tcx());
+                let discr_ty = enc
+                    .deps
+                    .require_local::<RustTySnapshotsEnc>(discr_ty)?
+                    .generic_snapshot;
+                Some(VariantData {
+                    discr_ty: discr_ty.snapshot,
+                    discr_prim: discr_ty.specifics.expect_primitive(),
+                    has_explicit,
+                    variants,
+                })
+            };
+            let specifics = enc.mk_enum_specifics(variants);
+            Ok((Some(enc.finalize(task_key)), specifics))
+            */
+        }
+        ty::AdtKind::Union => todo!(),
+    }
+}

--- a/prusti-encoder/src/encoders/type/kinds/closure.rs
+++ b/prusti-encoder/src/encoders/type/kinds/closure.rs
@@ -1,0 +1,134 @@
+use prusti_rustc_interface::middle::ty;
+use task_encoder::{EncodeFullError, TaskEncoder, TaskEncoderDependencies};
+use vir::{vir_format, ToKnownArity};
+use crate::encoders::{domain::{DomainBuilder, DomainDataStruct, DomainEnc, DomainEncSpecifics, FieldFunctions, FieldTy}, most_generic_ty::get_vir_base_name_kind};
+
+pub(crate) fn domain<'vir>(
+    task_key: <DomainEnc as TaskEncoder>::TaskKey<'vir>,
+    deps: &mut TaskEncoderDependencies<'vir, DomainEnc>,
+    builder: &mut DomainBuilder<'vir>,
+) -> Result<DomainEncSpecifics<'vir>, EncodeFullError<'vir, DomainEnc>> {
+    let ty = task_key.ty();
+    let ty_kind = ty.kind();
+    let ty::TyKind::Closure(_def_id, args) = ty_kind else { unreachable!(); };
+
+    let base_name = get_vir_base_name_kind(&ty_kind, builder.vcx);
+    builder.set_name(&base_name);
+
+    let typeof_ident = builder.function("typeof", &[builder.self_type()], builder.type_type());
+
+    deps.emit_output_ref(task_key, builder.output_ref(base_name, typeof_ident.to_known()))?;
+
+    let cl_args = args.as_closure();
+    let fields = cl_args
+        .upvar_tys()
+        .iter()
+        .map(|ty| FieldTy::from_ty(builder.vcx, deps, ty))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // constructor
+    let cons_ident = builder.function(
+        "cons",
+        builder.vcx.alloc_slice(&fields.iter().map(|fty| fty.ty).collect::<Vec<_>>()),
+        builder.self_type(),
+    );
+
+    // field accessors
+    let field_reads = fields
+        .iter()
+        .enumerate()
+        .map(|(idx, ty)| builder.function(&format!("read_{idx}"), &[builder.self_type()], ty.ty))
+        .collect::<Vec<_>>();
+    let field_writes = fields
+        .iter()
+        .enumerate()
+        .map(|(idx, ty)| builder.function(&format!("write_{idx}"), &[builder.self_type(), ty.ty], builder.self_type()))
+        .collect::<Vec<_>>();
+
+    // TODO: typeof and read_type axioms
+    /*
+    // for struct U<T> { x: T, y: i32 }
+    // this one forwards the generic
+    axiom ax_s_U_read_0_type {
+        forall self: s_U :: {s_U_read_0(self)} (typ(s_U_read_0(self))) == (s_U_typaram_T(typeof_s_U(self)))
+    }
+    // this one seems less useful: this could be an axiom over s_Int_i32_typeof generally?
+    axiom ax_s_U_read_1_type {
+        forall self: s_U :: {s_U_read_1(self)} (s_Int_i32_typeof(s_U_read_1(self))) == (s_Int_i32_type())
+    }
+    axiom ax_typeof_s_U {
+        forall self: s_U :: {s_U_typaram_T(typeof_s_U(self))} (typeof_s_U(self)) == (s_U_type(s_U_typaram_T(typeof_s_U(self))))
+    }
+    */
+
+    // variables for quantifiers
+    let field_vars = fields
+        .iter()
+        .enumerate()
+        .map(|(idx, ty)| builder.vcx.mk_local(&vir_format!(builder.vcx, "f{idx}"), ty.ty))
+        .collect::<Vec<_>>();
+
+    // field accessor axioms
+    for idx in 0..fields.len() {
+        builder.axiom(&format!("cons_read_{idx}"), vir::expr! {
+            forall ..[field_vars] ::
+                {[cons_ident](..[field_vars])}
+                ([field_reads[idx]]([cons_ident](..[field_vars]))) == ([field_vars[idx]])
+        });
+    }
+    for write_idx in 0..fields.len() {
+        for read_idx in 0..fields.len() {
+            // TODO: is the trigger here too specific? we could trigger on the read already?
+            builder.axiom(&format!("write_{write_idx}_read_{read_idx}"), if read_idx == write_idx {
+                vir::expr! {
+                    forall s: [builder.self_type()], value: [fields[write_idx].ty] ::
+                        {[field_reads[read_idx]]([field_writes[write_idx]](s, value))}
+                        ([field_reads[read_idx]]([field_writes[write_idx]](s, value))) == (value)
+                }
+            } else {
+                vir::expr! {
+                    forall s: [builder.self_type()], value: [fields[write_idx].ty] ::
+                        {[field_reads[read_idx]]([field_writes[write_idx]](s, value))}
+                        ([field_reads[read_idx]]([field_writes[write_idx]](s, value))) == ([field_reads[read_idx]](s))
+                }
+            });
+        }
+    }
+
+    let field_access = field_reads.into_iter()
+        .zip(field_writes)
+        .map(|(read, write)| FieldFunctions {
+            read: read.to_known(),
+            write: write.to_known(),
+        })
+        .collect::<Vec<_>>();
+
+    Ok(DomainEncSpecifics::StructLike(DomainDataStruct {
+        field_snaps_to_snap: cons_ident,
+        field_access: builder.vcx.alloc_slice(&field_access),
+    }))
+
+/*
+let cl_args = args.as_closure();
+let params = cl_args.parent_args();
+let generics = params
+    .iter()
+    .filter_map(|p| p.as_type())
+    .map(|ty| {
+        deps.require_local::<LiftedTyEnc<EncodeGenericsAsParamTy>>(ty)
+            .unwrap()
+            .expect_generic()
+    })
+    .collect();
+let fields = cl_args
+    .upvar_tys()
+    .iter()
+    .map(|ty| FieldTy::from_ty(vcx, deps, ty))
+    .collect::<Result<Vec<_>, _>>()?;
+let mut enc = DomainEncData::new(vcx, task_key, generics, deps);
+enc.deps
+    .emit_output_ref(*task_key, enc.output_ref(base_name))?;
+let specifics = enc.mk_struct_specifics(fields);
+return Ok((Some(enc.finalize(task_key)), specifics));
+*/
+}

--- a/prusti-encoder/src/encoders/type/kinds/mod.rs
+++ b/prusti-encoder/src/encoders/type/kinds/mod.rs
@@ -1,0 +1,10 @@
+//! Encoding for MIR types, organised by type kind.
+
+pub mod adt;
+pub mod closure;
+pub mod never;
+pub mod param;
+pub mod primitive;
+pub mod reference;
+pub mod str;
+pub mod tuple;

--- a/prusti-encoder/src/encoders/type/kinds/never.rs
+++ b/prusti-encoder/src/encoders/type/kinds/never.rs
@@ -1,0 +1,46 @@
+use prusti_rustc_interface::middle::ty;
+
+use crate::encoders::domain::{DomainBuilder, DomainEncSpecifics};
+
+pub(crate) fn domain<'vir>(
+    ty: ty::Ty<'vir>,
+    builder: &mut DomainBuilder<'vir>
+) -> DomainEncSpecifics<'vir> {
+    let ty_kind = ty.kind();
+    assert_eq!(*ty_kind, ty::TyKind::Never);
+
+    builder.set_name("never");
+    builder.emit_output_ref();
+
+    let cons_ident = builder.function("cons", &[], builder.self_type());
+    builder.function("type", &[builder.self_type()], builder.type_type());
+
+    todo!()
+    //DomainEncSpecifics::Primitive(DomainDataPrim {
+    //    prim_type,
+    //    snap_to_prim: value_ident.to_known(),
+    //    prim_to_snap: cons_ident.to_known(),
+    //})
+
+    /*
+
+    let prim_type_args = vec![FieldTy {
+        ty: prim_type,
+        rust_ty_data: None,
+    }];
+    let data = self.mk_field_functions(&prim_type_args, None, ty.is_integral());
+    // TODO: what to do about write?
+    let snap_to_prim = data.field_access[0].read;
+    let specifics = DomainDataPrim {
+        prim_type,
+        snap_to_prim,
+        prim_to_snap: data.field_snaps_to_snap.to_known(),
+    };
+    if let Some((lower, upper)) = specifics.bounds(ty) {
+        let exp = snap_to_prim.apply(self.vcx, [self.self_ex]);
+        let axiom = self.mk_bounds_axiom(self.domain.name_str(), exp, lower, upper);
+        self.axioms.push(axiom);
+    }
+    DomainEncSpecifics::Primitive(specifics)
+    */
+}

--- a/prusti-encoder/src/encoders/type/kinds/never.rs
+++ b/prusti-encoder/src/encoders/type/kinds/never.rs
@@ -1,46 +1,33 @@
 use prusti_rustc_interface::middle::ty;
+use task_encoder::{EncodeFullError, TaskEncoder, TaskEncoderDependencies};
+use vir::ToKnownArity;
 
-use crate::encoders::domain::{DomainBuilder, DomainEncSpecifics};
+use crate::encoders::domain::{DomainBuilder, DomainDataEnum, DomainDataStruct, DomainEnc, DomainEncSpecifics};
 
 pub(crate) fn domain<'vir>(
-    ty: ty::Ty<'vir>,
-    builder: &mut DomainBuilder<'vir>
-) -> DomainEncSpecifics<'vir> {
+    task_key: <DomainEnc as TaskEncoder>::TaskKey<'vir>,
+    deps: &mut TaskEncoderDependencies<'vir, DomainEnc>,
+    builder: &mut DomainBuilder<'vir>,
+) -> Result<DomainEncSpecifics<'vir>, EncodeFullError<'vir, DomainEnc>> {
+    let ty = task_key.ty();
     let ty_kind = ty.kind();
     assert_eq!(*ty_kind, ty::TyKind::Never);
 
-    builder.set_name("never");
-    builder.emit_output_ref();
+    let base_name = "Never".to_string();
+    builder.set_name(&base_name);
 
-    let cons_ident = builder.function("cons", &[], builder.self_type());
-    builder.function("type", &[builder.self_type()], builder.type_type());
+    let typeof_ident = builder.function("typeof", &[builder.self_type()], builder.type_type());
+    let dummy_cons_ident = builder.function("cons", &[], builder.self_type());
 
-    todo!()
-    //DomainEncSpecifics::Primitive(DomainDataPrim {
-    //    prim_type,
-    //    snap_to_prim: value_ident.to_known(),
-    //    prim_to_snap: cons_ident.to_known(),
-    //})
+    deps.emit_output_ref(task_key, builder.output_ref(base_name, typeof_ident.to_known()))?;
 
-    /*
+    //Ok(DomainEncSpecifics::EnumLike(DomainDataEnum {
+    //    discr_ty: &vir::TypeData::Int,
+    //    discr_prim: 
+    //}))
 
-    let prim_type_args = vec![FieldTy {
-        ty: prim_type,
-        rust_ty_data: None,
-    }];
-    let data = self.mk_field_functions(&prim_type_args, None, ty.is_integral());
-    // TODO: what to do about write?
-    let snap_to_prim = data.field_access[0].read;
-    let specifics = DomainDataPrim {
-        prim_type,
-        snap_to_prim,
-        prim_to_snap: data.field_snaps_to_snap.to_known(),
-    };
-    if let Some((lower, upper)) = specifics.bounds(ty) {
-        let exp = snap_to_prim.apply(self.vcx, [self.self_ex]);
-        let axiom = self.mk_bounds_axiom(self.domain.name_str(), exp, lower, upper);
-        self.axioms.push(axiom);
-    }
-    DomainEncSpecifics::Primitive(specifics)
-    */
+    Ok(DomainEncSpecifics::StructLike(DomainDataStruct {
+        field_snaps_to_snap: dummy_cons_ident,
+        field_access: &[],
+    }))
 }

--- a/prusti-encoder/src/encoders/type/kinds/param.rs
+++ b/prusti-encoder/src/encoders/type/kinds/param.rs
@@ -1,0 +1,26 @@
+use prusti_rustc_interface::middle::ty;
+use task_encoder::{EncodeFullError, TaskEncoder, TaskEncoderDependencies};
+use crate::encoders::{domain::{DomainBuilder, DomainEnc, DomainEncOutputRef, DomainEncSpecifics}, most_generic_ty::get_vir_base_name_kind, GenericEnc};
+
+pub(crate) fn domain<'vir>(
+    task_key: <DomainEnc as TaskEncoder>::TaskKey<'vir>,
+    deps: &mut TaskEncoderDependencies<'vir, DomainEnc>,
+    builder: &mut DomainBuilder<'vir>,
+) -> Result<DomainEncSpecifics<'vir>, EncodeFullError<'vir, DomainEnc>> {
+    let ty = task_key.ty();
+    let ty_kind = ty.kind();
+    assert!(matches!(ty_kind, ty::TyKind::Param(..)));
+
+    let base_name = get_vir_base_name_kind(&ty_kind, builder.vcx);
+    let out = deps.require_ref::<GenericEnc>(())?;
+    deps.emit_output_ref(
+        task_key,
+        DomainEncOutputRef {
+            base_name,
+            domain: out.domain_param_name,
+            ty_param_accessors: &[],
+            typeof_function: out.param_type_function,
+        },
+    )?;
+    Ok(DomainEncSpecifics::Param)
+}

--- a/prusti-encoder/src/encoders/type/kinds/primitive.rs
+++ b/prusti-encoder/src/encoders/type/kinds/primitive.rs
@@ -1,0 +1,199 @@
+use prusti_rustc_interface::middle::ty;
+use task_encoder::{EncodeFullError, TaskEncoder, TaskEncoderDependencies, TaskEncoderError};
+use vir::{Arity, FunctionIdent, ToKnownArity, UnknownArity};
+
+use crate::encoders::{domain::{DomainBuilder, DomainDataPrim, DomainEnc, DomainEncSpecifics}, most_generic_ty::get_vir_base_name_kind};
+
+trait ExprApply<'vir, A> {
+    fn expr_apply(&self, vcx: &'vir vir::VirCtxt<'vir>, args: &[A]) -> vir::Expr<'vir>;
+}
+trait ExprQuote<'vir> {
+    fn expr(&self, vcx: &'vir vir::VirCtxt<'vir>) -> vir::Expr<'vir>;
+}
+
+impl<'vir> ExprApply<'vir, vir::Expr<'vir>> for FunctionIdent<'vir, UnknownArity<'vir>> {
+    fn expr_apply(&self, vcx: &'vir vir::VirCtxt<'vir>, args: &[vir::Expr<'vir>]) -> vir::Expr<'vir> {
+        self.apply(vcx, args)
+    }
+}
+impl<'vir> ExprQuote<'vir> for vir::Expr<'vir> {
+    fn expr(&self, _vcx: &'vir vir::VirCtxt<'vir>) -> vir::Expr<'vir> {
+        self
+    }
+}
+
+#[macro_export]
+macro_rules! expr {
+    (@typ; [$outer:expr]) => { $outer };
+    (@typ; Bool) => { &vir::TypeData::Bool };
+    (@typ; Int) => { &vir::TypeData::Int };
+    (@typ; Ref) => { &vir::TypeData::Ref };
+
+    (@forall_qvars($output:ident, $qvars:ident); :: { $($triggers:tt)* } $($tokens:tt)*) => { $output.push(vcx!().mk_forall_expr(
+        vcx!().alloc_slice($qvars.as_slice()),
+        vcx!().alloc_slice($crate::expr!(@expr_list; $($triggers)*).into_iter().map(|e| vcx!().mk_trigger(&[e])).collect::<Vec<_>>().as_slice()),
+        $crate::expr!(@expr_one; $($tokens)*),
+    )) };
+    (@forall_qvars($output:ident, $qvars:ident); :: $($tokens:tt)*) => { $output.push(vcx!().mk_forall_expr(
+        // TODO: warn: no triggers provided?
+        vcx!().alloc_slice($qvars.as_slice()),
+        &[],
+        $crate::expr!(@expr_one; $($tokens)*),
+    )) };
+    (@forall_qvars($output:ident, $qvars:ident); $qvar:ident : $qtype:tt $($tokens:tt)*) => { {
+        let local = vcx!().mk_local(stringify!($qvar), $crate::expr!(@typ; $qtype)); // TODO: parse type
+        $qvars.push(vcx!().mk_local_decl_local(local));
+        let $qvar = vcx!().mk_local_ex_local(local);
+        $crate::expr!(@forall_qvars($output, $qvars); $($tokens)*)
+    } };
+    (@forall_qvars($output:ident, $qvars:ident); ) => { compile_error!("malformed forall") };
+
+    (@expr($output:ident); [ $outer:expr ]( $($args:tt)* ) ) => { { $output.push($outer.expr_apply(
+        vcx!(),
+        $crate::expr!(@expr_list; $($args)*).as_slice(),
+    )); } };
+    (@expr($output:ident); [ $outer:expr ] ) => { { $output.push($outer.expr(vcx!())); } };
+    (@expr($output:ident); ( $($lhs:tt)+ ) == ( $($rhs:tt)+ )) => { { $output.push(vcx!().mk_eq_expr(
+        $crate::expr!(@expr_one; $($lhs)*),
+        $crate::expr!(@expr_one; $($rhs)*),
+    )); } };
+    (@expr($output:ident); ( $($lhs:tt)+ ) && ( $($rhs:tt)+ )) => { { $output.push(vcx!().mk_conj(&[
+        $crate::expr!(@expr_one; $($lhs)*),
+        $crate::expr!(@expr_one; $($rhs)*),
+    ])); } };
+    (@expr($output:ident); ( $($lhs:tt)+ ) <= ( $($rhs:tt)+ )) => { { $output.push(vcx!().mk_bin_op_expr(
+        vir::BinOpKind::CmpLe,
+        $crate::expr!(@expr_one; $($lhs)*),
+        $crate::expr!(@expr_one; $($rhs)*),
+    )); } };
+    (@expr($output:ident); null) => { { $output.push(vcx!().mk_null()); } };
+    (@expr($output:ident); true) => { { $output.push(vcx!().mk_bool::<true>()); } };
+    (@expr($output:ident); false) => { { $output.push(vcx!().mk_bool::<false>()); } };
+    (@expr($output:ident); forall $($tokens:tt)+) => { {
+        let mut qvars = Vec::new();
+        $crate::expr!(@forall_qvars($output, qvars); $($tokens)*)
+    } };
+    (@expr($output:ident); $ident:ident) => { { $output.push($ident); } };
+    (@expr($output:ident); $($tokens:tt)+) => { compile_error!("syntax error") };
+    (@expr($output:ident);) => { compile_error!("unexpected end of VIR expression") };
+
+    (@expr_one; $($tokens:tt)*) => { {
+        #[allow(unused_mut)]
+        let mut output: Vec<vir::Expr> = Vec::with_capacity(1);
+        $crate::expr!(@expr(output); $($tokens)*);
+        assert_eq!(output.len(), 1, "expected one VIR expression");
+        output[0]
+    } };
+    (@expr_list; $($tokens:tt)*) => { {
+        #[allow(unused_mut)]
+        let mut output: Vec<vir::Expr> = Vec::new();
+        $crate::expr!(@expr(output); $($tokens)*);
+        output
+    } };
+
+    ($vcx:expr; $($tokens:tt)+) => { {
+        let vcx = $vcx; macro_rules! vcx { () => { vcx }; }
+        $crate::expr!(@expr_one; $($tokens)*)
+    } };
+    ($($tokens:tt)+) => { vir::with_vcx(|vcx| {
+        macro_rules! vcx { () => { vcx }; }
+        $crate::expr!(@expr_one; $($tokens)*)
+    }) };
+    () => { compile_error!("expected VIR expression") };
+}
+
+pub(crate) fn domain<'vir>(
+    task_key: <DomainEnc as TaskEncoder>::TaskKey<'vir>,
+    deps: &mut TaskEncoderDependencies<'vir, DomainEnc>,
+    builder: &mut DomainBuilder<'vir>,
+) -> Result<DomainEncSpecifics<'vir>, EncodeFullError<'vir, DomainEnc>> {
+    let ty = task_key.ty();
+    let ty_kind = ty.kind();
+    let prim_type = match ty_kind {
+        ty::TyKind::Bool => &vir::TypeData::Bool,
+        ty::TyKind::Char
+        | ty::TyKind::Int(_)
+        | ty::TyKind::Uint(_) => &vir::TypeData::Int,
+        ty::TyKind::Float(_) => todo!(),
+        _ => unreachable!(),
+    };
+
+    let base_name = get_vir_base_name_kind(&ty_kind, builder.vcx);
+    builder.set_name(&base_name);
+
+    let typeof_ident = builder.function("typeof", &[builder.self_type()], builder.type_type());
+
+    deps.emit_output_ref(task_key, builder.output_ref(base_name, typeof_ident.to_known()))?;
+
+    let value_ident = builder.function("value", &[builder.self_type()], prim_type);
+    let cons_ident = builder.function("cons", &[prim_type], builder.self_type());
+
+    builder.axiom("value", expr! {
+        forall value: [prim_type] :: {[cons_ident](value)} ([value_ident]([cons_ident](value))) == (value)
+    });
+    builder.axiom("cons", expr! {
+        forall s: [builder.self_type()] :: {[value_ident](s)} ([cons_ident]([value_ident](s))) == (s)
+    });
+
+    match ty_kind {
+        ty::TyKind::Int(_) => {
+            let min = builder.vcx.get_min_int(&ty_kind);
+            let max = builder.vcx.get_max_int(&ty_kind);
+            builder.axiom("bounds", expr! {
+                forall s: [builder.self_type()] :: {[value_ident](s)} (([min]) <= ([value_ident](s))) && (([value_ident](s)) <= ([max]))
+            });
+        }
+        _ => (),
+    }
+
+    Ok(DomainEncSpecifics::Primitive(DomainDataPrim {
+        prim_type,
+        snap_to_prim: value_ident.to_known(),
+        prim_to_snap: cons_ident.to_known(),
+    }))
+
+    /*
+
+    let prim_type_args = vec![FieldTy {
+        ty: prim_type,
+        rust_ty_data: None,
+    }];
+    let data = self.mk_field_functions(&prim_type_args, None, ty.is_integral());
+    // TODO: what to do about write?
+    let snap_to_prim = data.field_access[0].read;
+    let specifics = DomainDataPrim {
+        prim_type,
+        snap_to_prim,
+        prim_to_snap: data.field_snaps_to_snap.to_known(),
+    };
+    if let Some((lower, upper)) = specifics.bounds(ty) {
+        let exp = snap_to_prim.apply(self.vcx, [self.self_ex]);
+        let axiom = self.mk_bounds_axiom(self.domain.name_str(), exp, lower, upper);
+        self.axioms.push(axiom);
+    }
+    DomainEncSpecifics::Primitive(specifics)
+    */
+}
+
+/*
+
+
+domain s_Int_i32 {
+  axiom ax_s_Int_i32_cons_read_0 {
+    forall f0: Int :: {s_Int_i32_cons(f0)} (s_Int_i32_read_0(s_Int_i32_cons(f0))) == (f0)
+  }
+  axiom ax_s_Int_i32_cons {
+    forall self: s_Int_i32 :: {s_Int_i32_read_0(self)} (s_Int_i32_cons(s_Int_i32_read_0(self))) == (self)
+  }
+  axiom ax_s_Int_i32_write_0_read_0 {
+    forall self: s_Int_i32, val: Int :: {s_Int_i32_read_0(s_Int_i32_write_0(self, val))} (s_Int_i32_read_0(s_Int_i32_write_0(self, val))) == (val)
+  }
+  axiom s_Int_i32_bounds {
+    forall self: s_Int_i32 :: {s_Int_i32_read_0(self)} ((-(2147483648)) <= (s_Int_i32_read_0(self))) && ((s_Int_i32_read_0(self)) <= (2147483647))
+  }
+  function typeof_s_Int_i32(s_Int_i32): Type
+  function s_Int_i32_cons(Int): s_Int_i32
+  function s_Int_i32_read_0(s_Int_i32): Int
+  function s_Int_i32_write_0(s_Int_i32, Int): s_Int_i32
+}
+*/

--- a/prusti-encoder/src/encoders/type/kinds/primitive.rs
+++ b/prusti-encoder/src/encoders/type/kinds/primitive.rs
@@ -1,7 +1,7 @@
 use prusti_rustc_interface::middle::ty;
 use task_encoder::{EncodeFullError, TaskEncoder, TaskEncoderDependencies};
 use vir::ToKnownArity;
-use crate::encoders::{domain::{DomainBuilder, DomainDataPrim, DomainEnc, DomainEncSpecifics}, most_generic_ty::get_vir_base_name_kind};
+use crate::encoders::{domain::{DomainBuilder, DomainDataPrim, DomainEnc, DomainEncSpecifics}, most_generic_ty::get_vir_base_name_kind, predicate::{PredicateBuilder, PredicateEncData, PredicateEncOutput}, snapshot::SnapshotEncOutput, PredicateEnc, PredicateEncOutputRef};
 
 pub(crate) fn domain<'vir>(
     task_key: <DomainEnc as TaskEncoder>::TaskKey<'vir>,
@@ -52,4 +52,104 @@ pub(crate) fn domain<'vir>(
         snap_to_prim: value_ident.to_known(),
         prim_to_snap: cons_ident.to_known(),
     }))
+}
+
+pub(crate) fn predicate<'vir>(
+    task_key: <PredicateEnc as TaskEncoder>::TaskKey<'vir>,
+    snap: SnapshotEncOutput<'vir>,
+    deps: &mut TaskEncoderDependencies<'vir, PredicateEnc>,
+    builder: &mut PredicateBuilder<'vir>,
+) -> Result<(usize, usize), EncodeFullError<'vir, PredicateEnc>> {
+    let ty = task_key.ty();
+    let ty_kind = ty.kind();
+
+    let base_name = get_vir_base_name_kind(&ty_kind, builder.vcx);
+    builder.set_name(&base_name);
+
+    let snap_type = snap.snapshot;
+
+    let snap_self = builder.vcx.mk_local("self", snap_type);
+
+    let ref_self = builder.vcx.mk_local("self", &vir::TypeData::Ref);
+    let ref_self_decl = builder.vcx.mk_local_decl_local(ref_self);
+
+    let self_pred_ident = builder.predicate_ident(
+        "",
+        &[ref_self_decl],
+    );
+    let snap_func_ident = builder.function_ident(
+        "snap",
+        &[ref_self_decl],
+        snap_type,
+    );
+
+    // unreachable (requires false) to snap (TODO: move to domain enc)
+    let unr_idx = builder.functions.len();
+    let unreachable_to_snap = builder.function(
+        "unreachable",
+        &[],
+        snap_type,
+        &[builder.vcx.mk_bool::<false>()],
+        &[builder.vcx.mk_bool::<false>()], // TODO: is this necessary?
+        None,
+    );
+
+    // assign method
+    let value = builder.vcx.mk_local("value", snap_type);
+    let method_assign = builder.method(
+        "assign",
+        &[
+            ref_self_decl,
+            builder.vcx.mk_local_decl_local(value),
+        ],
+        &[],
+        &[],
+        &[
+            vir::expr! { [self_pred_ident](ref_self) },
+            vir::expr! { ([snap_func_ident](ref_self)) == (value) },
+        ],
+    );
+
+    let snap_data = snap.specifics.expect_primitive();
+
+    // fields
+    let prim_field = builder.field(
+        "val",
+        snap_type,
+    );
+
+    // main predicate
+    let self_pred = builder.predicate(
+        "",
+        &[ref_self_decl],
+        Some(vir::expr! { acc_field([prim_field](ref_self)) }),
+    );
+
+    // Ref-to-snap
+    let snap_idx = builder.functions.len();
+    let snap_func = builder.function(
+        "snap",
+        &[ref_self_decl],
+        snap_type,
+        &[vir::expr! { acc_wildcard([self_pred](ref_self)) }],
+        &[],
+        Some(vir::expr! {
+            unfolding_wildcard ([self_pred](ref_self)) in ([prim_field](ref_self))
+        }),
+    );
+
+    deps.emit_output_ref(
+        task_key,
+        PredicateEncOutputRef {
+            ref_to_pred: self_pred,
+            ref_to_snap: snap_func,
+            unreachable_to_snap: unreachable_to_snap.to_known(),
+            method_assign,
+            snapshot: snap_type,
+            specifics: PredicateEncData::Primitive(snap_data),
+            generics: &[],
+        },
+    )?;
+
+    Ok((unr_idx, snap_idx))
 }

--- a/prusti-encoder/src/encoders/type/kinds/primitive.rs
+++ b/prusti-encoder/src/encoders/type/kinds/primitive.rs
@@ -1,106 +1,7 @@
 use prusti_rustc_interface::middle::ty;
-use task_encoder::{EncodeFullError, TaskEncoder, TaskEncoderDependencies, TaskEncoderError};
-use vir::{Arity, FunctionIdent, ToKnownArity, UnknownArity};
-
+use task_encoder::{EncodeFullError, TaskEncoder, TaskEncoderDependencies};
+use vir::ToKnownArity;
 use crate::encoders::{domain::{DomainBuilder, DomainDataPrim, DomainEnc, DomainEncSpecifics}, most_generic_ty::get_vir_base_name_kind};
-
-trait ExprApply<'vir, A> {
-    fn expr_apply(&self, vcx: &'vir vir::VirCtxt<'vir>, args: &[A]) -> vir::Expr<'vir>;
-}
-trait ExprQuote<'vir> {
-    fn expr(&self, vcx: &'vir vir::VirCtxt<'vir>) -> vir::Expr<'vir>;
-}
-
-impl<'vir> ExprApply<'vir, vir::Expr<'vir>> for FunctionIdent<'vir, UnknownArity<'vir>> {
-    fn expr_apply(&self, vcx: &'vir vir::VirCtxt<'vir>, args: &[vir::Expr<'vir>]) -> vir::Expr<'vir> {
-        self.apply(vcx, args)
-    }
-}
-impl<'vir> ExprQuote<'vir> for vir::Expr<'vir> {
-    fn expr(&self, _vcx: &'vir vir::VirCtxt<'vir>) -> vir::Expr<'vir> {
-        self
-    }
-}
-
-#[macro_export]
-macro_rules! expr {
-    (@typ; [$outer:expr]) => { $outer };
-    (@typ; Bool) => { &vir::TypeData::Bool };
-    (@typ; Int) => { &vir::TypeData::Int };
-    (@typ; Ref) => { &vir::TypeData::Ref };
-
-    (@forall_qvars($output:ident, $qvars:ident); :: { $($triggers:tt)* } $($tokens:tt)*) => { $output.push(vcx!().mk_forall_expr(
-        vcx!().alloc_slice($qvars.as_slice()),
-        vcx!().alloc_slice($crate::expr!(@expr_list; $($triggers)*).into_iter().map(|e| vcx!().mk_trigger(&[e])).collect::<Vec<_>>().as_slice()),
-        $crate::expr!(@expr_one; $($tokens)*),
-    )) };
-    (@forall_qvars($output:ident, $qvars:ident); :: $($tokens:tt)*) => { $output.push(vcx!().mk_forall_expr(
-        // TODO: warn: no triggers provided?
-        vcx!().alloc_slice($qvars.as_slice()),
-        &[],
-        $crate::expr!(@expr_one; $($tokens)*),
-    )) };
-    (@forall_qvars($output:ident, $qvars:ident); $qvar:ident : $qtype:tt $($tokens:tt)*) => { {
-        let local = vcx!().mk_local(stringify!($qvar), $crate::expr!(@typ; $qtype)); // TODO: parse type
-        $qvars.push(vcx!().mk_local_decl_local(local));
-        let $qvar = vcx!().mk_local_ex_local(local);
-        $crate::expr!(@forall_qvars($output, $qvars); $($tokens)*)
-    } };
-    (@forall_qvars($output:ident, $qvars:ident); ) => { compile_error!("malformed forall") };
-
-    (@expr($output:ident); [ $outer:expr ]( $($args:tt)* ) ) => { { $output.push($outer.expr_apply(
-        vcx!(),
-        $crate::expr!(@expr_list; $($args)*).as_slice(),
-    )); } };
-    (@expr($output:ident); [ $outer:expr ] ) => { { $output.push($outer.expr(vcx!())); } };
-    (@expr($output:ident); ( $($lhs:tt)+ ) == ( $($rhs:tt)+ )) => { { $output.push(vcx!().mk_eq_expr(
-        $crate::expr!(@expr_one; $($lhs)*),
-        $crate::expr!(@expr_one; $($rhs)*),
-    )); } };
-    (@expr($output:ident); ( $($lhs:tt)+ ) && ( $($rhs:tt)+ )) => { { $output.push(vcx!().mk_conj(&[
-        $crate::expr!(@expr_one; $($lhs)*),
-        $crate::expr!(@expr_one; $($rhs)*),
-    ])); } };
-    (@expr($output:ident); ( $($lhs:tt)+ ) <= ( $($rhs:tt)+ )) => { { $output.push(vcx!().mk_bin_op_expr(
-        vir::BinOpKind::CmpLe,
-        $crate::expr!(@expr_one; $($lhs)*),
-        $crate::expr!(@expr_one; $($rhs)*),
-    )); } };
-    (@expr($output:ident); null) => { { $output.push(vcx!().mk_null()); } };
-    (@expr($output:ident); true) => { { $output.push(vcx!().mk_bool::<true>()); } };
-    (@expr($output:ident); false) => { { $output.push(vcx!().mk_bool::<false>()); } };
-    (@expr($output:ident); forall $($tokens:tt)+) => { {
-        let mut qvars = Vec::new();
-        $crate::expr!(@forall_qvars($output, qvars); $($tokens)*)
-    } };
-    (@expr($output:ident); $ident:ident) => { { $output.push($ident); } };
-    (@expr($output:ident); $($tokens:tt)+) => { compile_error!("syntax error") };
-    (@expr($output:ident);) => { compile_error!("unexpected end of VIR expression") };
-
-    (@expr_one; $($tokens:tt)*) => { {
-        #[allow(unused_mut)]
-        let mut output: Vec<vir::Expr> = Vec::with_capacity(1);
-        $crate::expr!(@expr(output); $($tokens)*);
-        assert_eq!(output.len(), 1, "expected one VIR expression");
-        output[0]
-    } };
-    (@expr_list; $($tokens:tt)*) => { {
-        #[allow(unused_mut)]
-        let mut output: Vec<vir::Expr> = Vec::new();
-        $crate::expr!(@expr(output); $($tokens)*);
-        output
-    } };
-
-    ($vcx:expr; $($tokens:tt)+) => { {
-        let vcx = $vcx; macro_rules! vcx { () => { vcx }; }
-        $crate::expr!(@expr_one; $($tokens)*)
-    } };
-    ($($tokens:tt)+) => { vir::with_vcx(|vcx| {
-        macro_rules! vcx { () => { vcx }; }
-        $crate::expr!(@expr_one; $($tokens)*)
-    }) };
-    () => { compile_error!("expected VIR expression") };
-}
 
 pub(crate) fn domain<'vir>(
     task_key: <DomainEnc as TaskEncoder>::TaskKey<'vir>,
@@ -128,10 +29,10 @@ pub(crate) fn domain<'vir>(
     let value_ident = builder.function("value", &[builder.self_type()], prim_type);
     let cons_ident = builder.function("cons", &[prim_type], builder.self_type());
 
-    builder.axiom("value", expr! {
+    builder.axiom("value", vir::expr! {
         forall value: [prim_type] :: {[cons_ident](value)} ([value_ident]([cons_ident](value))) == (value)
     });
-    builder.axiom("cons", expr! {
+    builder.axiom("cons", vir::expr! {
         forall s: [builder.self_type()] :: {[value_ident](s)} ([cons_ident]([value_ident](s))) == (s)
     });
 
@@ -139,7 +40,7 @@ pub(crate) fn domain<'vir>(
         ty::TyKind::Int(_) => {
             let min = builder.vcx.get_min_int(&ty_kind);
             let max = builder.vcx.get_max_int(&ty_kind);
-            builder.axiom("bounds", expr! {
+            builder.axiom("bounds", vir::expr! {
                 forall s: [builder.self_type()] :: {[value_ident](s)} (([min]) <= ([value_ident](s))) && (([value_ident](s)) <= ([max]))
             });
         }
@@ -151,49 +52,4 @@ pub(crate) fn domain<'vir>(
         snap_to_prim: value_ident.to_known(),
         prim_to_snap: cons_ident.to_known(),
     }))
-
-    /*
-
-    let prim_type_args = vec![FieldTy {
-        ty: prim_type,
-        rust_ty_data: None,
-    }];
-    let data = self.mk_field_functions(&prim_type_args, None, ty.is_integral());
-    // TODO: what to do about write?
-    let snap_to_prim = data.field_access[0].read;
-    let specifics = DomainDataPrim {
-        prim_type,
-        snap_to_prim,
-        prim_to_snap: data.field_snaps_to_snap.to_known(),
-    };
-    if let Some((lower, upper)) = specifics.bounds(ty) {
-        let exp = snap_to_prim.apply(self.vcx, [self.self_ex]);
-        let axiom = self.mk_bounds_axiom(self.domain.name_str(), exp, lower, upper);
-        self.axioms.push(axiom);
-    }
-    DomainEncSpecifics::Primitive(specifics)
-    */
 }
-
-/*
-
-
-domain s_Int_i32 {
-  axiom ax_s_Int_i32_cons_read_0 {
-    forall f0: Int :: {s_Int_i32_cons(f0)} (s_Int_i32_read_0(s_Int_i32_cons(f0))) == (f0)
-  }
-  axiom ax_s_Int_i32_cons {
-    forall self: s_Int_i32 :: {s_Int_i32_read_0(self)} (s_Int_i32_cons(s_Int_i32_read_0(self))) == (self)
-  }
-  axiom ax_s_Int_i32_write_0_read_0 {
-    forall self: s_Int_i32, val: Int :: {s_Int_i32_read_0(s_Int_i32_write_0(self, val))} (s_Int_i32_read_0(s_Int_i32_write_0(self, val))) == (val)
-  }
-  axiom s_Int_i32_bounds {
-    forall self: s_Int_i32 :: {s_Int_i32_read_0(self)} ((-(2147483648)) <= (s_Int_i32_read_0(self))) && ((s_Int_i32_read_0(self)) <= (2147483647))
-  }
-  function typeof_s_Int_i32(s_Int_i32): Type
-  function s_Int_i32_cons(Int): s_Int_i32
-  function s_Int_i32_read_0(s_Int_i32): Int
-  function s_Int_i32_write_0(s_Int_i32, Int): s_Int_i32
-}
-*/

--- a/prusti-encoder/src/encoders/type/kinds/reference.rs
+++ b/prusti-encoder/src/encoders/type/kinds/reference.rs
@@ -1,0 +1,48 @@
+use prusti_rustc_interface::middle::ty;
+use task_encoder::{EncodeFullError, TaskEncoder, TaskEncoderDependencies};
+use vir::ToKnownArity;
+use crate::encoders::{domain::{DomainBuilder, DomainDataRef, DomainEnc, DomainEncSpecifics}, most_generic_ty::get_vir_base_name_kind};
+
+pub(crate) fn domain<'vir>(
+    task_key: <DomainEnc as TaskEncoder>::TaskKey<'vir>,
+    deps: &mut TaskEncoderDependencies<'vir, DomainEnc>,
+    builder: &mut DomainBuilder<'vir>,
+) -> Result<DomainEncSpecifics<'vir>, EncodeFullError<'vir, DomainEnc>> {
+    let ty = task_key.ty();
+    let ty_kind = ty.kind();
+    assert!(matches!(ty_kind, ty::TyKind::Ref(..)));
+    let prim_type = &vir::TypeData::Ref;
+
+    let base_name = get_vir_base_name_kind(&ty_kind, builder.vcx);
+    builder.set_name(&base_name);
+
+    let typeof_ident = builder.function("typeof", &[builder.self_type()], builder.type_type());
+
+    deps.emit_output_ref(task_key, builder.output_ref(base_name, typeof_ident.to_known()))?;
+
+    let deref_ident = builder.function("deref", &[builder.self_type()], prim_type);
+    let cons_ident = builder.function("cons", &[prim_type], builder.self_type());
+
+    builder.axiom("deref", vir::expr! {
+        forall value: [prim_type] :: {[cons_ident](value)} ([deref_ident]([cons_ident](value))) == (value)
+    });
+    builder.axiom("cons", vir::expr! {
+        forall s: [builder.self_type()] :: {[deref_ident](s)} ([cons_ident]([deref_ident](s))) == (s)
+    });
+
+    match ty_kind {
+        ty::TyKind::Int(_) => {
+            let min = builder.vcx.get_min_int(&ty_kind);
+            let max = builder.vcx.get_max_int(&ty_kind);
+            builder.axiom("bounds", vir::expr! {
+                forall s: [builder.self_type()] :: {[deref_ident](s)} (([min]) <= ([deref_ident](s))) && (([deref_ident](s)) <= ([max]))
+            });
+        }
+        _ => (),
+    }
+
+    Ok(DomainEncSpecifics::Ref(DomainDataRef {
+        snap_to_prim: cons_ident.to_known(),
+        deref_access: deref_ident.to_known(),
+    }))
+}

--- a/prusti-encoder/src/encoders/type/kinds/reference.rs
+++ b/prusti-encoder/src/encoders/type/kinds/reference.rs
@@ -1,7 +1,7 @@
 use prusti_rustc_interface::middle::ty;
 use task_encoder::{EncodeFullError, TaskEncoder, TaskEncoderDependencies};
 use vir::ToKnownArity;
-use crate::encoders::{domain::{DomainBuilder, DomainDataRef, DomainEnc, DomainEncSpecifics}, most_generic_ty::get_vir_base_name_kind};
+use crate::encoders::{domain::{DomainBuilder, DomainDataRef, DomainEnc, DomainEncSpecifics}, most_generic_ty::get_vir_base_name_kind, predicate::{PredicateBuilder, PredicateEncData, PredicateEncDataRef}, snapshot::SnapshotEncOutput, PredicateEnc, PredicateEncOutputRef};
 
 pub(crate) fn domain<'vir>(
     task_key: <DomainEnc as TaskEncoder>::TaskKey<'vir>,
@@ -45,4 +45,112 @@ pub(crate) fn domain<'vir>(
         snap_to_prim: cons_ident.to_known(),
         deref_access: deref_ident.to_known(),
     }))
+}
+
+pub(crate) fn predicate<'vir>(
+    task_key: <PredicateEnc as TaskEncoder>::TaskKey<'vir>,
+    snap: SnapshotEncOutput<'vir>,
+    deps: &mut TaskEncoderDependencies<'vir, PredicateEnc>,
+    builder: &mut PredicateBuilder<'vir>,
+) -> Result<(usize, usize), EncodeFullError<'vir, PredicateEnc>> {
+    let ty = task_key.ty();
+    let ty_kind = ty.kind();
+    let ty::TyKind::Ref(_, _, _) = ty_kind else { unreachable!(); };
+
+    let base_name = get_vir_base_name_kind(&ty_kind, builder.vcx);
+    builder.set_name(&base_name);
+
+    let snap_type = snap.snapshot;
+
+    let snap_self = builder.vcx.mk_local("self", snap_type);
+    //let snap_self_decl = builder.vcx.mk_local_decl_local(snap_self);
+    //let snap_self_ex: vir::Expr = builder.vcx.mk_local_ex_local(snap_self);
+
+    let ref_self = builder.vcx.mk_local("self", &vir::TypeData::Ref);
+    let ref_self_decl = builder.vcx.mk_local_decl_local(ref_self);
+    //let ref_self_ex = builder.vcx.mk_local_ex_local(ref_self);
+
+    let self_pred_ident = builder.predicate_ident(
+        "owned",
+        &[ref_self_decl],
+    );
+    let snap_func_ident = builder.function_ident(
+        "snap",
+        &[ref_self_decl],
+        snap_type,
+    );
+
+    // unreachable (requires false) to snap (TODO: move to domain enc)
+    let unr_idx = builder.functions.len();
+    let unreachable_to_snap = builder.function(
+        "unreachable",
+        &[],
+        snap_type,
+        &[builder.vcx.mk_bool::<false>()],
+        &[builder.vcx.mk_bool::<false>()], // TODO: is this necessary?
+        None,
+    );
+
+    // assign method
+    let value = builder.vcx.mk_local("value", snap_type);
+    let method_assign = builder.method(
+        "assign",
+        &[
+            ref_self_decl,
+            builder.vcx.mk_local_decl_local(value),
+        ],
+        &[],
+        &[],
+        &[
+            vir::expr! { [self_pred_ident](ref_self) },
+            vir::expr! { ([snap_func_ident](ref_self)) == (value) },
+        ],
+    );
+
+    let snap_data = snap.specifics.expect_ref();
+
+    // fields
+    let ref_field = builder.field(
+        "val",
+        snap_type,
+    );
+
+    // main predicate
+    let self_pred = builder.predicate(
+        "",
+        &[ref_self_decl],
+        Some(vir::expr! { acc_field([ref_field](ref_self)) }),
+    );
+
+    // Ref-to-snap
+    let snap_idx = builder.functions.len();
+    let snap_func = builder.function(
+        "snap",
+        &[ref_self_decl],
+        snap_type,
+        &[vir::expr! { acc_wildcard([self_pred](ref_self)) }],
+        &[],
+        Some(vir::expr! {
+            unfolding_wildcard ([self_pred](ref_self)) in ([ref_field](ref_self))
+        }),
+    );
+
+    deps.emit_output_ref(
+        task_key,
+        PredicateEncOutputRef {
+            ref_to_pred: self_pred,
+            ref_to_snap: snap_func,
+            unreachable_to_snap: unreachable_to_snap.to_known(),
+            method_assign,
+            snapshot: snap_type,
+            specifics: PredicateEncData::Ref(PredicateEncDataRef {
+                ref_field,
+                perm: None,
+                snap_data,
+            }),
+            generics: &[],
+        },
+    )?;
+
+    Ok((unr_idx, snap_idx))
 }

--- a/prusti-encoder/src/encoders/type/kinds/str.rs
+++ b/prusti-encoder/src/encoders/type/kinds/str.rs
@@ -1,0 +1,27 @@
+use prusti_rustc_interface::middle::ty;
+use task_encoder::{EncodeFullError, TaskEncoder, TaskEncoderDependencies};
+use vir::ToKnownArity;
+use crate::encoders::domain::{DomainBuilder, DomainDataStruct, DomainEnc, DomainEncSpecifics};
+
+pub(crate) fn domain<'vir>(
+    task_key: <DomainEnc as TaskEncoder>::TaskKey<'vir>,
+    deps: &mut TaskEncoderDependencies<'vir, DomainEnc>,
+    builder: &mut DomainBuilder<'vir>,
+) -> Result<DomainEncSpecifics<'vir>, EncodeFullError<'vir, DomainEnc>> {
+    let ty = task_key.ty();
+    let ty_kind = ty.kind();
+    assert_eq!(*ty_kind, ty::TyKind::Str);
+
+    let base_name = "String".to_string();
+    builder.set_name(&base_name);
+
+    let typeof_ident = builder.function("typeof", &[builder.self_type()], builder.type_type());
+    let dummy_cons_ident = builder.function("cons", &[], builder.self_type());
+
+    deps.emit_output_ref(task_key, builder.output_ref(base_name, typeof_ident.to_known()))?;
+
+    Ok(DomainEncSpecifics::StructLike(DomainDataStruct {
+        field_snaps_to_snap: dummy_cons_ident,
+        field_access: &[],
+    }))
+}

--- a/prusti-encoder/src/encoders/type/kinds/tuple.rs
+++ b/prusti-encoder/src/encoders/type/kinds/tuple.rs
@@ -1,0 +1,128 @@
+use prusti_rustc_interface::middle::ty;
+use task_encoder::{EncodeFullError, TaskEncoder, TaskEncoderDependencies};
+use vir::{vir_format, ToKnownArity};
+use crate::encoders::{domain::{DomainBuilder, DomainDataStruct, DomainEnc, DomainEncSpecifics, FieldFunctions, FieldTy}, most_generic_ty::get_vir_base_name_kind};
+
+pub(crate) fn domain<'vir>(
+    task_key: <DomainEnc as TaskEncoder>::TaskKey<'vir>,
+    deps: &mut TaskEncoderDependencies<'vir, DomainEnc>,
+    builder: &mut DomainBuilder<'vir>,
+) -> Result<DomainEncSpecifics<'vir>, EncodeFullError<'vir, DomainEnc>> {
+    let ty = task_key.ty();
+    let ty_kind = ty.kind();
+    let ty::TyKind::Tuple(params) = ty_kind else { unreachable!(); };
+
+    let base_name = get_vir_base_name_kind(&ty_kind, builder.vcx);
+    builder.set_name(&base_name);
+
+    let typeof_ident = builder.function("typeof", &[builder.self_type()], builder.type_type());
+
+    deps.emit_output_ref(task_key, builder.output_ref(base_name, typeof_ident.to_known()))?;
+
+    let fields = params
+        .iter()
+        .map(|ty| FieldTy::from_ty(builder.vcx, deps, ty))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // constructor
+    let cons_ident = builder.function(
+        "cons",
+        builder.vcx.alloc_slice(&fields.iter().map(|fty| fty.ty).collect::<Vec<_>>()),
+        builder.self_type(),
+    );
+
+    // field accessors
+    let field_reads = fields
+        .iter()
+        .enumerate()
+        .map(|(idx, ty)| builder.function(&format!("read_{idx}"), &[builder.self_type()], ty.ty))
+        .collect::<Vec<_>>();
+    let field_writes = fields
+        .iter()
+        .enumerate()
+        .map(|(idx, ty)| builder.function(&format!("write_{idx}"), &[builder.self_type(), ty.ty], builder.self_type()))
+        .collect::<Vec<_>>();
+
+    // TODO: typeof and read_type axioms
+    /*
+    // for struct U<T> { x: T, y: i32 }
+    // this one forwards the generic
+    axiom ax_s_U_read_0_type {
+        forall self: s_U :: {s_U_read_0(self)} (typ(s_U_read_0(self))) == (s_U_typaram_T(typeof_s_U(self)))
+    }
+    // this one seems less useful: this could be an axiom over s_Int_i32_typeof generally?
+    axiom ax_s_U_read_1_type {
+        forall self: s_U :: {s_U_read_1(self)} (s_Int_i32_typeof(s_U_read_1(self))) == (s_Int_i32_type())
+    }
+    axiom ax_typeof_s_U {
+        forall self: s_U :: {s_U_typaram_T(typeof_s_U(self))} (typeof_s_U(self)) == (s_U_type(s_U_typaram_T(typeof_s_U(self))))
+    }
+    */
+
+    // variables for quantifiers
+    let field_vars = fields
+        .iter()
+        .enumerate()
+        .map(|(idx, ty)| builder.vcx.mk_local(&vir_format!(builder.vcx, "f{idx}"), ty.ty))
+        .collect::<Vec<_>>();
+
+    // field accessor axioms
+    for idx in 0..fields.len() {
+        builder.axiom(&format!("cons_read_{idx}"), vir::expr! {
+            forall ..[field_vars] ::
+                {[cons_ident](..[field_vars])}
+                ([field_reads[idx]]([cons_ident](..[field_vars]))) == ([field_vars[idx]])
+        });
+    }
+    for write_idx in 0..fields.len() {
+        for read_idx in 0..fields.len() {
+            // TODO: is the trigger here too specific? we could trigger on the read already?
+            builder.axiom(&format!("write_{write_idx}_read_{read_idx}"), if read_idx == write_idx {
+                vir::expr! {
+                    forall s: [builder.self_type()], value: [fields[write_idx].ty] ::
+                        {[field_reads[read_idx]]([field_writes[write_idx]](s, value))}
+                        ([field_reads[read_idx]]([field_writes[write_idx]](s, value))) == (value)
+                }
+            } else {
+                vir::expr! {
+                    forall s: [builder.self_type()], value: [fields[write_idx].ty] ::
+                        {[field_reads[read_idx]]([field_writes[write_idx]](s, value))}
+                        ([field_reads[read_idx]]([field_writes[write_idx]](s, value))) == ([field_reads[read_idx]](s))
+                }
+            });
+        }
+    }
+
+    let field_access = field_reads.into_iter()
+        .zip(field_writes)
+        .map(|(read, write)| FieldFunctions {
+            read: read.to_known(),
+            write: write.to_known(),
+        })
+        .collect::<Vec<_>>();
+
+    Ok(DomainEncSpecifics::StructLike(DomainDataStruct {
+        field_snaps_to_snap: cons_ident,
+        field_access: builder.vcx.alloc_slice(&field_access),
+    }))
+
+/*
+    let generics = params
+    .iter()
+    .map(|ty| {
+        deps.require_local::<LiftedTyEnc<EncodeGenericsAsParamTy>>(ty)
+            .unwrap()
+            .expect_generic()
+    })
+    .collect();
+let mut enc = DomainEncData::new(vcx, task_key, generics, deps);
+enc.deps
+    .emit_output_ref(*task_key, enc.output_ref(base_name))?;
+let field_tys = params
+    .iter()
+    .map(|ty| FieldTy::from_ty(vcx, enc.deps, ty))
+    .collect::<Result<Vec<_>, _>>()?;
+let specifics = enc.mk_struct_specifics(field_tys);
+return Ok((Some(enc.finalize(task_key)), specifics));
+*/
+}

--- a/prusti-encoder/src/encoders/type/mod.rs
+++ b/prusti-encoder/src/encoders/type/mod.rs
@@ -1,6 +1,7 @@
 pub mod domain;
 pub mod predicate;
 pub mod snapshot;
+pub mod kinds;
 pub mod lifted;
 pub mod most_generic_ty;
 pub mod rust_ty_predicates;

--- a/prusti-encoder/src/encoders/type/most_generic_ty.rs
+++ b/prusti-encoder/src/encoders/type/most_generic_ty.rs
@@ -23,45 +23,49 @@ impl<'tcx: 'vir, 'vir> MostGenericTy<'tcx> {
     }
 }
 
+pub fn get_vir_base_name_kind<'tcx>(kind: &ty::TyKind<'tcx>, vcx: &vir::VirCtxt<'tcx>) -> String {
+    match kind {
+        TyKind::Bool => String::from("Bool"),
+        TyKind::Char => String::from("Char"),
+        TyKind::Int(kind) => format!("Int_{}", kind.name_str()),
+        TyKind::Uint(kind) => format!("UInt_{}", kind.name_str()),
+        TyKind::Float(kind) => format!("Float_{}", kind.name_str()),
+        TyKind::Str => String::from("String"),
+        TyKind::Adt(adt, _) => vcx.tcx().item_name(adt.did()).to_ident_string(),
+        TyKind::Tuple(params) => format!("{}_Tuple", params.len()),
+        TyKind::Never => String::from("Never"),
+        TyKind::Ref(_, _, m) => {
+            if m.is_mut() {
+                String::from("Ref_mutable")
+            } else {
+                String::from("Ref_immutable")
+            }
+        }
+        TyKind::Param(_) => String::from("Param"),
+        TyKind::Closure(def_id, _) => {
+            let def_key = vcx.tcx().def_key(def_id);
+            match def_key.disambiguated_data.data {
+                // Asking for the item_name of a closure triggers an ICE in
+                // the compiler, so we give it a name based on its parent.
+                hir::definitions::DefPathData::Closure => format!(
+                    "{}_Closure_{}",
+                    vcx.tcx().item_name(DefId {
+                        krate: def_id.krate,
+                        index: def_key.parent.unwrap()
+                    }),
+                    def_key.disambiguated_data.disambiguator,
+                ),
+                _ => vcx.tcx().item_name(*def_id).to_ident_string(),
+            }
+        }
+        TyKind::FnPtr(..) => String::from("FnPtr"),
+        other => unimplemented!("get_vir_base_name for {:?}", other),
+    }
+}
+
 impl<'tcx> MostGenericTy<'tcx> {
     pub fn get_vir_base_name(&self, vcx: &vir::VirCtxt<'tcx>) -> String {
-        match self.kind() {
-            TyKind::Bool => String::from("Bool"),
-            TyKind::Char => String::from("Char"),
-            TyKind::Int(kind) => format!("Int_{}", kind.name_str()),
-            TyKind::Uint(kind) => format!("UInt_{}", kind.name_str()),
-            TyKind::Float(kind) => format!("Float_{}", kind.name_str()),
-            TyKind::Str => String::from("String"),
-            TyKind::Adt(adt, _) => vcx.tcx().item_name(adt.did()).to_ident_string(),
-            TyKind::Tuple(params) => format!("{}_Tuple", params.len()),
-            TyKind::Never => String::from("Never"),
-            TyKind::Ref(_, _, m) => {
-                if m.is_mut() {
-                    String::from("Ref_mutable")
-                } else {
-                    String::from("Ref_immutable")
-                }
-            }
-            TyKind::Param(_) => String::from("Param"),
-            TyKind::Closure(def_id, _) => {
-                let def_key = vcx.tcx().def_key(def_id);
-                match def_key.disambiguated_data.data {
-                    // Asking for the item_name of a closure triggers an ICE in
-                    // the compiler, so we give it a name based on its parent.
-                    hir::definitions::DefPathData::Closure => format!(
-                        "{}_Closure_{}",
-                        vcx.tcx().item_name(DefId {
-                            krate: def_id.krate,
-                            index: def_key.parent.unwrap()
-                        }),
-                        def_key.disambiguated_data.disambiguator,
-                    ),
-                    _ => vcx.tcx().item_name(*def_id).to_ident_string(),
-                }
-            }
-            TyKind::FnPtr(..) => String::from("FnPtr"),
-            other => unimplemented!("get_vir_base_name for {:?}", other),
-        }
+        get_vir_base_name_kind(self.kind(), vcx)
     }
 
     pub fn is_generic(&self) -> bool {

--- a/prusti-encoder/src/encoders/type/predicate.rs
+++ b/prusti-encoder/src/encoders/type/predicate.rs
@@ -44,7 +44,7 @@ pub struct PredicateEncDataVariant<'vir> {
 pub struct PredicateEncDataRef<'vir> {
     pub ref_field: vir::Field<'vir>,
     pub perm: Option<vir::Expr<'vir>>,
-    pub snap_data: DomainDataStruct<'vir>,
+    pub snap_data: DomainDataRef<'vir>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -181,7 +181,7 @@ pub struct PredicateEncOutput<'vir> {
 use crate::encoders::GenericEnc;
 
 use super::{
-    domain::{DiscrBounds, DomainDataEnum, DomainDataPrim, DomainDataStruct},
+    domain::{DiscrBounds, DomainDataEnum, DomainDataPrim, DomainDataRef, DomainDataStruct},
     lifted::{
         generic::LiftedGeneric,
         ty::{EncodeGenericsAsLifted, LiftedTy, LiftedTyEnc},
@@ -368,14 +368,14 @@ impl TaskEncoder for PredicateEnc {
                 ty::AdtKind::Union => todo!(),
             },
             TyKind::Never => {
-                let specifics = enc.mk_enum_ref(snap.specifics.expect_enumlike());
-                assert!(specifics.is_none());
+                let specifics = enc.mk_struct_ref(Some("Never"), snap.specifics.expect_structlike());
+                //assert!(specifics.is_none());
                 deps.emit_output_ref(*task_key, enc.output_ref(PredicateEncData::EnumLike(None)))?;
 
                 Ok((enc.mk_enum(None), ()))
             }
             &TyKind::Ref(_, inner, m) => {
-                let snap_data = snap.specifics.expect_structlike();
+                let snap_data = snap.specifics.expect_ref();
                 let specifics = enc.mk_ref_ref(snap_data, m.is_mut());
                 deps.emit_output_ref(*task_key, enc.output_ref(PredicateEncData::Ref(specifics)))?;
 
@@ -545,7 +545,7 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
     }
     pub fn mk_ref_ref(
         &mut self,
-        snap_data: DomainDataStruct<'vir>,
+        snap_data: DomainDataRef<'vir>,
         mutbl: bool,
     ) -> PredicateEncDataRef<'vir> {
         let name = vir::vir_format_identifier!(self.vcx, "{}_ref", self.ref_to_pred.name());
@@ -716,12 +716,12 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
         let snap = if data.perm.is_none() {
             // `Ref` is only part of snapshots for mutable references.
             data.snap_data
-                .field_snaps_to_snap
-                .apply(self.vcx, &[inner_snap, self_ref])
+                .snap_to_prim
+                .apply(self.vcx, [self_ref]) // &[inner_snap, self_ref])
         } else {
             data.snap_data
-                .field_snaps_to_snap
-                .apply(self.vcx, &[inner_snap])
+                .snap_to_prim
+                .apply(self.vcx, [self_ref]) // &[inner_snap])
         };
         let fn_snap_body = self.vcx.mk_unfolding_expr(self.self_pred_read, snap);
         self.finalize(Some(fn_snap_body))

--- a/prusti-encoder/src/encoders/type/predicate.rs
+++ b/prusti-encoder/src/encoders/type/predicate.rs
@@ -4,8 +4,7 @@ use prusti_rustc_interface::{
 };
 use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 use vir::{
-    add_debug_note, CallableIdent, FunctionIdent, MethodIdent, NullaryArity, PredicateIdent,
-    TypeData, UnaryArity, UnknownArity, VirCtxt,
+    add_debug_note, CallableIdent, FunctionData, FunctionIdent, MethodIdent, NullaryArity, PredicateIdent, TypeData, UnaryArity, UnknownArity, VirCtxt
 };
 
 /// Takes a `MostGenericTy` and returns various Viper predicates and functions for
@@ -26,9 +25,9 @@ pub struct PredicateEncDataStruct<'vir> {
 
 #[derive(Clone, Copy, Debug)]
 pub struct PredicateEncDataEnum<'vir> {
-    pub discr: vir::Field<'vir>,
+    pub discr: FunctionIdent<'vir, UnaryArity<'vir>>,
     pub discr_prim: DomainDataPrim<'vir>,
-    pub discr_bounds: DiscrBounds<'vir>,
+    //pub discr_bounds: DiscrBounds<'vir>,
     // pub snap_to_discr_snap: FunctionIdent<'vir, UnaryArity<'vir>>,
     pub variants: &'vir [PredicateEncDataVariant<'vir>],
 }
@@ -167,6 +166,166 @@ impl<'vir> PredicateEncOutputRef<'vir> {
     }
 }
 
+pub(crate) struct PredicateBuilder<'vir> {
+    pub(crate) vcx: &'vir vir::VirCtxt<'vir>,
+    name: Option<&'vir str>,
+    pub(crate) fields: Vec<vir::Field<'vir>>,
+    pub(crate) predicates: Vec<vir::Predicate<'vir>>,
+    pub(crate) functions: Vec<vir::Function<'vir>>,
+    pub(crate) methods: Vec<vir::Method<'vir>>,
+}
+
+impl<'vir> PredicateBuilder<'vir> {
+    pub(crate) fn new(
+        vcx: &'vir vir::VirCtxt<'vir>,
+    ) -> Self {
+        PredicateBuilder {
+            vcx,
+            name: None,
+            fields: Vec::new(),
+            functions: Vec::new(),
+            methods: Vec::new(),
+            predicates: Vec::new(),
+        }
+    }
+
+    pub(crate) fn set_name(&mut self, name: &str) {
+        let name = vir::vir_format!(self.vcx, "p_{name}");
+        self.name = Some(name);
+    }
+
+    fn ident_str(&self, name: &str) -> &'vir str {
+        let prefix = self.name.expect("name should be set");
+        if name == "" {
+            prefix
+        } else {
+            vir::vir_format!(self.vcx, "{prefix}_{name}")
+        }
+    }
+
+    pub(crate) fn field(
+        &mut self,
+        name: &str,
+        typ: vir::Type<'vir>,
+    ) -> vir::Field<'vir> {
+        let name = self.ident_str(name);
+        let field = self.vcx.mk_field(name, typ);
+        self.fields.push(field);
+        field
+    }
+
+    pub(crate) fn predicate_ident(
+        &mut self,
+        name: &str,
+        args: &[vir::LocalDecl<'vir>],
+    ) -> PredicateIdent<'vir, UnknownArity<'vir>> {
+        let name = self.ident_str(name);
+        let ident = PredicateIdent::new(
+            vir::ViperIdent::new(name),
+            UnknownArity::new(self.vcx.alloc_slice(&args.iter().map(|arg| arg.ty).collect::<Vec<_>>())),
+        );
+        ident
+    }
+    pub(crate) fn predicate(
+        &mut self,
+        name: &str,
+        args: &[vir::LocalDecl<'vir>],
+        expr: Option<vir::Expr<'vir>>,
+    ) -> PredicateIdent<'vir, UnknownArity<'vir>> {
+        let name = self.ident_str(name);
+        let ident = PredicateIdent::new(
+            vir::ViperIdent::new(name),
+            UnknownArity::new(self.vcx.alloc_slice(&args.iter().map(|arg| arg.ty).collect::<Vec<_>>())),
+        );
+        self.predicates.push(self.vcx.mk_predicate(
+            ident,
+            self.vcx.alloc_slice(args),
+            expr,
+        ));
+        ident
+    }
+
+    pub(crate) fn function_ident(
+        &mut self,
+        name: &str,
+        args: &[vir::LocalDecl<'vir>],
+        ret: vir::Type<'vir>,
+    ) -> FunctionIdent<'vir, UnknownArity<'vir>> {
+        let name = self.ident_str(name);
+        let ident = FunctionIdent::new(
+            vir::ViperIdent::new(name),
+            UnknownArity::new(self.vcx.alloc_slice(&args.iter().map(|arg| arg.ty).collect::<Vec<_>>())),
+            ret,
+        );
+        ident
+    }
+    pub(crate) fn function(
+        &mut self,
+        name: &str,
+        args: &[vir::LocalDecl<'vir>],
+        ret: vir::Type<'vir>,
+        pres: &[vir::Expr<'vir>],
+        posts: &[vir::Expr<'vir>],
+        expr: Option<vir::Expr<'vir>>,
+    ) -> FunctionIdent<'vir, UnknownArity<'vir>> {
+        let name = self.ident_str(name);
+        let ident = FunctionIdent::new(
+            vir::ViperIdent::new(name),
+            UnknownArity::new(self.vcx.alloc_slice(&args.iter().map(|arg| arg.ty).collect::<Vec<_>>())),
+            ret,
+        );
+        self.functions.push(self.vcx.mk_function(
+            name,
+            self.vcx.alloc_slice(args),
+            ret,
+            self.vcx.alloc_slice(pres),
+            self.vcx.alloc_slice(posts),
+            expr,
+        ));
+        ident
+    }
+
+    pub(crate) fn method(
+        &mut self,
+        name: &str,
+        args: &[vir::LocalDecl<'vir>],
+        rets: &[vir::LocalDecl<'vir>],
+        pres: &[vir::Expr<'vir>],
+        posts: &[vir::Expr<'vir>],
+    ) -> MethodIdent<'vir, UnknownArity<'vir>> {
+        let name = self.ident_str(name);
+        let ident = MethodIdent::new(
+            vir::ViperIdent::new(name),
+            UnknownArity::new(self.vcx.alloc_slice(&args.iter().map(|arg| arg.ty).collect::<Vec<_>>())),
+            //ret,
+        );
+        self.methods.push(self.vcx.mk_method(
+            ident,
+            self.vcx.alloc_slice(args),
+            self.vcx.alloc_slice(rets),
+            self.vcx.alloc_slice(pres),
+            self.vcx.alloc_slice(posts),
+            None,
+        ));
+        ident
+    }
+
+    pub(crate) fn build(self, unr_idx: usize, snap_idx: usize) -> PredicateEncOutput<'vir> {
+        PredicateEncOutput {
+            fields: self.fields,
+            predicates: self.predicates,
+            unreachable_to_snap: self.functions[unr_idx],
+            function_snap: self.functions[snap_idx],
+            ref_to_field_refs: self.functions.iter()
+                .enumerate()
+                .filter(|(idx, _)| *idx != unr_idx && *idx != snap_idx)
+                .map(|(_, f)| *f)
+                .collect::<Vec<_>>(),
+            method_assign: self.methods[0],
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct PredicateEncOutput<'vir> {
     pub fields: Vec<vir::Field<'vir>>,
@@ -212,10 +371,32 @@ impl TaskEncoder for PredicateEnc {
     ) -> EncodeFullResult<'vir, Self> {
         let snap = deps.require_local::<SnapshotEnc>(*task_key)?;
         let generic_output_ref = deps.require_ref::<GenericEnc>(())?;
+        if let Some(res) = vir::with_vcx(|vcx| {
+            let mut builder = PredicateBuilder::new(vcx);
+            let (unr_idx, snap_idx) = match task_key.kind() {
+                TyKind::Bool
+                | TyKind::Char
+                | TyKind::Int(_)
+                | TyKind::Uint(_)
+                | TyKind::Float(_) => super::kinds::primitive::predicate(*task_key, snap.clone(), deps, &mut builder)?,
+                TyKind::Adt(..) => super::kinds::adt::predicate(*task_key, snap.clone(), deps, &mut builder)?,
+                TyKind::Ref(..) => super::kinds::reference::predicate(*task_key, snap.clone(), deps, &mut builder)?,
+                _ => return Ok(None),
+            };
+            Ok(Some(builder.build(unr_idx, snap_idx)))
+        })? {
+            return Ok((res, ()));
+        }
+
         let mut enc = vir::with_vcx(|vcx| {
             PredicateEncValues::new(vcx, &snap.base_name, snap.snapshot, snap.generics)
         });
+
         match task_key.kind() {
+            TyKind::Bool | TyKind::Char | TyKind::Int(_) | TyKind::Uint(_) | TyKind::Float(_) => unreachable!(),
+            TyKind::Adt(..) => unreachable!(),
+            TyKind::Ref(..) => unreachable!(),
+
             TyKind::Param(_) => {
                 let method_assign = vir::with_vcx(|vcx| {
                     MethodIdent::new(
@@ -262,11 +443,6 @@ impl TaskEncoder for PredicateEnc {
                     ))
                 })
             }
-            TyKind::Bool | TyKind::Char | TyKind::Int(_) | TyKind::Uint(_) | TyKind::Float(_) => {
-                let specifics = PredicateEncData::Primitive(snap.specifics.expect_primitive());
-                deps.emit_output_ref(*task_key, enc.output_ref(specifics))?;
-                Ok((enc.mk_prim(&snap.base_name), ()))
-            }
             TyKind::Closure(_def_id, args) => {
                 let snap_data = snap.specifics.expect_structlike();
                 let specifics = enc.mk_struct_ref(None, snap_data);
@@ -303,89 +479,15 @@ impl TaskEncoder for PredicateEnc {
                     enc.mk_struct_ref_to_snap_body(None, fields, snap_data.field_snaps_to_snap);
                 Ok((enc.mk_struct(fn_snap_body), ()))
             }
-            TyKind::Adt(adt, args) => match adt.adt_kind() {
-                ty::AdtKind::Struct => {
-                    let snap_data = snap.specifics.expect_structlike();
-                    let specifics = enc.mk_struct_ref(None, snap_data);
-                    deps.emit_output_ref(
-                        *task_key,
-                        enc.output_ref(PredicateEncData::StructLike(specifics)),
-                    )?;
-
-                    let fields = if !adt.is_box() {
-                        let variant = adt.non_enum_variant();
-                        variant
-                            .fields
-                            .iter()
-                            .map(|f| {
-                                deps.require_ref::<RustTyPredicatesEnc>(f.ty(enc.tcx(), args))
-                                    .unwrap()
-                            })
-                            .collect()
-                    } else {
-                        // Box special case (this should be replaced by an
-                        // extern spec in the future)
-                        vec![deps
-                            .require_ref::<RustTyPredicatesEnc>(args[0].expect_ty())
-                            .unwrap()]
-                    };
-                    let fields = enc.mk_field_apps(specifics.ref_to_field_refs, fields);
-                    let fn_snap_body =
-                        enc.mk_struct_ref_to_snap_body(None, fields, snap_data.field_snaps_to_snap);
-                    Ok((enc.mk_struct(fn_snap_body), ()))
-                }
-                ty::AdtKind::Enum => {
-                    let specifics = enc.mk_enum_ref(snap.specifics.expect_enumlike());
-                    deps.emit_output_ref(
-                        *task_key,
-                        enc.output_ref(PredicateEncData::EnumLike(specifics)),
-                    )?;
-
-                    let specifics = specifics.map(|specifics| {
-                        let variants: Vec<_> = specifics
-                            .variants
-                            .iter()
-                            .map(|data| {
-                                (
-                                    data.vid,
-                                    adt.variant(data.vid)
-                                        .fields
-                                        .iter()
-                                        .map(|f| {
-                                            deps.require_ref::<RustTyPredicatesEnc>(
-                                                f.ty(enc.tcx(), args),
-                                            )
-                                            .unwrap()
-                                        })
-                                        .collect(),
-                                )
-                            })
-                            .collect();
-                        (specifics, variants)
-                    });
-                    Ok((enc.mk_enum(specifics), ()))
-                }
-                ty::AdtKind::Union => todo!(),
-            },
             TyKind::Never => {
+                todo!()
+                /*
                 let specifics = enc.mk_struct_ref(Some("Never"), snap.specifics.expect_structlike());
                 //assert!(specifics.is_none());
                 deps.emit_output_ref(*task_key, enc.output_ref(PredicateEncData::EnumLike(None)))?;
 
                 Ok((enc.mk_enum(None), ()))
-            }
-            &TyKind::Ref(_, inner, m) => {
-                let snap_data = snap.specifics.expect_ref();
-                let specifics = enc.mk_ref_ref(snap_data, m.is_mut());
-                deps.emit_output_ref(*task_key, enc.output_ref(PredicateEncData::Ref(specifics)))?;
-
-                let lifted_ty = deps
-                    .require_local::<LiftedTyEnc<EncodeGenericsAsLifted>>(inner)
-                    .unwrap();
-                let inner = deps
-                    .require_ref::<RustTyPredicatesEnc>(inner)?
-                    .generic_predicate;
-                Ok((enc.mk_ref(inner, lifted_ty, specifics), ()))
+                */
             }
             TyKind::Str => {
                 let specifics = enc.mk_struct_ref(None, snap.specifics.expect_structlike());
@@ -562,6 +664,7 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
             snap_data,
         }
     }
+    /*
     pub fn mk_enum_ref(
         &mut self,
         snap_data: Option<DomainDataEnum<'vir>>,
@@ -604,6 +707,7 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
             }
         })
     }
+    */
 
     pub fn output_ref(&self, specifics: PredicateEncData<'vir>) -> PredicateEncOutputRef<'vir> {
         PredicateEncOutputRef {
@@ -726,6 +830,7 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
         let fn_snap_body = self.vcx.mk_unfolding_expr(self.self_pred_read, snap);
         self.finalize(Some(fn_snap_body))
     }
+    /*
     #[allow(clippy::type_complexity)]
     pub fn mk_enum(
         mut self,
@@ -799,7 +904,7 @@ impl<'vir, 'tcx> PredicateEncValues<'vir, 'tcx> {
         ));
         self.finalize(fn_snap_body)
     }
-
+*/
     fn finalize(self, fn_snap_body: Option<vir::Expr<'vir>>) -> PredicateEncOutput<'vir> {
         let mut ref_to_args = vec![self.self_decl[0]];
         ref_to_args.extend_from_slice(self.generics);

--- a/vir/src/lib.rs
+++ b/vir/src/lib.rs
@@ -9,7 +9,7 @@ mod debug;
 mod debug_info;
 mod gendata;
 mod genrefs; // TODO: explain gen...
-mod macros;
+pub mod macros;
 mod make;
 mod refs;
 mod reify;

--- a/vir/src/macros.rs
+++ b/vir/src/macros.rs
@@ -301,3 +301,121 @@ macro_rules! vir_predicate {
         )
     }};
 }
+
+pub trait ExprApply<'vir, A> {
+    fn expr_apply(&self, vcx: &'vir crate::VirCtxt<'vir>, args: &[A]) -> crate::Expr<'vir>;
+}
+pub trait ExprQuote<'vir> {
+    fn expr(&self, vcx: &'vir crate::VirCtxt<'vir>) -> crate::Expr<'vir>;
+}
+
+impl<'vir> ExprApply<'vir, crate::Expr<'vir>> for crate::FunctionIdent<'vir, crate::UnknownArity<'vir>> {
+    fn expr_apply(&self, vcx: &'vir crate::VirCtxt<'vir>, args: &[crate::Expr<'vir>]) -> crate::Expr<'vir> {
+        self.apply(vcx, args)
+    }
+}
+impl<'vir> ExprQuote<'vir> for crate::Expr<'vir> {
+    fn expr(&self, _vcx: &'vir crate::VirCtxt<'vir>) -> crate::Expr<'vir> {
+        self
+    }
+}
+impl<'vir> ExprQuote<'vir> for crate::Local<'vir> {
+    fn expr(&self, vcx: &'vir crate::VirCtxt<'vir>) -> crate::Expr<'vir> {
+        vcx.mk_local_ex_local(self)
+    }
+}
+
+#[macro_export]
+macro_rules! expr {
+    (@typ; [$outer:expr]) => { $outer };
+    (@typ; Bool) => { &$crate::TypeData::Bool };
+    (@typ; Int) => { &$crate::TypeData::Int };
+    (@typ; Ref) => { &$crate::TypeData::Ref };
+
+    (@forall_qvars($output:ident, $qvars:ident); :: { $($triggers:tt)* } $($tokens:tt)*) => { $output.push(vcx!().mk_forall_expr(
+        vcx!().alloc_slice($qvars.as_slice()),
+        vcx!().alloc_slice($crate::expr!(@expr_list; $($triggers)*).into_iter().map(|e| vcx!().mk_trigger(&[e])).collect::<Vec<_>>().as_slice()),
+        $crate::expr!(@expr_one; $($tokens)*),
+    )) };
+    (@forall_qvars($output:ident, $qvars:ident); :: $($tokens:tt)*) => { $output.push(vcx!().mk_forall_expr(
+        // TODO: warn: no triggers provided?
+        vcx!().alloc_slice($qvars.as_slice()),
+        &[],
+        $crate::expr!(@expr_one; $($tokens)*),
+    )) };
+    (@forall_qvars($output:ident, $qvars:ident); ..[$outer:expr] $($tokens:tt)*) => { {
+        $qvars.extend($outer.iter().map(|local| vcx!().mk_local_decl_local(local)));
+        $crate::expr!(@forall_qvars($output, $qvars); $($tokens)*)
+    } };
+    (@forall_qvars($output:ident, $qvars:ident); $qvar:ident : $qtype:tt $($tokens:tt)* ) => { {
+        let local = vcx!().mk_local(stringify!($qvar), $crate::expr!(@typ; $qtype));
+        $qvars.push(vcx!().mk_local_decl_local(local));
+        let $qvar: $crate::Expr = vcx!().mk_local_ex_local(local);
+        $crate::expr!(@forall_qvars($output, $qvars); $($tokens)*)
+    } };
+    (@forall_qvars($output:ident, $qvars:ident); , $($tokens:tt)* ) => { // TODO: this accepts too many commas
+        $crate::expr!(@forall_qvars($output, $qvars); $($tokens)*)
+    };
+    (@forall_qvars($output:ident, $qvars:ident); ) => { compile_error!("malformed forall") };
+
+    (@expr_done($output:ident); , $($tokens:tt)+) => { $crate::expr!(@expr($output); $($tokens)*) };
+    (@expr_done($output:ident); $($tokens:tt)+) => { compile_error!("unexpected VIR expression (missing comma?)") };
+    (@expr_done($output:ident);) => {};
+
+    (@expr($output:ident); [ $outer:expr ]( $($args:tt)* ) ) => { { $output.push($outer.expr_apply(
+        vcx!(),
+        $crate::expr!(@expr_list; $($args)*).as_slice(),
+    )); } };
+    (@expr($output:ident); [ $outer:expr ] ) => { { $output.push($outer.expr(vcx!())); } };
+    (@expr($output:ident); ..[ $outer:expr ] ) => { { $output.extend($outer.iter().map(|e| e.expr(vcx!()))); } };
+    (@expr($output:ident); ( $($lhs:tt)+ ) == ( $($rhs:tt)+ )) => { { $output.push(vcx!().mk_eq_expr(
+        $crate::expr!(@expr_one; $($lhs)*),
+        $crate::expr!(@expr_one; $($rhs)*),
+    )); } };
+    (@expr($output:ident); ( $($lhs:tt)+ ) && ( $($rhs:tt)+ )) => { { $output.push(vcx!().mk_conj(&[
+        $crate::expr!(@expr_one; $($lhs)*),
+        $crate::expr!(@expr_one; $($rhs)*),
+    ])); } };
+    (@expr($output:ident); ( $($lhs:tt)+ ) <= ( $($rhs:tt)+ )) => { { $output.push(vcx!().mk_bin_op_expr(
+        $crate::BinOpKind::CmpLe,
+        $crate::expr!(@expr_one; $($lhs)*),
+        $crate::expr!(@expr_one; $($rhs)*),
+    )); } };
+    (@expr($output:ident); null) => { { $output.push(vcx!().mk_null()); } };
+    (@expr($output:ident); true) => { { $output.push(vcx!().mk_bool::<true>()); } };
+    (@expr($output:ident); false) => { { $output.push(vcx!().mk_bool::<false>()); } };
+    (@expr($output:ident); forall $($tokens:tt)+) => { {
+        let mut qvars = Vec::new();
+        $crate::expr!(@forall_qvars($output, qvars); $($tokens)*)
+    } };
+    (@expr($output:ident); $ident:ident $($rest:tt)*) => { { $output.push($ident); $crate::expr!(@expr_done($output); $($rest)*); } };
+    (@expr($output:ident); $($tokens:tt)+) => { compile_error!("VIR syntax error") };
+    (@expr($output:ident);) => { compile_error!("unexpected end of VIR expression") };
+
+    (@expr_one; $($tokens:tt)*) => { {
+        #[allow(unused_mut)]
+        let mut output: Vec<$crate::Expr> = Vec::with_capacity(1);
+        $crate::expr!(@expr(output); $($tokens)*);
+        assert_eq!(output.len(), 1, "expected one VIR expression");
+        output[0]
+    } };
+    (@expr_list; $($tokens:tt)*) => { {
+        #[allow(unused_mut)]
+        let mut output: Vec<$crate::Expr> = Vec::new();
+        $crate::expr!(@expr(output); $($tokens)*);
+        output
+    } };
+
+    ($vcx:expr; $($tokens:tt)+) => { {
+        use $crate::macros::{ExprApply, ExprQuote};
+        let vcx = $vcx; macro_rules! vcx { () => { vcx }; }
+        $crate::expr!(@expr_one; $($tokens)*)
+    } };
+    ($($tokens:tt)+) => { vir::with_vcx(|vcx| {
+        use $crate::macros::{ExprApply, ExprQuote};
+        #[allow(unused)]
+        macro_rules! vcx { () => { vcx }; }
+        $crate::expr!(@expr_one; $($tokens)*)
+    }) };
+    () => { compile_error!("expected VIR expression") };
+}

--- a/vir/src/macros.rs
+++ b/vir/src/macros.rs
@@ -305,15 +305,28 @@ macro_rules! vir_predicate {
 pub trait ExprApply<'vir, A> {
     fn expr_apply(&self, vcx: &'vir crate::VirCtxt<'vir>, args: &[A]) -> crate::Expr<'vir>;
 }
-pub trait ExprQuote<'vir> {
-    fn expr(&self, vcx: &'vir crate::VirCtxt<'vir>) -> crate::Expr<'vir>;
-}
 
 impl<'vir> ExprApply<'vir, crate::Expr<'vir>> for crate::FunctionIdent<'vir, crate::UnknownArity<'vir>> {
     fn expr_apply(&self, vcx: &'vir crate::VirCtxt<'vir>, args: &[crate::Expr<'vir>]) -> crate::Expr<'vir> {
         self.apply(vcx, args)
     }
 }
+impl<'vir> ExprApply<'vir, crate::Expr<'vir>> for crate::PredicateIdent<'vir, crate::UnknownArity<'vir>> {
+    fn expr_apply(&self, vcx: &'vir crate::VirCtxt<'vir>, args: &[crate::Expr<'vir>]) -> crate::Expr<'vir> {
+        vcx.mk_predicate_app_expr(self.apply(vcx, args, None))
+    }
+}
+impl<'vir> ExprApply<'vir, crate::Expr<'vir>> for crate::Field<'vir> {
+    fn expr_apply(&self, vcx: &'vir crate::VirCtxt<'vir>, args: &[crate::Expr<'vir>]) -> crate::Expr<'vir> {
+        assert_eq!(args.len(), 1);
+        vcx.mk_field_expr(args[0], self)
+    }
+}
+
+pub trait ExprQuote<'vir> {
+    fn expr(&self, vcx: &'vir crate::VirCtxt<'vir>) -> crate::Expr<'vir>;
+}
+
 impl<'vir> ExprQuote<'vir> for crate::Expr<'vir> {
     fn expr(&self, _vcx: &'vir crate::VirCtxt<'vir>) -> crate::Expr<'vir> {
         self
@@ -362,12 +375,41 @@ macro_rules! expr {
     (@expr_done($output:ident); $($tokens:tt)+) => { compile_error!("unexpected VIR expression (missing comma?)") };
     (@expr_done($output:ident);) => {};
 
+    (@expr($output:ident); unfolding_wildcard ( [ $outer:expr ]( $($args:tt)* ) ) in ( $($rhs:tt)+ ) ) => { { $output.push(vcx!().mk_unfolding_expr(
+        $outer.apply(vcx!(),
+            $crate::expr!(@expr_list; $($args)*).as_slice(),
+            Some(vcx!().mk_wildcard()),
+        ),
+        $crate::expr!(@expr_one; $($rhs)*),
+    )); } };
+    (@expr($output:ident); acc( [ $outer:expr ]( $($args:tt)* ) ) ) => { { $output.push(vcx!().mk_predicate_app_expr(
+        $outer.apply(vcx!(),
+            $crate::expr!(@expr_list; $($args)*).as_slice(),
+            None,
+        )
+    )); } };
+    (@expr($output:ident); acc_field( [ $outer:expr ]( $($args:tt)* ) ) ) => { { $output.push(vcx!().mk_acc_field_expr(
+        $crate::expr!(@expr_one; $($args)*),
+        $outer,
+        None,
+    )); } };
+    (@expr($output:ident); acc_wildcard( [ $outer:expr ]( $($args:tt)* ) ) ) => { { $output.push(vcx!().mk_predicate_app_expr(
+        $outer.apply(vcx!(),
+            $crate::expr!(@expr_list; $($args)*).as_slice(),
+            Some(vcx!().mk_wildcard()),
+        )
+    )); } };
     (@expr($output:ident); [ $outer:expr ]( $($args:tt)* ) ) => { { $output.push($outer.expr_apply(
         vcx!(),
         $crate::expr!(@expr_list; $($args)*).as_slice(),
     )); } };
     (@expr($output:ident); [ $outer:expr ] ) => { { $output.push($outer.expr(vcx!())); } };
     (@expr($output:ident); ..[ $outer:expr ] ) => { { $output.extend($outer.iter().map(|e| e.expr(vcx!()))); } };
+    (@expr($output:ident); ( $($lhs:tt)+ ) => ( $($rhs:tt)+ )) => { { $output.push(vcx!().mk_bin_op_expr(
+        $crate::BinOpKind::Implies,
+        $crate::expr!(@expr_one; $($lhs)*),
+        $crate::expr!(@expr_one; $($rhs)*),
+    )); } };
     (@expr($output:ident); ( $($lhs:tt)+ ) == ( $($rhs:tt)+ )) => { { $output.push(vcx!().mk_eq_expr(
         $crate::expr!(@expr_one; $($lhs)*),
         $crate::expr!(@expr_one; $($rhs)*),
@@ -388,7 +430,7 @@ macro_rules! expr {
         let mut qvars = Vec::new();
         $crate::expr!(@forall_qvars($output, qvars); $($tokens)*)
     } };
-    (@expr($output:ident); $ident:ident $($rest:tt)*) => { { $output.push($ident); $crate::expr!(@expr_done($output); $($rest)*); } };
+    (@expr($output:ident); $ident:ident $($rest:tt)*) => { { $output.push($ident.expr(vcx!())); $crate::expr!(@expr_done($output); $($rest)*); } };
     (@expr($output:ident); $($tokens:tt)+) => { compile_error!("VIR syntax error") };
     (@expr($output:ident);) => { compile_error!("unexpected end of VIR expression") };
 


### PR DESCRIPTION
The idea is to split each type *kind* into a module of its own that defines a `domain` encoding and a `predicate` encoding, each of which uses a generic "builder" which more or less just accumulates functions, methods, etc. The messy VIR expression constructions are made a bit less painful with a declarative macro `vir::expr!` that parses a subset of VIR syntax.