### PR TITLE
Fewer panics

### DIFF
--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -187,134 +187,167 @@ impl MirBuiltinEnc {
                 vcx.get_bit_width_int(l_ty.kind()),
             );
         }
-        let op_kind = vir::BinOpKind::from(op);
-        let viper_val = vcx.mk_bin_op_expr_inner(op_kind, lhs, rhs);
-        let (pres, val) = match op {
-            // Overflow well defined as wrapping (implicit) and for the shifts
-            // the RHS will be masked to the bit width.
-            Add | Sub | Mul | Shl | Shr => (
-                Vec::new(),
-                Self::get_wrapped_val(vcx, viper_val.downcast_ty(), res_ty).upcast_ty(),
-            ),
-            // Undefined behavior to overflow (need precondition)
-            AddUnchecked | SubUnchecked | MulUnchecked => {
-                let min = vcx.get_min_int(res_ty.kind());
-                // `(arg1 op arg2) >= -iN::MIN`
-                let lower_bound = vcx
-                    .mk_bin_op_expr(vir::BinOpKind::CmpGe, viper_val.downcast_ty(), min)
-                    .downcast_ty::<vir::Bool>();
-                let max = vcx.get_max_int(res_ty.kind());
-                // `(arg1 op arg2) <= iN::MAX`
-                let upper_bound = vcx
-                    .mk_bin_op_expr(vir::BinOpKind::CmpLe, viper_val.downcast_ty(), max)
-                    .downcast_ty::<vir::Bool>();
-                (vec![lower_bound, upper_bound], viper_val)
-            }
-            // Overflow is well defined as wrapping (implicit), but shifting by
-            // more than the bit width (or less than 0) is undefined behavior.
-            ShlUnchecked | ShrUnchecked => {
-                let min = vcx.mk_int::<0>();
-                // `arg2 >= 0`
-                let lower_bound = vcx
-                    .mk_bin_op_expr(vir::BinOpKind::CmpGe, rhs.downcast_ty(), min)
-                    .downcast_ty::<vir::Bool>();
-                let max = vcx.get_bit_width_int(l_ty.kind());
-                // `arg2 < bit_width(arg1)`
-                let upper_bound = vcx
-                    .mk_bin_op_expr(vir::BinOpKind::CmpLt, rhs.downcast_ty(), max)
-                    .downcast_ty::<vir::Bool>();
-                (
-                    vec![lower_bound, upper_bound],
+
+        let (pres, val) = if matches!(op, Cmp) {
+            // Cmp does not have a direct analogue to VIR binary operations,
+            // so we treat it specially.
+            // a > b ? 1 : (b > a ? -1 : 0)
+            let a_gt_b = vcx
+                .mk_bin_op_expr(
+                    vir::BinOpKind::CmpGt,
+                    lhs,
+                    rhs,
+                ).downcast_ty();
+            let b_gt_a = vcx
+                .mk_bin_op_expr(
+                    vir::BinOpKind::CmpGt,
+                    rhs,
+                    lhs,
+                ).downcast_ty();
+            let val = vcx.mk_ternary_expr(
+                a_gt_b,
+                vcx.mk_int::<1>(),
+                vcx.mk_ternary_expr(
+                    b_gt_a,
+                    vcx.mk_int::<-1>(),
+                    vcx.mk_int::<0>(),
+                ),
+            ).upcast_ty();
+            (vec![], val)
+        } else {
+            let op_kind = vir::BinOpKind::from(op);
+            let viper_val = vcx.mk_bin_op_expr_inner(op_kind, lhs, rhs);
+            match op {
+                // Overflow well defined as wrapping (implicit) and for the shifts
+                // the RHS will be masked to the bit width.
+                Add | Sub | Mul | Shl | Shr => (
+                    Vec::new(),
                     Self::get_wrapped_val(vcx, viper_val.downcast_ty(), res_ty).upcast_ty(),
-                )
-            }
-            // Could divide by zero or overflow if divisor is `-1`
-            Div | Rem => {
-                // `0 != arg2 `
-                let pre = vcx
-                    .mk_bin_op_expr(vir::BinOpKind::CmpNe, vcx.mk_int::<0>(), rhs.downcast_ty())
-                    .downcast_ty::<vir::Bool>();
-                let mut pres = vec![pre];
-                let mut val = viper_val;
-                if res_ty.is_signed() {
+                ),
+                // Undefined behavior to overflow (need precondition)
+                AddUnchecked | SubUnchecked | MulUnchecked => {
                     let min = vcx.get_min_int(res_ty.kind());
-                    // `arg1 != -iN::MIN`
-                    let arg1_cond =
-                        vcx.mk_bin_op_expr(vir::BinOpKind::CmpNe, lhs.downcast_ty(), min);
-                    // `-1 != arg2 `
-                    let arg2_cond = vcx.mk_bin_op_expr(
-                        vir::BinOpKind::CmpNe,
-                        vcx.mk_int::<-1>(),
-                        rhs.downcast_ty(),
-                    );
-                    // `-1 != arg2 || arg1 != -iN::MIN`
-                    let pre = vcx
-                        .mk_bin_op_expr(vir::BinOpKind::Or, arg1_cond, arg2_cond)
+                    // `(arg1 op arg2) >= -iN::MIN`
+                    let lower_bound = vcx
+                        .mk_bin_op_expr(vir::BinOpKind::CmpGe, viper_val.downcast_ty(), min)
                         .downcast_ty::<vir::Bool>();
-                    pres.push(pre);
-                    // The Rust and Viper (SMT) semantics for `\` and `%` do not
-                    // match up when `arg1 < 0`, encode this difference.
-                    if matches!(op, Div) {
-                        // `arg1 >= 0 ? arg1 \ arg2 : arg2 >= 0 ? (arg1 - 1) \ arg2 + 1 : (arg1 - 1) \ arg2 - 1`
-                        let lhs_sub = vcx.mk_bin_op_expr(
-                            vir::BinOpKind::Sub,
-                            lhs.downcast_ty(),
-                            vcx.mk_int::<1>(),
-                        );
-                        let common_div = vcx.mk_bin_op_expr_inner(op_kind, lhs_sub, rhs).downcast_ty();
-                        let neg_pos =
-                            vcx.mk_bin_op_expr(vir::BinOpKind::Add, common_div, vcx.mk_int::<1>());
-                        let neg_neg =
-                            vcx.mk_bin_op_expr(vir::BinOpKind::Sub, common_div, vcx.mk_int::<1>());
-                        let rhs_pos = vcx
-                            .mk_bin_op_expr(
-                                vir::BinOpKind::CmpGe,
-                                rhs.downcast_ty(),
-                                vcx.mk_int::<0>(),
-                            )
-                            .downcast_ty();
-                        let negative = vcx.mk_ternary_expr(rhs_pos, neg_pos, neg_neg);
-                        let lhs_pos = vcx
-                            .mk_bin_op_expr(
-                                vir::BinOpKind::CmpGe,
-                                lhs.downcast_ty(),
-                                vcx.mk_int::<0>(),
-                            )
-                            .downcast_ty();
-                        val = vcx.mk_ternary_expr(lhs_pos, val, negative);
-                    } else {
-                        // `arg1 >= 0 ? arg1 % arg2 : (arg1 % arg2) - (arg2 >= 0 ? arg2 : -arg2)`
-                        let rhs_pos = vcx
-                            .mk_bin_op_expr(
-                                vir::BinOpKind::CmpGe,
-                                rhs.downcast_ty(),
-                                vcx.mk_int::<0>(),
-                            )
-                            .downcast_ty();
-                        let rhs_abs = vcx.mk_ternary_expr(
-                            rhs_pos,
-                            rhs,
-                            vcx.mk_unary_op_expr(vir::UnOpKind::Neg, rhs),
-                        );
-                        let negative = vcx.mk_bin_op_expr(vir::BinOpKind::Sub, viper_val, rhs_abs);
-                        let lhs_pos = vcx
-                            .mk_bin_op_expr(
-                                vir::BinOpKind::CmpGe,
-                                lhs.downcast_ty(),
-                                vcx.mk_int::<0>(),
-                            )
-                            .downcast_ty();
-                        val = vcx.mk_ternary_expr(lhs_pos, val, negative);
-                    }
+                    let max = vcx.get_max_int(res_ty.kind());
+                    // `(arg1 op arg2) <= iN::MAX`
+                    let upper_bound = vcx
+                        .mk_bin_op_expr(vir::BinOpKind::CmpLe, viper_val.downcast_ty(), max)
+                        .downcast_ty::<vir::Bool>();
+                    (vec![lower_bound, upper_bound], viper_val)
                 }
-                (pres, val)
+                // Overflow is well defined as wrapping (implicit), but shifting by
+                // more than the bit width (or less than 0) is undefined behavior.
+                ShlUnchecked | ShrUnchecked => {
+                    let min = vcx.mk_int::<0>();
+                    // `arg2 >= 0`
+                    let lower_bound = vcx
+                        .mk_bin_op_expr(vir::BinOpKind::CmpGe, rhs.downcast_ty(), min)
+                        .downcast_ty::<vir::Bool>();
+                    let max = vcx.get_bit_width_int(l_ty.kind());
+                    // `arg2 < bit_width(arg1)`
+                    let upper_bound = vcx
+                        .mk_bin_op_expr(vir::BinOpKind::CmpLt, rhs.downcast_ty(), max)
+                        .downcast_ty::<vir::Bool>();
+                    (
+                        vec![lower_bound, upper_bound],
+                        Self::get_wrapped_val(vcx, viper_val.downcast_ty(), res_ty).upcast_ty(),
+                    )
+                }
+                // Could divide by zero or overflow if divisor is `-1`
+                Div | Rem => {
+                    // `0 != arg2 `
+                    let pre = vcx
+                        .mk_bin_op_expr(vir::BinOpKind::CmpNe, vcx.mk_int::<0>(), rhs.downcast_ty())
+                        .downcast_ty::<vir::Bool>();
+                    let mut pres = vec![pre];
+                    let mut val = viper_val;
+                    if res_ty.is_signed() {
+                        let min = vcx.get_min_int(res_ty.kind());
+                        // `arg1 != -iN::MIN`
+                        let arg1_cond =
+                            vcx.mk_bin_op_expr(vir::BinOpKind::CmpNe, lhs.downcast_ty(), min);
+                        // `-1 != arg2 `
+                        let arg2_cond = vcx.mk_bin_op_expr(
+                            vir::BinOpKind::CmpNe,
+                            vcx.mk_int::<-1>(),
+                            rhs.downcast_ty(),
+                        );
+                        // `-1 != arg2 || arg1 != -iN::MIN`
+                        let pre = vcx
+                            .mk_bin_op_expr(vir::BinOpKind::Or, arg1_cond, arg2_cond)
+                            .downcast_ty::<vir::Bool>();
+                        pres.push(pre);
+                        // The Rust and Viper (SMT) semantics for `\` and `%` do not
+                        // match up when `arg1 < 0`, encode this difference.
+                        if matches!(op, Div) {
+                            // `arg1 >= 0 ? arg1 \ arg2 : arg2 >= 0 ? (arg1 - 1) \ arg2 + 1 : (arg1 - 1) \ arg2 - 1`
+                            let lhs_sub = vcx.mk_bin_op_expr(
+                                vir::BinOpKind::Sub,
+                                lhs.downcast_ty(),
+                                vcx.mk_int::<1>(),
+                            );
+                            let common_div = vcx.mk_bin_op_expr_inner(op_kind, lhs_sub, rhs).downcast_ty();
+                            let neg_pos =
+                                vcx.mk_bin_op_expr(vir::BinOpKind::Add, common_div, vcx.mk_int::<1>());
+                            let neg_neg =
+                                vcx.mk_bin_op_expr(vir::BinOpKind::Sub, common_div, vcx.mk_int::<1>());
+                            let rhs_pos = vcx
+                                .mk_bin_op_expr(
+                                    vir::BinOpKind::CmpGe,
+                                    rhs.downcast_ty(),
+                                    vcx.mk_int::<0>(),
+                                )
+                                .downcast_ty();
+                            let negative = vcx.mk_ternary_expr(rhs_pos, neg_pos, neg_neg);
+                            let lhs_pos = vcx
+                                .mk_bin_op_expr(
+                                    vir::BinOpKind::CmpGe,
+                                    lhs.downcast_ty(),
+                                    vcx.mk_int::<0>(),
+                                )
+                                .downcast_ty();
+                            val = vcx.mk_ternary_expr(lhs_pos, val, negative);
+                        } else {
+                            // `arg1 >= 0 ? arg1 % arg2 : (arg1 % arg2) - (arg2 >= 0 ? arg2 : -arg2)`
+                            let rhs_pos = vcx
+                                .mk_bin_op_expr(
+                                    vir::BinOpKind::CmpGe,
+                                    rhs.downcast_ty(),
+                                    vcx.mk_int::<0>(),
+                                )
+                                .downcast_ty();
+                            let rhs_abs = vcx.mk_ternary_expr(
+                                rhs_pos,
+                                rhs,
+                                vcx.mk_unary_op_expr(vir::UnOpKind::Neg, rhs),
+                            );
+                            let negative = vcx.mk_bin_op_expr(vir::BinOpKind::Sub, viper_val, rhs_abs);
+                            let lhs_pos = vcx
+                                .mk_bin_op_expr(
+                                    vir::BinOpKind::CmpGe,
+                                    lhs.downcast_ty(),
+                                    vcx.mk_int::<0>(),
+                                )
+                                .downcast_ty();
+                            val = vcx.mk_ternary_expr(lhs_pos, val, negative);
+                        }
+                    }
+                    (pres, val)
+                }
+                // Cannot overflow and no undefined behavior
+                BitXor | BitAnd | BitOr | Eq | Lt | Le | Ne | Ge | Gt | Offset => {
+                    (Vec::new(), viper_val)
+                }
+
+                // these are handled in `handle_checked_bin_op`
+                AddWithOverflow | SubWithOverflow | MulWithOverflow => unreachable!(),
+
+                // this is handled separately, earlier
+                Cmp => unreachable!(),
             }
-            // Cannot overflow and no undefined behavior
-            BitXor | BitAnd | BitOr | Eq | Lt | Le | Ne | Ge | Gt | Offset => {
-                (Vec::new(), viper_val)
-            }
-            Cmp => todo!(),
-            _ => unreachable!(),
         };
         let val = (prim_res_ty.prim_to_snap)(val);
         Ok(vcx.mk_function(

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -918,6 +918,8 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
             }
         }
 
+        let span = statement.source_info.span;
+
         match &statement.kind {
             mir::StatementKind::Assign(box (dest, rvalue)) => {
                 // What are we assigning to?
@@ -1079,20 +1081,33 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
                 self.stmt(method_assign_app);
             }
 
-            // no-ops ?
-            mir::StatementKind::StorageLive(..)
-            | mir::StatementKind::StorageDead(..) => {}
-
             // no-ops
-            mir::StatementKind::FakeRead(_)
-            | mir::StatementKind::Retag(..)
+            mir::StatementKind::StorageLive(..)
+            | mir::StatementKind::StorageDead(..)
+            | mir::StatementKind::FakeRead(_)
             | mir::StatementKind::PlaceMention(_)
             | mir::StatementKind::AscribeUserType(..)
             | mir::StatementKind::Coverage(_)
-            //| mir::StatementKind::ConstEvalCounter
-            | mir::StatementKind::Nop => {}
+            | mir::StatementKind::ConstEvalCounter
+            | mir::StatementKind::Nop
+            | mir::StatementKind::BackwardIncompatibleDropHint { .. } => {}
 
-            k => todo!("statement {k:?}"),
+            mir::StatementKind::Intrinsic(intrinsic_kind) => {
+                let intrinsic_kind = intrinsic_kind.clone();
+                self.vcx.with_span(span, |vcx| {
+                    vcx.handle_error("exhale.failed:assertion.false", move |_| {
+                        Some(vec![PrustiError::verification(
+                            format!("unsupported intrinsic statement {intrinsic_kind:?} might be reached"),
+                            span.into(),
+                        )])
+                    });
+                    self.stmt(self.vcx.mk_exhale_stmt(self.vcx.mk_bool::<false>()));
+                });
+            },
+
+            mir::StatementKind::Retag(..)
+            | mir::StatementKind::SetDiscriminant { .. }
+            | mir::StatementKind::Deinit(..) => unreachable!("the statement kind {:?} is not allowed in the MIR analysis phase", statement.kind),
         }
         self.new_after_label(location);
     }
@@ -1564,10 +1579,58 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
                 )
             }
 
