### PR TITLE
Reference fix in encoding `PrustiBuiltin::Forall`

### DIFF
--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -1052,10 +1052,27 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
                     .deps
                     .require_local::<RustTyCastersEnc<CastTypePure>>(closure_ty)
                     .unwrap();
-                reify_args.push(cast.cast_to_concrete_if_possible(
-                    self.vcx,
-                    ref_to_closure_ty_out.value_access.gen()(closure_ref.downcast_ty()).upcast_ty(),
-                ));
+                let has_ref_upvars = match closure_ty.kind() {
+                    TyKind::Closure(_, cl_args) => {
+                        cl_args.as_closure().upvar_tys().iter().any(|upvar_ty| {
+                            matches!(upvar_ty.kind(), ty::TyKind::Ref(_, _, _))
+                        })
+                    }
+                    _ => false,
+                };
+                if !(has_ref_upvars) {
+                    reify_args.push(
+                        cast.cast_to_concrete_if_possible(
+                            self.vcx,
+                            ref_to_closure_ty_out 
+                                .value_access
+                                .gen()(closure_ref.downcast_ty())
+                                .upcast_ty(),
+                        ),
+                    );
+                } else {
+                    reify_args.push(closure_ref)
+                }
                 reify_args.extend(
                     qvars
                         .iter()

--- a/prusti-tests/tests/v2/pass/quantifiers/method_calls.rs
+++ b/prusti-tests/tests/v2/pass/quantifiers/method_calls.rs
@@ -1,0 +1,37 @@
+use prusti_contracts::*;
+
+struct TestStructReference {
+    len: usize,
+}
+struct TestStruct {
+    len: usize,
+}
+
+impl TestStructReference {
+    #[trusted]
+    #[pure]
+    #[ensures(result >= 0)]
+    pub fn get(&self, idx: usize) -> i32 {
+        unimplemented!()
+    }
+}
+impl TestStruct {
+    #[trusted]
+    #[pure]
+    #[ensures(result >= 0)]
+    pub fn get(&self, idx: usize) -> i32 {
+        unimplemented!()
+    }
+}
+
+// Test method call on reference type within forall quantifier
+// This tests the branch where has_ref_upvars is true (reference case)
+#[requires(forall(|i: usize| i < res.len ==> res.get(i) >= 0))]
+pub fn test1_ref_method_call(res: &TestStructReference) {}
+
+// Test method call on owned type within forall quantifier
+// This tests the branch where has_ref_upvars is false (owned case)
+#[requires(forall(|i: usize| i < res.len ==> res.get(i) >= 0))]
+pub fn test2_method_call(res: TestStruct) {}
+
+fn main() {}


### PR DESCRIPTION
Solves issue where forall annotations could not handle references.  It checks whether the closure captures variables containing references, if it does, it does not put `(make_concrete_s_prusti_pre_item_..._Closure_0(s_Ref_immutable_value(...)))` around it.

I'm aware that right now this is not solved in a very elegant way and we might need to find a better way to solve this and solve the underlying issue.


