### PR TITLE
Improve wand encoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,17 +1874,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mir-ssa-analysis"
-version = "0.1.0"
-dependencies = [
- "bumpalo",
- "lazy_static",
- "once_cell",
- "prusti-rustc-interface",
- "rustc-hash",
-]
-
-[[package]]
 name = "multer"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,7 +2470,6 @@ name = "prusti-encoder"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
- "mir-ssa-analysis",
  "pcg",
  "prusti-interface",
  "prusti-rustc-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
     "prusti-utils",
     "prusti-viper",
     "tracing",
-    "mir-ssa-analysis",
+    #"mir-ssa-analysis",
     "pcg",
     "prusti-interface",
     "prusti-server",

--- a/jni-gen/src/errors.rs
+++ b/jni-gen/src/errors.rs
@@ -4,6 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#![allow(unexpected_cfgs)]
 use jni;
 use std;
 

--- a/jni-gen/src/unordered_set_eq.rs
+++ b/jni-gen/src/unordered_set_eq.rs
@@ -10,7 +10,7 @@ use std::hash::Hash;
 #[derive(Debug, Copy, Clone)]
 pub struct UnorderedSetEq<'a, T: 'a>(pub &'a [T]);
 
-impl<'a, T> PartialEq for UnorderedSetEq<'a, T>
+impl<T> PartialEq for UnorderedSetEq<'_, T>
 where
     T: Eq + Hash,
 {

--- a/prusti-contracts/prusti-specs/src/common.rs
+++ b/prusti-contracts/prusti-specs/src/common.rs
@@ -204,7 +204,7 @@ mod self_type_rewriter {
         self_type_trait: Option<&'a TypePath>,
     }
 
-    impl<'a> Rewriter<'a> {
+    impl Rewriter<'_> {
         pub fn rewrite_impl_item_method(&mut self, item: &mut ImplItemMethod) {
             syn::visit_mut::visit_impl_item_method_mut(self, item);
         }
@@ -218,7 +218,7 @@ mod self_type_rewriter {
         }
     }
 
-    impl<'a> VisitMut for Rewriter<'a> {
+    impl VisitMut for Rewriter<'_> {
         fn visit_type_mut(&mut self, ty: &mut Type) {
             if let Type::Path(ty_path) = ty {
                 if ty_path.qself.is_none()
@@ -302,7 +302,7 @@ mod receiver_rewriter {
         new_ty: &'a Type,
     }
 
-    impl<'a> Rewriter<'a> {
+    impl Rewriter<'_> {
         fn rewrite_impl_item_method(&mut self, item: &mut ImplItemMethod) {
             syn::visit_mut::visit_impl_item_method_mut(self, item);
         }
@@ -332,7 +332,7 @@ mod receiver_rewriter {
         }
     }
 
-    impl<'a> VisitMut for Rewriter<'a> {
+    impl VisitMut for Rewriter<'_> {
         fn visit_fn_arg_mut(&mut self, fn_arg: &mut FnArg) {
             if let FnArg::Receiver(receiver) = fn_arg {
                 let span = receiver.span();

--- a/prusti-contracts/prusti-specs/src/extern_spec_rewriter/common.rs
+++ b/prusti-contracts/prusti-specs/src/extern_spec_rewriter/common.rs
@@ -27,7 +27,7 @@ impl ElidedLifetimeCounter {
     }
 }
 
-impl<'ast> syn::visit::Visit<'ast> for ElidedLifetimeCounter {
+impl syn::visit::Visit<'_> for ElidedLifetimeCounter {
     fn visit_receiver(&mut self, receiver: &syn::Receiver) {
         if let Some((_, None)) = receiver.reference {
             self.num_elided_lifetimes += 1;

--- a/prusti-contracts/prusti-specs/src/extern_spec_rewriter/traits.rs
+++ b/prusti-contracts/prusti-specs/src/extern_spec_rewriter/traits.rs
@@ -118,7 +118,7 @@ struct GeneratedStruct<'a> {
     generated_struct: syn::ItemStruct,
 }
 
-impl<'a> GeneratedStruct<'a> {
+impl GeneratedStruct<'_> {
     fn generate_impl(&self) -> syn::Result<syn::ItemImpl> {
         // Generate impl block
         let struct_ident = &self.generated_struct.ident;

--- a/prusti-contracts/prusti-specs/src/specifications/common.rs
+++ b/prusti-contracts/prusti-specs/src/specifications/common.rs
@@ -32,7 +32,7 @@ pub enum TryFromStringError {
     UnknownSpecificationType,
 }
 
-impl<'a> TryFrom<&'a str> for SpecType {
+impl TryFrom<&str> for SpecType {
     type Error = TryFromStringError;
 
     fn try_from(typ: &str) -> Result<SpecType, TryFromStringError> {

--- a/prusti-encoder/Cargo.toml
+++ b/prusti-encoder/Cargo.toml
@@ -12,7 +12,7 @@ cfg-if = "1.0.0"
 prusti-rustc-interface = { path = "../prusti-rustc-interface" }
 prusti-interface = { path = "../prusti-interface" }
 prusti-utils = { path = "../prusti-utils" }
-mir-ssa-analysis = { path = "../mir-ssa-analysis" }
+# mir-ssa-analysis = { path = "../mir-ssa-analysis" }
 pcg = { path = "../pcg" }
 task-encoder = { path = "../task-encoder" }
 vir = { path = "../vir" }

--- a/prusti-encoder/src/encoder_traits/impure_function_enc.rs
+++ b/prusti-encoder/src/encoder_traits/impure_function_enc.rs
@@ -90,7 +90,7 @@ where
             let mut pres = Vec::new();
             let mut posts = Vec::new();
             let spec = deps.require_local::<MirSpecEnc>((def_id, substs, None, false))?;
-            let wands = deps.require_local::<WandEnc>(WandEncTask { def_id, substs })?;
+            let wands = deps.require_local::<WandEnc>(WandEncTask { def_id })?;
 
             // Add direct resources for inputs and outputs to the pre- and
             // postconditions, respectively. "Direct" here refers to owned

--- a/prusti-encoder/src/encoders/impure/fn_wand.rs
+++ b/prusti-encoder/src/encoders/impure/fn_wand.rs
@@ -1,14 +1,13 @@
 use crate::encoders::{
-    indirect::IndirectPredicatesEnc, ImpureEncVisitor, MirLocalDefEncOutput, MirSpecEnc,
+    indirect::{IndirectKey, IndirectPredicatesEnc},
+    ImpureEncVisitor, MirLocalDefEncOutput, MirSpecEnc,
 };
 use pcg::borrow_pcg::{state::BorrowsState, unblock_graph::UnblockGraph};
-use prusti_interface::PrustiError;
+use prusti_interface::{environment::EnvQuery, PrustiError};
 use prusti_rustc_interface::{
-    data_structures::fx::FxHashMap,
-    middle::{
-        mir,
-        ty::{self, GenericArgs},
-    },
+    data_structures::fx::{FxHashMap, FxHashSet},
+    infer::infer::region_constraints::GenericKind,
+    middle::{mir, ty},
     span::{def_id::DefId, Span},
 };
 use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
@@ -18,75 +17,54 @@ pub struct WandEnc;
 
 pub type WandEncError = ();
 
+type Pledges<'vir> = Vec<(Option<(vir::Expr<'vir>, Span)>, vir::Expr<'vir>, Span)>;
+
 #[derive(Clone, Debug, Default)]
 pub struct WandEncOutput<'vir> {
-    pub encoded_wands: Vec<EncodedWand<'vir>>,
-    pub indirect_pres: Vec<(ty::Region<'vir>, mir::Local, ty::Ty<'vir>)>,
-    pub indirect_posts: Vec<(ty::Region<'vir>, mir::Local, ty::Ty<'vir>)>,
-}
-
-#[derive(Clone, Debug)]
-pub struct EncodedWand<'vir> {
-    pub region: ty::Region<'vir>,
-    pub lhs_resources: Vec<(ty::Region<'vir>, mir::Local, ty::Ty<'vir>)>,
-    pub rhs_resources: Vec<(mir::Local, ty::Ty<'vir>)>,
-    pub lhs_specs: Vec<(vir::Expr<'vir>, Span)>,
-    pub rhs_specs: Vec<(vir::Expr<'vir>, Span)>,
-}
-
-impl<'vir> EncodedWand<'vir> {
-    pub fn mk_wand<'a, E: TaskEncoder>(
-        &'a self,
-        mut snap_lhs: impl FnMut(mir::Local) -> vir::Expr<'vir>,
-        mut snap_rhs: impl FnMut(mir::Local) -> vir::Expr<'vir>,
-        vcx: &'vir vir::VirCtxt<'vir>,
-        deps: &mut TaskEncoderDependencies<'vir, E>,
-    ) -> vir::Wand<'vir> {
-        use vir::Reify;
-        let mut resource_to_expr =
-            |(region, local, ty): (ty::Region<'vir>, mir::Local, ty::Ty<'vir>)| {
-                let indirect = deps
-                    .require_ref::<IndirectPredicatesEnc>((ty, region))
-                    .unwrap();
-                indirect.expr.into_iter().map(move |e| (local, e))
-            };
-        let lhs = self
-            .lhs_resources
-            .iter()
-            .copied()
-            .flat_map(&mut resource_to_expr)
-            .map(|(l, expr)| expr.reify(vcx, snap_lhs(l)))
-            .chain(self.lhs_specs.iter().map(|(e, _)| *e))
-            .collect::<Vec<_>>();
-        let rhs = self
-            .rhs_resources
-            .iter()
-            .map(|(l, t)| (self.region, *l, *t))
-            .flat_map(&mut resource_to_expr)
-            .map(|(l, expr)| expr.reify(vcx, snap_rhs(l)))
-            .chain(self.rhs_specs.iter().map(|(e, _)| *e))
-            .collect::<Vec<_>>();
-        let lhs = vcx.mk_conj(vcx.alloc_slice(&lhs));
-        let rhs = vcx.mk_conj(vcx.alloc_slice(&rhs));
-        vcx.mk_wand(lhs, rhs)
-    }
+    pub late_bound: Vec<IndirectKey>,
+    pub inputs: Vec<IndirectKey>,
+    pub outputs: Vec<IndirectKey>,
+    pub edges: Vec<(IndirectKey, IndirectKey)>,
+    pub generic_to_param: FxHashMap<IndirectKey, Vec<(mir::Local, ty::Ty<'vir>)>>,
+    pub pledges: Pledges<'vir>,
 }
 
 impl<'vir> WandEncOutput<'vir> {
+    fn encode_generic(
+        &self,
+        vcx: &'vir vir::VirCtxt<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, impl TaskEncoder>,
+        g: IndirectKey,
+        input: bool,
+        mut snap: impl FnMut(mir::Local) -> vir::Expr<'vir>,
+    ) -> vir::Expr<'vir> {
+        use vir::Reify;
+        let conjs = self.generic_to_param[&g]
+            .iter()
+            .filter(|i| !(input && i.0 == mir::RETURN_PLACE))
+            .flat_map(move |(i, ty)| {
+                let indirect = deps.require_ref::<IndirectPredicatesEnc>((*ty, g)).unwrap();
+                let indirect = if input == (*i == mir::RETURN_PLACE) {
+                    indirect.contravariant
+                } else {
+                    indirect.covariant
+                };
+                let expr = (!indirect.is_empty()).then(|| snap(*i));
+                indirect
+                    .into_iter()
+                    .map(move |e| e.reify(vcx, expr.unwrap()))
+            });
+        vcx.mk_conj(vcx.alloc_slice(&conjs.collect::<Vec<_>>()))
+    }
+
     pub fn indirect_pres<'a, E: TaskEncoder>(
         &'a self,
         vcx: &'vir vir::VirCtxt<'vir>,
         local_defs: &'a MirLocalDefEncOutput<'vir>,
         deps: &'a mut TaskEncoderDependencies<'vir, E>,
     ) -> impl Iterator<Item = vir::Expr<'vir>> + 'a {
-        use vir::Reify;
-        self.indirect_pres.iter().flat_map(|(region, local, ty)| {
-            let indirect = deps
-                .require_ref::<IndirectPredicatesEnc>((*ty, *region))
-                .unwrap();
-            let expr = local_defs.locals[*local].impure_snap;
-            indirect.expr.into_iter().map(|e| e.reify(vcx, expr))
-        })
+        self.inputs()
+            .map(|g| self.encode_generic(vcx, deps, g, true, &|i| local_defs.locals[i].impure_snap))
     }
 
     pub fn indirect_posts<'a, E: TaskEncoder>(
@@ -95,17 +73,8 @@ impl<'vir> WandEncOutput<'vir> {
         local_defs: &'a MirLocalDefEncOutput<'vir>,
         deps: &'a mut TaskEncoderDependencies<'vir, E>,
     ) -> impl Iterator<Item = vir::Expr<'vir>> + 'a {
-        use vir::Reify;
-        self.indirect_posts.iter().flat_map(|(region, local, ty)| {
-            let indirect = deps
-                .require_ref::<IndirectPredicatesEnc>((*ty, *region))
-                .unwrap();
-            let mut expr = local_defs.locals[*local].impure_snap;
-            if *local != mir::RETURN_PLACE {
-                expr = vcx.mk_old_expr(expr);
-            }
-            indirect.expr.into_iter().map(|e| e.reify(vcx, expr))
-        })
+        self.outputs()
+            .map(|g| self.encode_generic(vcx, deps, g, false, |i| local_defs.locals[i].impure_snap))
     }
 
     pub fn wand_posts<'a, E: TaskEncoder>(
@@ -114,25 +83,31 @@ impl<'vir> WandEncOutput<'vir> {
         local_defs: &'a MirLocalDefEncOutput<'vir>,
         deps: &'a mut TaskEncoderDependencies<'vir, E>,
     ) -> impl Iterator<Item = vir::Expr<'vir>> + 'a {
-        let return_ = &local_defs.locals[mir::RETURN_PLACE];
-        let var_name = "_0_wand";
-        let tmp_ex = vcx.mk_local_ex(var_name, return_.ty.snapshot);
-        self.encoded_wands.iter().map(move |ewand| {
-            let mut uses_return = false;
-            let snap_lhs = |l| {
-                if l == mir::RETURN_PLACE {
-                    uses_return = true;
-                    tmp_ex
-                } else {
-                    vcx.mk_old_expr(local_defs.locals[l].impure_snap)
-                }
+        // TODO: wands for late-bound regions
+        self.viper_wands().into_iter().map(|(lhs, rhs, pledge)| {
+            let mut snaps = FxHashMap::default();
+            let snap_lhs = |i| {
+                snaps
+                    .entry(i)
+                    .or_insert_with(|| {
+                        let name = vir::vir_format!(vcx, "wand{:?}", i);
+                        (
+                            name,
+                            vcx.mk_local_ex(name, local_defs.locals[i].ty.snapshot),
+                        )
+                    })
+                    .1
             };
-            let snap_rhs = |l| vcx.mk_old_expr(local_defs.locals[l].impure_snap);
-            let wand = vcx.mk_wand_expr(ewand.mk_wand(snap_lhs, snap_rhs, vcx, deps));
-            if uses_return {
-                vcx.mk_let_expr(var_name, return_.impure_snap, wand)
-            } else {
-                wand
+            let snap_rhs = |i| vcx.mk_old_expr(local_defs.locals[i].impure_snap);
+            match self.mk_wand(&lhs, &rhs, &pledge, snap_lhs, snap_rhs, vcx, deps) {
+                Ok(wand) => {
+                    snaps
+                        .into_iter()
+                        .fold(vcx.mk_wand_expr(wand), |acc, (local, (name, _))| {
+                            vcx.mk_let_expr(name, local_defs.locals[local].impure_snap, acc)
+                        })
+                }
+                Err(rhs) => rhs,
             }
         })
     }
@@ -154,8 +129,13 @@ impl<'vir> WandEncOutput<'vir> {
         };
         let snap_rhs =
             |l: mir::Local| vcx.mk_local_labelled_old_expr(arguments[l.as_usize()], label_pre);
-        for ewand in &self.encoded_wands {
-            let wand = ewand.mk_wand(snap_lhs, snap_rhs, vcx, visitor.deps);
+        for (lhs, rhs, pledge) in self.viper_wands() {
+            if lhs.is_empty() {
+                continue;
+            }
+            let wand = self
+                .mk_wand(&lhs, &rhs, &pledge, snap_lhs, snap_rhs, vcx, visitor.deps)
+                .unwrap();
             visitor.stmt(visitor.vcx.mk_apply_stmt(wand));
         }
     }
@@ -177,12 +157,20 @@ impl<'vir> WandEncOutput<'vir> {
         };
         let snap_rhs = |l| vcx.mk_old_expr(visitor.local_defs.locals[l].impure_snap);
 
-        for ewand in &self.encoded_wands {
-            let wand = ewand.mk_wand(snap_lhs, snap_rhs, vcx, visitor.deps);
+        for (lhs, rhs, pledge) in self.viper_wands() {
+            if lhs.is_empty() {
+                continue;
+            }
+            let wand = self
+                .mk_wand(&lhs, &rhs, &pledge, snap_lhs, snap_rhs, vcx, visitor.deps)
+                .unwrap();
             let mut package_script = Vec::new();
-            for (rhs, _) in ewand.rhs_resources.iter().copied() {
+            for (rhs, _) in rhs.iter().flat_map(|g| &self.generic_to_param[g]) {
+                if *rhs == mir::RETURN_PLACE {
+                    continue;
+                }
                 let ug = UnblockGraph::for_node(
-                    mir::Place::from(rhs),
+                    mir::Place::from(*rhs),
                     final_borrow_state,
                     visitor.pcg_ctxt(),
                 );
@@ -193,7 +181,7 @@ impl<'vir> WandEncOutput<'vir> {
                 package_script.extend(unblock);
             }
 
-            for &(spec, span) in ewand.rhs_specs.iter() {
+            for &(_, spec, span) in pledge.iter() {
                 visitor.vcx.with_span(span, |vcx| {
                     vcx.handle_error("exhale.failed:assertion.false", move |_| {
                         Some(vec![PrustiError::verification(
@@ -212,26 +200,49 @@ impl<'vir> WandEncOutput<'vir> {
         }
         wand_packages
     }
+
+    fn mk_wand<'a, E: TaskEncoder>(
+        &'a self,
+        lhs: &[IndirectKey],
+        rhs: &[IndirectKey],
+        pledge: &Pledges<'vir>,
+        mut snap_lhs: impl FnMut(mir::Local) -> vir::Expr<'vir>,
+        mut snap_rhs: impl FnMut(mir::Local) -> vir::Expr<'vir>,
+        vcx: &'vir vir::VirCtxt<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, E>,
+    ) -> Result<vir::Wand<'vir>, vir::Expr<'vir>> {
+        let rhs = rhs
+            .iter()
+            .map(|g| self.encode_generic(vcx, deps, *g, true, &mut snap_rhs));
+        let rhs = rhs.chain(pledge.iter().map(|(_, rhs, _)| *rhs));
+        let rhs = vcx.mk_conj(vcx.alloc_slice(&rhs.collect::<Vec<_>>()));
+        if lhs.is_empty() {
+            return Err(rhs);
+        }
+        let lhs = lhs
+            .iter()
+            .map(|g| self.encode_generic(vcx, deps, *g, false, &mut snap_lhs));
+        let lhs = lhs.chain(
+            pledge
+                .iter()
+                .filter_map(|(lhs, _, _)| lhs.map(|(lhs, _)| lhs)),
+        );
+        let lhs = vcx.mk_conj(vcx.alloc_slice(&lhs.collect::<Vec<_>>()));
+        Ok(vcx.mk_wand(lhs, rhs))
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct WandEncTask<'tcx> {
+pub struct WandEncTask {
     pub def_id: DefId,
-    pub substs: ty::GenericArgsRef<'tcx>,
-}
-
-macro_rules! wands_println {
-    ($($args:tt)*) => {
-        // println!($($args)*)
-    };
 }
 
 impl TaskEncoder for WandEnc {
     task_encoder::encoder_cache!(WandEnc);
 
-    type TaskDescription<'vir> = WandEncTask<'vir>;
+    type TaskDescription<'vir> = WandEncTask;
 
-    type TaskKey<'vir> = WandEncTask<'vir>;
+    type TaskKey<'vir> = WandEncTask;
 
     type OutputFullLocal<'vir> = WandEncOutput<'vir>;
 
@@ -240,7 +251,6 @@ impl TaskEncoder for WandEnc {
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         WandEncTask {
             def_id: task.def_id,
-            substs: task.substs,
         }
     }
 
@@ -251,194 +261,202 @@ impl TaskEncoder for WandEnc {
         deps.emit_output_ref(task_key.clone(), ())?;
         vir::with_vcx(|vcx| {
             let def_id = task_key.def_id;
-            let substs = task_key.substs;
             let tcx = vcx.tcx();
+            let ecx = EnvQuery::new(tcx);
+            let substs = ecx.identity_substs(def_id);
 
-            // Collect all early-boundy lifetimes. These are generics, same as
-            // type params, so we can find them in the identity substitution.
-            let lifetimes = GenericArgs::identity_for_item(tcx, def_id)
-                .regions()
-                .collect::<Vec<_>>();
-            let sig = tcx.fn_sig(def_id);
-            let sig_identity = sig.instantiate_identity();
-
-            // TODO: what about late-bound regions? In function signatures such
-            //   as this reborrowing function:
-            // ```rust
-            // fn reborrow(x: &mut (i32, i32)) -> &mut i32 { &mut x.0 }
-            // ```
-            //   the lifetimes are *not* early-bound, but we still want a magic
-            //   wand to represent the reborrow.
-            /*
-            #[derive(Debug)]
-            enum SigLifetime<'tcx> {
-                Early(ty::Region<'tcx>),
-                Late(ty::BoundRegionKind),
-            }
-            let mut lifetimes = Vec::new();
-            //   - early-bound regions are substituted with the generics of the
-            //     item, so we can find them in the identity substitution
-            lifetimes.extend(GenericArgs::identity_for_item(tcx, def_id)
-                .regions()
-                .map(SigLifetime::Early));
-            //   - late-bound regions are found in the item's binder
-            let sig = tcx.fn_sig(def_id);
-            let sig_identity = sig.instantiate_identity();
-            lifetimes.extend(tcx.collect_referenced_late_bound_regions(sig_identity)
+            let fn_sig = ecx.get_fn_sig(def_id, substs);
+            let late_bound = tcx.collect_referenced_late_bound_regions(fn_sig);
+            let args = [fn_sig.skip_binder().output()]
                 .into_iter()
-                .map(SigLifetime::Late));
-            println!("  lifetimes: {:?}", lifetimes);
-            */
+                .chain(fn_sig.skip_binder().inputs().iter().copied())
+                .enumerate();
+            let mut generic_to_param: FxHashMap<IndirectKey, Vec<_>> = Default::default();
+            for (i, ty) in args {
+                for ga in ty.walk() {
+                    let Some(key) = IndirectKey::from_generic_arg(ga) else {
+                        continue;
+                    };
+                    generic_to_param
+                        .entry(key)
+                        .or_default()
+                        .push((mir::Local::from_usize(i), ty));
+                }
+            }
 
-            // TODO: consider variance of arguments wrt. each lifetime.
+            let outlives_env = ecx.outlives_env(def_id);
 
-            // Collect outlives relations, both explicit (e.g. declared in a
-            // `where` clause) and inferred (e.g. due to type nesting).
-            let mut outlives: FxHashMap<ty::Region, Vec<ty::Region>> = FxHashMap::default();
-            for (predicate, _span) in tcx.predicates_of(def_id).instantiate_identity(tcx) {
-                let Some(clause_kind) = predicate.kind().no_bound_vars() else {
-                    wands_println!(
-                        "  predicate not handled due to non-empty binder: {predicate:?}"
-                    );
-                    continue;
+            // for b in inputs { requires b }
+            let mut inputs = Vec::new();
+            // for a in outputs { ensures a }
+            let mut outputs = Vec::new();
+            // for (a, b) in edges { ensures a --* b }
+            let mut edges = Vec::new();
+
+            let variances = tcx.variances_of(def_id);
+            let generics = tcx.generics_of(def_id);
+            assert_eq!(generics.count(), variances.len());
+            assert!(generics.has_late_bound_regions.is_some() || late_bound.is_empty());
+
+            let mut gidx_map: FxHashMap<IndirectKey, usize> = Default::default();
+            for i in 0..generics.count() {
+                let g = generics.param_at(i, tcx);
+                let key = match g.kind {
+                    ty::GenericParamDefKind::Lifetime => {
+                        IndirectKey::Early(g.to_early_bound_region_data())
+                    }
+                    ty::GenericParamDefKind::Type { .. } => IndirectKey::Param(ty::ParamTy {
+                        index: g.index,
+                        name: g.name,
+                    }),
+                    // TODO: skip here?
+                    ty::GenericParamDefKind::Const { .. } => continue,
                 };
-                // TODO: there may be other clauses which might be important
-                //   for wands? In paritcular, see `TypeOutlives`.`
-                if let ty::ClauseKind::RegionOutlives(ty::OutlivesPredicate(long, short)) =
-                    clause_kind
-                {
-                    if long == short {
+                gidx_map.insert(key, i);
+                match variances[i] {
+                    ty::Variance::Covariant => {
+                        outputs.push(key);
+                    }
+                    ty::Variance::Contravariant => {
+                        inputs.push(key);
+                    }
+                    ty::Variance::Invariant => {
+                        inputs.push(key);
+                        outputs.push(key);
+                        edges.push((key, key));
+                    }
+                    ty::Variance::Bivariant => todo!("not sure what this means/how to handle it"),
+                }
+            }
+
+            // `b` outlives `a`
+            let mut insert_edge = |a, b| {
+                let (v_a, v_b) = (variances[gidx_map[&a]], variances[gidx_map[&b]]);
+                match (v_a, v_b) {
+                    (
+                        ty::Variance::Covariant | ty::Variance::Invariant,
+                        ty::Variance::Contravariant | ty::Variance::Invariant,
+                    ) => {
+                        edges.push((a, b));
+                    }
+                    _ => (),
+                }
+            };
+
+            let frm = outlives_env.free_region_map();
+            let rbp = outlives_env.region_bound_pairs();
+
+            // FIXME: hopefully the quadratic thing here isn't an issue
+            for r_a in frm.elements() {
+                for r_b in frm.elements() {
+                    if r_a == r_b {
                         continue;
                     }
-                    outlives.entry(long).or_default().push(short)
-                }
-            }
-            wands_println!("  outlives: {:?}", outlives);
-
-            // Associate resources to lifetimes. At this point, we will only
-            // walk the inputs and output types of the function to find ones
-            // which mention the given lifetime *at all*, regardless of its
-            // function/variance in the type. Later, the indirect encoder will
-            // be invoked on these to get the concrete predicates.
-            let sig_identity_liberated = tcx.liberate_late_bound_regions(def_id, sig_identity);
-            // let locals = sig_identity_liberated.inputs_and_output
-            //     .iter()
-            //     .enumerate()
-            //     .map(|(local, ty)| {
-            //         vcx.mk_lazy_expr(
-            //             vir::vir_format!(vcx, "wand in _{local}"),
-            //             &vir::TypeData::Ref,
-            //             Box::new(move |_vcx, lctx: ExprInput<'vir>| lctx.1[local - 1].kind),
-            //         )
-            //     })
-            //     .collect::<Vec<_>>();
-            let mut resources_by_region: FxHashMap<
-                &ty::Region<'_>,
-                Vec<(mir::Local, ty::Ty<'vir>)>,
-            > = FxHashMap::default();
-            for region in &lifetimes {
-                // let SigLifetime::Early(region) = region else { continue; };
-                let mut resources = Vec::new();
-                let inputs = sig_identity_liberated
-                    .inputs()
-                    .iter()
-                    .enumerate()
-                    .map(|(i, ty)| (mir::Local::from(i + 1), *ty));
-                let output_and_inputs = [(mir::RETURN_PLACE, sig_identity_liberated.output())]
-                    .into_iter()
-                    .chain(inputs);
-                for (local_idx, ty) in output_and_inputs {
-                    if !ty.walk().any(|t| t.as_region() == Some(*region)) {
+                    if !frm.sub_free_regions(tcx, r_a, r_b) {
                         continue;
                     }
-                    resources.push((local_idx, ty));
+                    let (ty::RegionKind::ReEarlyParam(a), ty::RegionKind::ReEarlyParam(b)) =
+                        (r_a.kind(), r_b.kind())
+                    else {
+                        todo!("region bound pair: ({r_a:?}, {r_b:?})");
+                    };
+                    insert_edge(IndirectKey::Early(a), IndirectKey::Early(b));
                 }
-                resources_by_region.insert(region, resources);
             }
-            wands_println!("  resources: {:?}", resources_by_region);
 
-            // Construct a graph of resources, related by the outlives edges.
-            // TODO: at the moment, we will only construct a bipartite graph;
-            //   sometimes a more complex shape should be constructed?
-            let mut indirect_pres = Vec::new();
-            let mut indirect_posts = Vec::new();
-            let mut wands: Vec<(
-                ty::Region<'_>,
-                Vec<(ty::Region<'_>, mir::Local, ty::Ty<'vir>)>,
-                Vec<(mir::Local, ty::Ty<'vir>)>,
-            )> = Vec::new();
-            for region in &lifetimes {
-                // is there anything to block on the input side?
-                let blocked_resources = &resources_by_region[&region];
-                if blocked_resources.is_empty() {
-                    continue;
-                }
-
-                indirect_pres.extend(
-                    blocked_resources
-                        .iter()
-                        .filter(|(l, _)| *l != mir::RETURN_PLACE)
-                        .map(|(l, t)| (*region, *l, *t)),
-                );
-                // are there regions outlived by this one?
-                let Some(shorter) = outlives.get(region) else {
-                    indirect_posts.extend(blocked_resources.iter().map(|(l, t)| (*region, *l, *t)));
-                    continue;
+            for pred in rbp {
+                let GenericKind::Param(b) = pred.0 else {
+                    todo!("region bound pair: {pred:?}");
                 };
-
-                // do these regions have any resources on the output side?
-                let blocking_resources = shorter
-                    .iter()
-                    .filter_map(|shorter| {
-                        resources_by_region
-                            .get(&shorter)
-                            .map(|e| e.iter().map(|(l, t)| (*shorter, *l, *t)))
-                    })
-                    .flatten()
-                    .collect::<Vec<_>>();
-                if blocking_resources.is_empty() {
-                    indirect_posts.extend(blocked_resources.iter().map(|(l, t)| (*region, *l, *t)));
-                    continue;
-                }
-
-                wands.push((*region, blocking_resources, blocked_resources.clone()));
+                let ty::RegionKind::ReEarlyParam(a) = pred.1.kind() else {
+                    todo!("region bound pair: {pred:?}");
+                };
+                insert_edge(IndirectKey::Early(a), IndirectKey::Param(b));
             }
-            wands_println!("  wands: {:?}", wands);
 
-            // Collect pledge specifications and add them to wands.
+            let late_bound = late_bound
+                .into_iter()
+                .map(|brk| IndirectKey::Late(brk))
+                .collect();
+
             let spec = deps.require_local::<MirSpecEnc>((def_id, substs, None, false))?;
-            let encoded_wands: Vec<EncodedWand<'vir>> = wands
-                .into_iter()
-                .map(|(region, lhs_resources, rhs_resources)| {
-                    let mut lhs_specs: Vec<(vir::Expr<'vir>, Span)> = Vec::new();
-                    let mut rhs_specs: Vec<(vir::Expr<'vir>, Span)> = Vec::new();
-                    if !spec.pledges.is_empty() {
-                        // TODO: find the corresponding pledge, also the pledges should expect to be reified with the locals
-                        for (lhs_expr, rhs_expr, rhs_span) in &spec.pledges {
-                            if let Some((lhs_expr, lhs_span)) = lhs_expr {
-                                lhs_specs.push((lhs_expr, *lhs_span));
-                            }
-                            rhs_specs.push((rhs_expr, *rhs_span));
-                        }
-                    }
-                    EncodedWand {
-                        region,
-                        lhs_resources,
-                        rhs_resources,
-                        lhs_specs,
-                        rhs_specs,
-                    }
-                })
-                .collect::<Vec<_>>();
 
             Ok((
                 WandEncOutput {
-                    encoded_wands,
-                    indirect_pres,
-                    indirect_posts,
+                    late_bound,
+                    inputs,
+                    outputs,
+                    edges,
+                    generic_to_param,
+                    pledges: spec.pledges,
                 },
                 (),
             ))
         })
+    }
+}
+
+impl<'vir> WandEncOutput<'vir> {
+    pub fn inputs(&self) -> impl Iterator<Item = IndirectKey> + '_ {
+        self.inputs
+            .iter()
+            .copied()
+            .chain(self.late_bound.iter().copied())
+    }
+
+    pub fn outputs(&self) -> impl Iterator<Item = IndirectKey> + '_ {
+        self.outputs
+            .iter()
+            .copied()
+            .chain(self.late_bound.iter().copied())
+    }
+
+    /// convert edges to viper-supported wands
+    pub fn viper_wands(&self) -> Vec<(Vec<IndirectKey>, Vec<IndirectKey>, Pledges<'vir>)> {
+        // Indexed by the `rhs` of wands
+        let mut edge_rhs: FxHashMap<IndirectKey, Vec<IndirectKey>> = Default::default();
+        // Indexed by the `lhs` of wands
+        let mut edge_lhs: FxHashMap<IndirectKey, Vec<IndirectKey>> = Default::default();
+        let mut wands: Vec<(Vec<IndirectKey>, Vec<IndirectKey>, Pledges<'vir>)> =
+            Default::default();
+
+        for (lhs, rhs) in &self.edges {
+            edge_lhs.entry(*rhs).or_default().push(*lhs);
+            edge_rhs.entry(*lhs).or_default().push(*rhs);
+        }
+
+        let mut skip = FxHashSet::default();
+        for &rhs in &self.inputs {
+            if !skip.insert(rhs) {
+                continue;
+            }
+            let Some(lhss) = edge_rhs.get(&rhs) else {
+                wands.push((vec![], vec![rhs], vec![]));
+                continue;
+            };
+            let lhs = lhss.first().unwrap();
+            let rhss = &edge_lhs[lhs];
+            for rhs_other in rhss {
+                let lhss_other = &edge_lhs[rhs_other];
+                assert_eq!(lhss, lhss_other, "two inputs do not block the same set of outputs: {rhs:?} blocks {lhss:?}, {rhs_other:?} blocks {lhss_other:?}");
+            }
+            for lhs_other in lhss {
+                let rhss_other = &edge_rhs[lhs_other];
+                assert_eq!(rhss, rhss_other, "two outputs are not blocked by the same set of inputs: {lhs:?} blocked by {rhss:?}, {lhs_other:?} blocked by {rhss_other:?}");
+            }
+            wands.push((lhss.clone(), rhss.clone(), vec![]));
+            skip.extend(rhss);
+        }
+        if !self.pledges.is_empty() {
+            let mut actual_wands = wands.iter_mut().filter(|(lhs, ..)| !lhs.is_empty());
+            let wand = actual_wands.next();
+            assert!(wand.is_some(), "pledge for function with no wands");
+            assert!(
+                actual_wands.next().is_none(),
+                "pledge for function with multiple wands"
+            );
+            wand.unwrap().2 = self.pledges.clone();
+        }
+        wands
     }
 }

--- a/prusti-encoder/src/encoders/impure/fn_wand.rs
+++ b/prusti-encoder/src/encoders/impure/fn_wand.rs
@@ -332,14 +332,11 @@ impl TaskEncoder for WandEnc {
             // `b` outlives `a`
             let mut insert_edge = |a, b| {
                 let (v_a, v_b) = (variances[gidx_map[&a]], variances[gidx_map[&b]]);
-                match (v_a, v_b) {
-                    (
+                if let (
                         ty::Variance::Covariant | ty::Variance::Invariant,
                         ty::Variance::Contravariant | ty::Variance::Invariant,
-                    ) => {
-                        edges.push((a, b));
-                    }
-                    _ => (),
+                    ) = (v_a, v_b) {
+                    edges.push((a, b));
                 }
             };
 
@@ -376,7 +373,7 @@ impl TaskEncoder for WandEnc {
 
             let late_bound = late_bound
                 .into_iter()
-                .map(|brk| IndirectKey::Late(brk))
+                .map(IndirectKey::Late)
                 .collect();
 
             let spec = deps.require_local::<MirSpecEnc>((def_id, substs, None, false))?;

--- a/prusti-encoder/src/encoders/impure/loop.rs
+++ b/prusti-encoder/src/encoders/impure/loop.rs
@@ -13,7 +13,7 @@ use task_encoder::TaskEncoder;
 use vir::Reify;
 
 use crate::encoders::{
-    indirect::IndirectPredicatesEnc,
+    indirect::{IndirectKey, IndirectPredicatesEnc},
     rust_ty_predicates::{RustTyPredicatesEnc, RustTyPredicatesEncOutputRef},
     ImpureEncVisitor,
 };
@@ -52,7 +52,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 let pred = ty_out.ref_to_pred(self.vcx, place_res.expr, None);
                 inv.push(pred);
 
-                let regions = ty.ty.walk().flat_map(|w| w.as_region());
+                let regions = ty.ty.walk().flat_map(IndirectKey::from_generic_arg);
                 for region in regions {
                     let indirect = self
                         .deps
@@ -60,7 +60,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                         .unwrap();
                     inv.extend(
                         indirect
-                            .expr
+                            .covariant
                             .into_iter()
                             .map(|expr| expr.reify(self.vcx, snap)),
                     );
@@ -131,7 +131,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             }
             MaybeRemoteRegionProjectionBase::Const(c) => todo!("{c:?}"),
         };
-        let mut regions = ty.ty.walk().flat_map(|w| w.as_region());
+        let mut regions = ty.ty.walk().flat_map(IndirectKey::from_generic_arg);
         let region = regions.next().unwrap();
         // TODO:
         assert!(
@@ -144,7 +144,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             .require_ref::<IndirectPredicatesEnc>((ty.ty, region))
             .unwrap();
         indirect
-            .expr
+            .covariant
             .into_iter()
             .map(|expr| expr.reify(self.vcx, place_snap))
             .collect::<Vec<_>>()

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -1339,7 +1339,7 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
                             let borrows = &current_fpcs.statements.last().unwrap().states
                                 [EvalStmtPhase::PostMain];
                             let mut extra_stmts = self
-                                .collect_pcs_succ(&borrows, &current_fpcs.terminator.succs[idx]);
+                                .collect_pcs_succ(borrows, &current_fpcs.terminator.succs[idx]);
                             self.current_fpcs = Some(current_fpcs);
                             extra_stmts.push(self.set_from_to_flag(location.block, target));
 
@@ -1367,7 +1367,7 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
                 let borrows =
                     &current_fpcs.statements.last().unwrap().states[EvalStmtPhase::PostMain];
                 let mut otherwise_stmts = self
-                    .collect_pcs_succ(&borrows, &current_fpcs.terminator.succs[otherwise_succ_idx]);
+                    .collect_pcs_succ(borrows, &current_fpcs.terminator.succs[otherwise_succ_idx]);
                 self.current_fpcs = Some(current_fpcs);
                 otherwise_stmts.push(self.set_from_to_flag(location.block, targets.otherwise()));
 

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -412,7 +412,6 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                     .deps
                     .require_local::<WandEnc>(WandEncTask {
                         def_id: call.def_id(),
-                        substs: call.substs(),
                     })
                     .unwrap();
                 let bb = &self.body[call.location().block];

--- a/prusti-encoder/src/encoders/type/indirect.rs
+++ b/prusti-encoder/src/encoders/type/indirect.rs
@@ -12,9 +12,7 @@ pub enum IndirectKey {
 }
 
 impl IndirectKey {
-    pub fn from_generic_arg(
-        ga: ty::GenericArg,
-    ) -> Option<Self> {
+    pub fn from_generic_arg(ga: ty::GenericArg) -> Option<Self> {
         match ga.unpack() {
             ty::GenericArgKind::Lifetime(region) => Self::from_region(region),
             ty::GenericArgKind::Type(ty) => match *ty.kind() {
@@ -25,14 +23,16 @@ impl IndirectKey {
         }
     }
 
-    pub fn from_region(
-        region: ty::Region,
-    ) -> Option<Self> {
+    pub fn from_region(region: ty::Region) -> Option<Self> {
         use ty::RegionKind;
         match region.kind() {
             RegionKind::ReEarlyParam(e) => Some(IndirectKey::Early(e)),
             RegionKind::ReBound(_, g) => Some(IndirectKey::Late(g.kind)),
-            RegionKind::RePlaceholder(..) | RegionKind::ReError(..) | RegionKind::ReErased | RegionKind::ReVar(..) | RegionKind::ReLateParam(..) => unreachable!(),
+            RegionKind::RePlaceholder(..)
+            | RegionKind::ReError(..)
+            | RegionKind::ReErased
+            | RegionKind::ReVar(..)
+            | RegionKind::ReLateParam(..) => unreachable!(),
             RegionKind::ReStatic => None,
         }
     }
@@ -83,7 +83,9 @@ impl TaskEncoder for IndirectPredicatesEnc {
                         .specifics
                         .expect_mutref()
                         .deref_access;
-                    if IndirectKey::from_region(*ref_region).is_some_and(|indirect| &indirect == proj_region) {
+                    if IndirectKey::from_region(*ref_region)
+                        .is_some_and(|indirect| &indirect == proj_region)
+                    {
                         let inner_ty_enc = deps.require_ref::<RustTyPredicatesEnc>(*inner_ty)?;
                         covariant.push(vcx.mk_lazy_expr(
                             "ref_indirect",
@@ -98,17 +100,22 @@ impl TaskEncoder for IndirectPredicatesEnc {
                     // TODO: is this correct??? do we always project into the inner type, regardless of region?
                     let inner_indirect =
                         deps.require_ref::<IndirectPredicatesEnc>((*inner_ty, *proj_region))?;
-                    let inner = inner_indirect.covariant.into_iter().chain(inner_indirect.contravariant).map(|inner_expr| {
-                        vcx.mk_lazy_expr(
-                            "ref_inner_indirect",
-                            &vir::TypeData::Predicate,
-                            Box::new(move |vcx, self_expr| {
-                                inner_expr
-                                    .reify(vcx, deref_access.apply(vcx, [self_expr]))
-                                    .kind
-                            }),
-                        )
-                    }).collect::<Vec<_>>();
+                    let inner = inner_indirect
+                        .covariant
+                        .into_iter()
+                        .chain(inner_indirect.contravariant)
+                        .map(|inner_expr| {
+                            vcx.mk_lazy_expr(
+                                "ref_inner_indirect",
+                                &vir::TypeData::Predicate,
+                                Box::new(move |vcx, self_expr| {
+                                    inner_expr
+                                        .reify(vcx, deref_access.apply(vcx, [self_expr]))
+                                        .kind
+                                }),
+                            )
+                        })
+                        .collect::<Vec<_>>();
                     covariant.extend(inner.clone());
                     contravariant.extend(inner);
                 }
@@ -142,7 +149,13 @@ impl TaskEncoder for IndirectPredicatesEnc {
                 // TODO: recurse into other types
                 _ => (),
             }
-            deps.emit_output_ref(*task_key, IndirectPredicatesEncOutputRef { covariant, contravariant })?;
+            deps.emit_output_ref(
+                *task_key,
+                IndirectPredicatesEncOutputRef {
+                    covariant,
+                    contravariant,
+                },
+            )?;
             Ok(((), ()))
         })
     }

--- a/prusti-encoder/src/encoders/type/indirect.rs
+++ b/prusti-encoder/src/encoders/type/indirect.rs
@@ -4,13 +4,49 @@ use vir::Reify;
 
 use super::{rust_ty_predicates::RustTyPredicatesEnc, rust_ty_snapshots::RustTySnapshotsEnc};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IndirectKey {
+    Early(ty::EarlyParamRegion),
+    Late(ty::BoundRegionKind),
+    Param(ty::ParamTy),
+}
+
+impl IndirectKey {
+    pub fn from_generic_arg(
+        ga: ty::GenericArg,
+    ) -> Option<Self> {
+        match ga.unpack() {
+            ty::GenericArgKind::Lifetime(region) => Self::from_region(region),
+            ty::GenericArgKind::Type(ty) => match *ty.kind() {
+                ty::TyKind::Param(p) => Some(IndirectKey::Param(p)),
+                _ => None,
+            },
+            ty::GenericArgKind::Const(_) => None,
+        }
+    }
+
+    pub fn from_region(
+        region: ty::Region,
+    ) -> Option<Self> {
+        use ty::RegionKind;
+        match region.kind() {
+            RegionKind::ReEarlyParam(e) => Some(IndirectKey::Early(e)),
+            RegionKind::ReBound(_, g) => Some(IndirectKey::Late(g.kind)),
+            RegionKind::RePlaceholder(..) | RegionKind::ReError(..) | RegionKind::ReErased | RegionKind::ReVar(..) | RegionKind::ReLateParam(..) => unreachable!(),
+            RegionKind::ReStatic => None,
+        }
+    }
+}
+
 pub struct IndirectPredicatesEnc;
 
 type ExprInput<'vir> = vir::Expr<'vir>;
+type ExprOutput<'vir> = vir::ExprGen<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>;
 
 #[derive(Clone)]
 pub struct IndirectPredicatesEncOutputRef<'vir> {
-    pub expr: Vec<vir::ExprGen<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>>,
+    pub covariant: Vec<ExprOutput<'vir>>,
+    pub contravariant: Vec<ExprOutput<'vir>>,
 }
 
 impl<'vir> task_encoder::OutputRefAny for IndirectPredicatesEncOutputRef<'vir> {}
@@ -18,7 +54,7 @@ impl<'vir> task_encoder::OutputRefAny for IndirectPredicatesEncOutputRef<'vir> {
 impl TaskEncoder for IndirectPredicatesEnc {
     task_encoder::encoder_cache!(IndirectPredicatesEnc);
 
-    type TaskDescription<'vir> = (ty::Ty<'vir>, ty::Region<'vir>);
+    type TaskDescription<'vir> = (ty::Ty<'vir>, IndirectKey);
 
     type TaskKey<'tcx> = Self::TaskDescription<'tcx>;
 
@@ -38,17 +74,18 @@ impl TaskEncoder for IndirectPredicatesEnc {
         vir::with_vcx(|vcx| {
             let (ty, proj_region) = task_key;
             let self_ty_enc = deps.require_local::<RustTySnapshotsEnc>(*ty)?;
-            let mut expr = Vec::new();
+            let mut covariant = Vec::new();
+            let mut contravariant = Vec::new();
             match ty.kind() {
                 ty::TyKind::Ref(ref_region, inner_ty, ty::Mutability::Mut) => {
-                    let inner_ty_enc = deps.require_ref::<RustTyPredicatesEnc>(*inner_ty)?;
                     let deref_access = self_ty_enc
                         .generic_snapshot
                         .specifics
                         .expect_mutref()
                         .deref_access;
-                    if ref_region == proj_region {
-                        expr.push(vcx.mk_lazy_expr(
+                    if IndirectKey::from_region(*ref_region).is_some_and(|indirect| &indirect == proj_region) {
+                        let inner_ty_enc = deps.require_ref::<RustTyPredicatesEnc>(*inner_ty)?;
+                        covariant.push(vcx.mk_lazy_expr(
                             "ref_indirect",
                             &vir::TypeData::Predicate,
                             Box::new(move |vcx, self_expr| {
@@ -61,7 +98,7 @@ impl TaskEncoder for IndirectPredicatesEnc {
                     // TODO: is this correct??? do we always project into the inner type, regardless of region?
                     let inner_indirect =
                         deps.require_ref::<IndirectPredicatesEnc>((*inner_ty, *proj_region))?;
-                    expr.extend(inner_indirect.expr.into_iter().map(|inner_expr| {
+                    let inner = inner_indirect.covariant.into_iter().chain(inner_indirect.contravariant).map(|inner_expr| {
                         vcx.mk_lazy_expr(
                             "ref_inner_indirect",
                             &vir::TypeData::Predicate,
@@ -71,7 +108,9 @@ impl TaskEncoder for IndirectPredicatesEnc {
                                     .kind
                             }),
                         )
-                    }));
+                    }).collect::<Vec<_>>();
+                    covariant.extend(inner.clone());
+                    contravariant.extend(inner);
                 }
                 ty::TyKind::Tuple(params) => {
                     let field_accessors = self_ty_enc
@@ -80,11 +119,7 @@ impl TaskEncoder for IndirectPredicatesEnc {
                         .expect_structlike()
                         .field_access;
                     for (field_ty, accessor) in params.into_iter().zip(field_accessors) {
-                        // TODO: tuple generics need to be passed to field accessors
-                        // TODO: tuple fields need to be (snapshot) cast
-                        let field_indirect =
-                            deps.require_ref::<IndirectPredicatesEnc>((field_ty, *proj_region))?;
-                        expr.extend(field_indirect.expr.into_iter().map(|inner_expr| {
+                        let project = |inner_expr: ExprOutput<'vir>| {
                             vcx.mk_lazy_expr(
                                 "ref_inner_indirect",
                                 &vir::TypeData::Predicate,
@@ -94,13 +129,20 @@ impl TaskEncoder for IndirectPredicatesEnc {
                                         .kind
                                 }),
                             )
-                        }));
+                        };
+
+                        // TODO: tuple generics need to be passed to field accessors
+                        // TODO: tuple fields need to be (snapshot) cast
+                        let field_indirect =
+                            deps.require_ref::<IndirectPredicatesEnc>((field_ty, *proj_region))?;
+                        covariant.extend(field_indirect.covariant.into_iter().map(project));
+                        contravariant.extend(field_indirect.contravariant.into_iter().map(project));
                     }
                 }
                 // TODO: recurse into other types
                 _ => (),
             }
-            deps.emit_output_ref(*task_key, IndirectPredicatesEncOutputRef { expr })?;
+            deps.emit_output_ref(*task_key, IndirectPredicatesEncOutputRef { covariant, contravariant })?;
             Ok(((), ()))
         })
     }

--- a/prusti-interface/src/environment/query.rs
+++ b/prusti-interface/src/environment/query.rs
@@ -4,21 +4,23 @@ use crate::data::ProcedureDefId;
 use log::debug;
 use prusti_rustc_interface::{
     ast::ast::Attribute,
+    data_structures::fx::FxIndexSet,
     hir::hir_id::HirId,
+    infer::infer::{outlives::env::OutlivesEnvironment, InferCtxt},
     middle::{
         hir::map::Map,
         ty::{self, GenericArgsRef, ParamEnv, PredicatePolarity, TraitPredicate, TyCtxt},
     },
     span::{
-        def_id::{DefId, LocalDefId},
+        def_id::{DefId, LocalDefId, CRATE_DEF_ID},
         source_map::SourceMap,
         Span,
     },
     trait_selection::{
         infer::{InferCtxtExt, TyCtxtInferExt},
         traits::{
-            query::evaluate_obligation::InferCtxtExt as QueryInferCtxtExt, ImplSource, Obligation,
-            ObligationCause, SelectionContext,
+            outlives_bounds::InferCtxtExt as BoundsInferCtxtExt, query::evaluate_obligation::InferCtxtExt as QueryInferCtxtExt,
+            ImplSource, Obligation, ObligationCause, SelectionContext,
         },
     },
 };
@@ -47,6 +49,10 @@ impl<'tcx> EnvQuery<'tcx> {
     /// Returns the `CodeMap`
     pub fn codemap(self) -> &'tcx SourceMap {
         self.tcx.sess.source_map()
+    }
+
+    pub fn infer_ctxt(self) -> InferCtxt<'tcx> {
+        self.tcx.infer_ctxt().build(ty::TypingMode::PostAnalysis)
     }
 
     // /// Returns the type of a `HirId`
@@ -177,6 +183,29 @@ impl<'tcx> EnvQuery<'tcx> {
         self.resolve_assoc_types(sig, caller_def_id.into_param())
     }
 
+    pub fn get_liberated_fn_sig(self, def_id: impl IntoParam<ProcedureDefId>, substs: GenericArgsRef<'tcx>) -> ty::FnSig<'tcx> {
+        let def_id = def_id.into_param();
+        let sig = self.get_fn_sig(def_id, substs);
+        self.tcx.liberate_late_bound_regions(def_id, sig)
+    }
+
+    pub fn assumed_wf_types(self, def_id: impl IntoParam<ProcedureDefId>) -> FxIndexSet<ty::Ty<'tcx>> {
+        let def_id = def_id.into_param();
+        let liberated_sig = self.get_liberated_fn_sig(def_id, self.identity_substs(def_id));
+        // TODO: same as `ObligationCtxt::assumed_wf_types` but skips `deeply_normalize` step, is that fine?
+        liberated_sig.inputs_and_output.iter().collect::<FxIndexSet<_>>()
+    }
+
+    pub fn outlives_env(self, def_id: impl IntoParam<ProcedureDefId>) -> OutlivesEnvironment<'tcx> {
+        let def_id = def_id.into_param();
+        let wf_tys = self.assumed_wf_types(def_id);
+
+        let infcx = self.infer_ctxt();
+        let param_env = self.tcx.param_env(def_id);
+        let ib = infcx.implied_bounds_tys(param_env, CRATE_DEF_ID, &wf_tys);
+        OutlivesEnvironment::with_bounds(param_env, ib)
+    }
+
     /// Returns true iff `def_id` is a closure.
     pub fn is_closure(self, def_id: impl IntoParam<DefId>) -> bool {
         self.tcx.is_closure_like(def_id.into_param())
@@ -281,7 +310,7 @@ impl<'tcx> EnvQuery<'tcx> {
             debug!("Fetching implementations of method '{:?}' defined in trait '{}' with substs '{:?}'", proc_def_id, self.tcx.def_path_str(trait_id), substs);
             // TODO(tymap): don't use reveal_all
             let typing_env = ty::TypingEnv::fully_monomorphized();
-            let infcx = self.tcx.infer_ctxt().build(typing_env.typing_mode);
+            let infcx = self.infer_ctxt();
             let mut sc = SelectionContext::new(&infcx);
             let trait_ref = ty::TraitRef::new(self.tcx, trait_id, substs);
             let obligation = Obligation::new(
@@ -397,7 +426,7 @@ impl<'tcx> EnvQuery<'tcx> {
         param_env: impl IntoParamTcx<'tcx, ParamEnv<'tcx>>,
     ) -> bool {
         assert!(self.tcx.is_trait(trait_def_id));
-        let infcx = self.tcx.infer_ctxt().build(ty::TypingMode::PostAnalysis);
+        let infcx = self.infer_ctxt();
         infcx
             .type_implements_trait(
                 trait_def_id,
@@ -436,9 +465,7 @@ impl<'tcx> EnvQuery<'tcx> {
             predicate,
         );
 
-        self.tcx
-            .infer_ctxt()
-            .build(ty::TypingMode::PostAnalysis)
+        self.infer_ctxt()
             .predicate_must_hold_considering_regions(&obligation)
     }
 

--- a/prusti-interface/src/environment/query.rs
+++ b/prusti-interface/src/environment/query.rs
@@ -19,8 +19,9 @@ use prusti_rustc_interface::{
     trait_selection::{
         infer::{InferCtxtExt, TyCtxtInferExt},
         traits::{
-            outlives_bounds::InferCtxtExt as BoundsInferCtxtExt, query::evaluate_obligation::InferCtxtExt as QueryInferCtxtExt,
-            ImplSource, Obligation, ObligationCause, SelectionContext,
+            outlives_bounds::InferCtxtExt as BoundsInferCtxtExt,
+            query::evaluate_obligation::InferCtxtExt as QueryInferCtxtExt, ImplSource, Obligation,
+            ObligationCause, SelectionContext,
         },
     },
 };
@@ -183,17 +184,27 @@ impl<'tcx> EnvQuery<'tcx> {
         self.resolve_assoc_types(sig, caller_def_id.into_param())
     }
 
-    pub fn get_liberated_fn_sig(self, def_id: impl IntoParam<ProcedureDefId>, substs: GenericArgsRef<'tcx>) -> ty::FnSig<'tcx> {
+    pub fn get_liberated_fn_sig(
+        self,
+        def_id: impl IntoParam<ProcedureDefId>,
+        substs: GenericArgsRef<'tcx>,
+    ) -> ty::FnSig<'tcx> {
         let def_id = def_id.into_param();
         let sig = self.get_fn_sig(def_id, substs);
         self.tcx.liberate_late_bound_regions(def_id, sig)
     }
 
-    pub fn assumed_wf_types(self, def_id: impl IntoParam<ProcedureDefId>) -> FxIndexSet<ty::Ty<'tcx>> {
+    pub fn assumed_wf_types(
+        self,
+        def_id: impl IntoParam<ProcedureDefId>,
+    ) -> FxIndexSet<ty::Ty<'tcx>> {
         let def_id = def_id.into_param();
         let liberated_sig = self.get_liberated_fn_sig(def_id, self.identity_substs(def_id));
         // TODO: same as `ObligationCtxt::assumed_wf_types` but skips `deeply_normalize` step, is that fine?
-        liberated_sig.inputs_and_output.iter().collect::<FxIndexSet<_>>()
+        liberated_sig
+            .inputs_and_output
+            .iter()
+            .collect::<FxIndexSet<_>>()
     }
 
     pub fn outlives_env(self, def_id: impl IntoParam<ProcedureDefId>) -> OutlivesEnvironment<'tcx> {

--- a/prusti-interface/src/specs/checker/predicate_checks.rs
+++ b/prusti-interface/src/specs/checker/predicate_checks.rs
@@ -153,7 +153,7 @@ struct CheckPredicatesVisitor<'tcx> {
     pred_usages: Vec<(Span, Span)>,
 }
 
-impl<'v, 'tcx: 'v> NonSpecExprVisitor<'tcx> for CheckPredicatesVisitor<'tcx> {
+impl<'tcx> NonSpecExprVisitor<'tcx> for CheckPredicatesVisitor<'tcx> {
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.env_query.tcx()
     }

--- a/prusti-interface/src/utils.rs
+++ b/prusti-interface/src/utils.rs
@@ -8,7 +8,6 @@
 
 use prusti_rustc_interface::{
     ast::ast,
-    data_structures::fx::FxHashSet,
     middle::{mir, ty::TyCtxt},
 };
 use std::borrow::Borrow;

--- a/prusti-server/src/backend.rs
+++ b/prusti-server/src/backend.rs
@@ -6,7 +6,7 @@ pub enum Backend<'a> {
     Viper(viper::Verifier<'a>, &'a VerificationContext<'a>),
 }
 
-impl<'a> Backend<'a> {
+impl Backend<'_> {
     pub fn verify(&mut self, program: vir::ProgramRef) -> VerificationResult {
         match self {
             Backend::Viper(viper, context) => {

--- a/prusti-server/tests/basic_requests.rs
+++ b/prusti-server/tests/basic_requests.rs
@@ -1,11 +1,6 @@
 #![feature(rustc_private)]
 use lazy_static::lazy_static;
-use prusti_server::{
-    spawn_server_thread, tokio::runtime::Builder, PrustiClient, VerificationRequest,
-    ViperBackendConfig,
-};
-use viper::VerificationResult;
-use vir::*;
+use prusti_server::spawn_server_thread;
 
 lazy_static! {
     // only start the jvm & server once

--- a/prusti-tests/tests/harnesses/cargotest.rs
+++ b/prusti-tests/tests/harnesses/cargotest.rs
@@ -58,7 +58,7 @@ fn run_cargo_tests(root_dir: &str, cargo_flags: &[&str], cargo_env: &[(&str, &st
     // This setup for testing with `cargo` is loosely based on `ui_test`'s;
     // see https://github.com/oli-obk/ui_test/blob/main/tests/integration.rs
 
-    let mut config = Config::cargo(&root_dir);
+    let mut config = Config::cargo(root_dir);
 
     let args = Args::test().unwrap();
     config.with_args(&args);

--- a/prusti-viper/src/lib.rs
+++ b/prusti-viper/src/lib.rs
@@ -48,7 +48,7 @@ pub struct ToViperContext<'vir, 'v> {
     domain_axioms: FxHashMap<&'vir str, (vir::Domain<'vir>, vir::DomainAxiom<'vir>)>,
 }
 
-impl<'vir, 'v> ToViperContext<'vir, 'v> {
+impl<'vir> ToViperContext<'vir, '_> {
     /// If a span is given, convert it to a Viper position. Otherwise, return
     /// a "no position".
     // TODO: This signature is chosen to accommodate optional spans in

--- a/prusti/src/callbacks.rs
+++ b/prusti/src/callbacks.rs
@@ -9,7 +9,7 @@ use prusti_rustc_interface::{
     driver::Compilation,
     hir::{def::DefKind, def_id::LocalDefId},
     index::IndexVec,
-    interface::{interface::Compiler, Config, Queries},
+    interface::{interface::Compiler, Config},
     middle::{
         mir, query::queries::mir_borrowck::ProvidedValue as MirBorrowck, ty::TyCtxt,
         util::Providers,

--- a/viper/benches/bench_program.rs
+++ b/viper/benches/bench_program.rs
@@ -112,7 +112,7 @@ fn build_program<'a>(ast: &'a AstFactory) -> Program<'a> {
                         ast.local_var("box", ast.ref_type(), ast.no_position()),
                         ast.field("value", ast.int_type()),
                     ),
-                    ast.full_perm(),
+                    Some(ast.full_perm()),
                 ),
                 ast.func_app(
                     "even",
@@ -147,7 +147,7 @@ fn build_program<'a>(ast: &'a AstFactory) -> Program<'a> {
                     &[ast.local_var("box", ast.ref_type(), ast.no_position())],
                     "EvenNumBox",
                 ),
-                ast.full_perm(),
+                Some(ast.full_perm()),
             ),
         ],
         Some(ast.seqn(
@@ -179,7 +179,7 @@ fn build_program<'a>(ast: &'a AstFactory) -> Program<'a> {
                         &[ast.local_var("box", ast.ref_type(), ast.no_position())],
                         "EvenNumBox",
                     ),
-                    ast.full_perm(),
+                    Some(ast.full_perm()),
                 )),
             ],
             &[],

--- a/viper/src/errors.rs
+++ b/viper/src/errors.rs
@@ -4,6 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#![allow(unexpected_cfgs)]
 error_chain::error_chain! {
     errors {
         // Example:

--- a/viper/src/verifier.rs
+++ b/viper/src/verifier.rs
@@ -406,7 +406,7 @@ impl<'a> Verifier<'a> {
     }
 }
 
-impl<'a> Drop for Verifier<'a> {
+impl Drop for Verifier<'_> {
     fn drop(&mut self) {
         // Tell the verifier to stop its threads.
         self.jni

--- a/viper/tests/complex_program.rs
+++ b/viper/tests/complex_program.rs
@@ -109,7 +109,7 @@ fn success_with_complex_program() {
                         ast.local_var("box", ast.ref_type(), ast.no_position()),
                         ast.field("value", ast.int_type()),
                     ),
-                    ast.full_perm(),
+                    Some(ast.full_perm()),
                 ),
                 ast.func_app(
                     "even",
@@ -144,7 +144,7 @@ fn success_with_complex_program() {
                     &[ast.local_var("box", ast.ref_type(), ast.no_position())],
                     "EvenNumBox",
                 ),
-                ast.full_perm(),
+                Some(ast.full_perm()),
             ),
         ],
         Some(ast.seqn(
@@ -176,7 +176,7 @@ fn success_with_complex_program() {
                         &[ast.local_var("box", ast.ref_type(), ast.no_position())],
                         "EvenNumBox",
                     ),
-                    ast.full_perm(),
+                    Some(ast.full_perm()),
                 )),
             ],
             &[],


### PR DESCRIPTION
Handles all indirect resources (those behind earlybound, latebound, and inside ty params).

Wands do not get generated for latebound, and the indirect encoder does not support many things (e.g. adt, ty params, etc.).