-            unsupported_kind => self.vcx.mk_dummy_stmt(vir::vir_format!(
-                self.vcx,
-                "terminator {unsupported_kind:?}"
-            )),
+            mir::TerminatorKind::UnwindResume
+            | mir::TerminatorKind::UnwindTerminate(..) => self.vcx().with_span(span, |vcx| {
+                vcx.handle_error("exhale.failed:assertion.false", move |_| {
+                    Some(vec![PrustiError::unsupported(
+                        "unwind paths are not supported",
+                        span.into(),
+                    )])
+                });
+                self.stmt(self.vcx.mk_exhale_stmt(self.vcx.mk_bool::<false>()));
+                self.vcx.mk_assume_false_stmt()
+            }),
+
+            mir::TerminatorKind::TailCall { .. } => self.vcx().with_span(span, |vcx| {
+                vcx.handle_error("exhale.failed:assertion.false", move |_| {
+                    Some(vec![PrustiError::unsupported(
+                        "tail calls are not supported",
+                        span.into(),
+                    )])
+                });
+                self.stmt(self.vcx.mk_exhale_stmt(self.vcx.mk_bool::<false>()));
+                self.vcx.mk_assume_false_stmt()
+            }),
+            mir::TerminatorKind::Yield { .. } => self.vcx().with_span(span, |vcx| {
+                vcx.handle_error("exhale.failed:assertion.false", move |_| {
+                    Some(vec![PrustiError::unsupported(
+                        "yield statements are not supported",
+                        span.into(),
+                    )])
+                });
+                self.stmt(self.vcx.mk_exhale_stmt(self.vcx.mk_bool::<false>()));
+                self.vcx.mk_assume_false_stmt()
+            }),
+            mir::TerminatorKind::CoroutineDrop => self.vcx().with_span(span, |vcx| {
+                vcx.handle_error("exhale.failed:assertion.false", move |_| {
+                    Some(vec![PrustiError::unsupported(
+                        "coroutines are not supported",
+                        span.into(),
+                    )])
+                });
+                self.stmt(self.vcx.mk_exhale_stmt(self.vcx.mk_bool::<false>()));
+                self.vcx.mk_assume_false_stmt()
+            }),
+            mir::TerminatorKind::InlineAsm { .. } => self.vcx().with_span(span, |vcx| {
+                vcx.handle_error("exhale.failed:assertion.false", move |_| {
+                    Some(vec![PrustiError::unsupported(
+                        "inline assembly is not supported",
+                        span.into(),
+                    )])
+                });
+                self.stmt(self.vcx.mk_exhale_stmt(self.vcx.mk_bool::<false>()));
+                self.vcx.mk_assume_false_stmt()
+            }),
         };
         self.new_after_label(location);
         assert!(self.current_terminator.replace(terminator).is_none());

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -813,7 +813,7 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
                     &[],
                     &[],
                     self.vcx
