### PR TITLE
Fix undeclared identifier issue

### DIFF
--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -617,12 +617,8 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
     ) -> Update<'vir> {
         let mut update = Update::new();
         match &stmt.kind {
-            &mir::StatementKind::StorageLive(local) => {
-                let new_version = self.version_ctr[local];
-                self.version_ctr[local] += 1;
-                update.versions.insert(local, new_version);
-            }
-            mir::StatementKind::StorageDead(..)
+            mir::StatementKind::StorageLive(..)
+            | mir::StatementKind::StorageDead(..)
             | mir::StatementKind::FakeRead(..)
             | mir::StatementKind::AscribeUserType(..)
             | mir::StatementKind::PlaceMention(..) => {} // nop

--- a/viper-sys/build.rs
+++ b/viper-sys/build.rs
@@ -79,6 +79,10 @@ fn main() {
                 method!("get", "(Ljava/lang/String;[Ljava/lang/String;)Ljava/nio/file/Path;"),
             ]),
             // Scala
+            java_class!("scala.Option", vec![
+                method!("isEmpty"),
+                constructor!(),
+            ]),
             java_class!("scala.Some", vec![
                 method!("get"),
                 constructor!(),

--- a/viper/src/verifier.rs
+++ b/viper/src/verifier.rs
@@ -234,8 +234,12 @@ impl<'a> Verifier<'a> {
             run_timed!("Viper verification", debug,
                 self.jni.unwrap_result(self.frontend_wrapper.call_verification(self.frontend_instance));
                 let viper_result_option = self.jni.unwrap_result(self.frontend_wrapper.call_getVerificationResult(self.frontend_instance));
-                let viper_result = self.jni.unwrap_result(scala::Some::with(self.env).call_get(viper_result_option));
             );
+            let is_empty = self.jni.unwrap_result(scala::Option::with(self.env).call_isEmpty(viper_result_option));
+            if is_empty {
+                panic!("Error during typechecking/consistency checking!");
+            }
+            let viper_result = self.jni.unwrap_result(scala::Some::with(self.env).call_get(viper_result_option));
             debug!(
                 "Viper verification result: {}",
                 self.jni.to_string(viper_result)


### PR DESCRIPTION
Fixes https://github.com/Aurel300/prusti-dev/issues/74, explains https://github.com/Aurel300/prusti-dev/issues/75: the issue is that there is a recursive call in the postcondition (which Viper now forbids without a decreases).