-                        .mk_dummy_stmt(vir::vir_format!(self.vcx, "cleanup block",)),
+                        .mk_dummy_stmt(vir::vir_format!(self.vcx, "cleanup block")),
                 ),
             );
             return;
@@ -1472,7 +1472,7 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
                 expected,
                 msg,
                 target,
-                unwind,
+                ..
             } => {
                 const REAL_TARGET_SUCC_IDX: usize = 0;
                 // Ensure that the terminator succ that we use for the repacks is the correct one
@@ -1530,34 +1530,12 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
                     });
                     self.stmt(self.vcx.mk_exhale_stmt(assert));
                 });
-
+                let set_flag = self.set_from_to_flag(location.block, *target);
+                self.stmt(set_flag);
                 let target_bb = self
                     .vcx
                     .alloc(vir::CfgBlockLabelData::BasicBlock(target.as_usize()));
-                let otherwise_statement;
-                let otherwise = match unwind {
-                    mir::UnwindAction::Cleanup(bb) => {
-                        otherwise_statement = self.set_from_to_flag(location.block, *bb);
-                        self
-                            .vcx
-                            .alloc(vir::CfgBlockLabelData::BasicBlock(bb.as_usize()))
-                    }
-                    _ => todo!(),
-                };
-
-                let statements = self.set_from_to_flag(location.block, *target);
-                let statements = self.vcx.alloc_slice(&[statements]);
-
-                self.vcx.mk_goto_if_stmt(
-                    enc.as_dyn(),
-                    self.vcx.alloc_slice(&[self.vcx.mk_goto_if_target(
-                        expected.as_dyn(),
-                        target_bb,
-                        statements,
-                    )]),
-                    otherwise,
-                    self.vcx.alloc_slice(&[otherwise_statement]),
-                )
+                self.vcx.mk_goto_stmt(target_bb)
             }
             mir::TerminatorKind::Unreachable => self.vcx().with_span(span, |vcx| {
                 vcx.handle_error("exhale.failed:assertion.false", move |_| {

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -690,7 +690,6 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
                 unop_function.call()(self.encode_operand(curr_ver, operand).downcast_ty())
                     .upcast_ty()
             }
-            // Discriminant
             mir::Rvalue::Aggregate(box kind, fields) => match kind {
                 mir::AggregateKind::Adt(..)
                 | mir::AggregateKind::Tuple
@@ -711,7 +710,16 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
                         .collect::<Vec<_>>();
                     sl.field_snaps_to_snap(cons_args).upcast_ty()
                 }
-                _ => todo!("Unsupported Rvalue::AggregateKind: {kind:?}"),
+                _k => {
+                    // TODO: attach kind of aggregate to the unreachable
+                    //   expression in case it is reached
+                    self
+                        .deps
+                        .require_local::<TyPureEnc>(rvalue_ty)
+                        .unwrap()
+                        .unreachable_to_snap()
+                        .call()()
+                }
             },
             mir::Rvalue::Discriminant(place) => {
                 let place_ty = place.ty(self.body, self.vcx.tcx());
@@ -741,9 +749,15 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
             }
             // ShallowInitBox
             // CopyForDeref
-            k => {
-                //dbg!(self.body);
-                todo!("rvalue {k:?}")
+            _k => {
+                // TODO: attach kind of rvalue to the unreachable expression
+                //   in case it is reached
+                self
+                    .deps
+                    .require_local::<TyPureEnc>(rvalue_ty)
+                    .unwrap()
+                    .unreachable_to_snap()
+                    .call()()
             }
         }
     }

--- a/prusti-encoder/src/encoders/type/domain.rs
+++ b/prusti-encoder/src/encoders/type/domain.rs
@@ -219,14 +219,13 @@ impl TaskEncoder for DomainEnc {
                 TyKind::Bool
                 | TyKind::Char
                 | TyKind::Int(_)
-                | TyKind::Uint(_)
-                | TyKind::Float(_) => {
+                | TyKind::Uint(_) => {
                     super::kinds::primitive::domain(*task_key, deps, builder)?
                 }
                 TyKind::Closure(..) => {
                     super::kinds::closure::domain(*task_key, &output_ref, deps, builder)?
                 }
-                TyKind::Adt(..) => {
+                TyKind::Adt(adt, _) if !adt.is_union() => {
                     super::kinds::adt::domain(*task_key, &output_ref, deps, builder)?
                 }
                 TyKind::Tuple(..) => {

--- a/prusti-encoder/src/encoders/type/kinds/adt.rs
+++ b/prusti-encoder/src/encoders/type/kinds/adt.rs
@@ -151,7 +151,7 @@ pub(crate) fn domain<'vir>(
             Ok((Some(enc.finalize(task_key)), specifics))
             */
         }
-        ty::AdtKind::Union => todo!(),
+        ty::AdtKind::Union => unreachable!(),
     }
 }
 
@@ -443,6 +443,6 @@ pub(crate) fn predicate<'vir>(
                 None,
             ))
         }
-        ty::AdtKind::Union => todo!(),
+        ty::AdtKind::Union => unreachable!(),
     }
 }

--- a/prusti-encoder/src/encoders/type/kinds/primitive.rs
+++ b/prusti-encoder/src/encoders/type/kinds/primitive.rs
@@ -17,7 +17,6 @@ pub(crate) fn domain<'vir>(
     let prim_type: vir::TypePrim<'vir> = match ty_kind {
         ty::TyKind::Bool => vir::TYPE_BOOL.upcast_ty(),
         ty::TyKind::Char | ty::TyKind::Int(_) | ty::TyKind::Uint(_) => vir::TYPE_INT.upcast_ty(),
-        ty::TyKind::Float(_) => todo!(),
         _ => unreachable!(),
     };
 

--- a/prusti-interface/src/environment/mir_storage.rs
+++ b/prusti-interface/src/environment/mir_storage.rs
@@ -35,6 +35,7 @@ pub unsafe fn store_mir_body<'tcx>(
     // SAFETY: See the module level comment.
     let body_with_facts: BodyWithBorrowckFacts<'static> =
         unsafe { std::mem::transmute(body_with_facts) };
+    assert_eq!(body_with_facts.body.phase, mir::MirPhase::Analysis(mir::AnalysisPhase::Initial));
     SHARED_STATE_WITH_FACTS.with(|state| {
         let mut map = state.borrow_mut();
         assert!(map.insert(def_id, body_with_facts).is_none());
@@ -69,6 +70,7 @@ pub unsafe fn store_promoted_mir_body<'tcx>(
 ) {
     // SAFETY: See the module level comment.
     let body: mir::Body<'static> = unsafe { std::mem::transmute(body) };
+    assert_eq!(body.phase, mir::MirPhase::Analysis(mir::AnalysisPhase::Initial));
     SHARED_STATE_WITHOUT_FACTS.with(|state| {
         let mut map = state.borrow_mut();
         assert!(map.insert(def_id, body).is_none());


### PR DESCRIPTION
WIP to start removing `todo!()`s, especially for non-exhaustive matches on MIR data. A lot of these can be handled as `unreachable!` in verified code: encode as an `assert false` statement with an error message saying this feature is not supported. This allows the code to still be fully encoded and even verified if the feature is on a dead code path.