### PR TITLE
Move more unsupported errors into verification time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3189,6 +3189,7 @@ name = "task-encoder"
 version = "0.1.0"
 dependencies = [
  "hashlink",
+ "prusti-rustc-interface",
  "vir",
 ]
 

--- a/prusti-encoder/src/encoder_traits/impure_function_enc.rs
+++ b/prusti-encoder/src/encoder_traits/impure_function_enc.rs
@@ -55,11 +55,12 @@ where
         vir::with_vcx(|vcx| {
             use mir::visit::Visitor;
 
+            let span = vcx.tcx().def_span(def_id);
             let substs = Self::get_substs(vcx, &task_key);
             let trusted = crate::encoders::is_function_trusted(def_id, substs);
 
             let arg_defs =
-                deps.require_ref::<MirLocalDefEnc>((def_id, substs, caller_def_id, false))?;
+                deps.require_ref_spanned::<MirLocalDefEnc>((def_id, substs, caller_def_id, false), span)?;
 
             // Argument count for the Viper method:
             // - one (`Ref`) for the return place;
@@ -79,7 +80,7 @@ where
             let method_name = Self::mk_method_ident(vcx, &task_key);
             let ref_args = vcx.alloc_slice(&vec![vir::TYPE_REF; arg_count]);
             let param_ty_decls = deps
-                .require_local::<LiftedTyParamsEnc>(substs)?
+                .require_local_spanned::<LiftedTyParamsEnc>(substs, span)?
                 .iter()
                 .map(|g| g.decl())
                 .collect::<Vec<_>>();
@@ -103,15 +104,15 @@ where
             })?;
 
             let arg_defs =
-                deps.require_local::<MirLocalDefEnc>((def_id, substs, caller_def_id, false))?;
+                deps.require_local_spanned::<MirLocalDefEnc>((def_id, substs, caller_def_id, false), span)?;
 
             // Method contract. We will need to emit pre- and postconditions for
             // the permissions, the functional spec, and (in the postcondition)
             // wands in case of a reborrowing function.
             let mut pres = Vec::new();
             let mut posts = Vec::new();
-            let spec = deps.require_local::<MirSpecEnc>((def_id, substs, None, false))?;
-            let wands = deps.require_local::<WandEnc>(WandEncTask { def_id })?;
+            let spec = deps.require_local_spanned::<MirSpecEnc>((def_id, substs, None, false), span)?;
+            let wands = deps.require_local_spanned::<WandEnc>(WandEncTask { def_id }, span)?;
 
             // Add direct resources for inputs and outputs to the pre- and
             // postconditions, respectively. "Direct" here refers to owned
@@ -136,7 +137,7 @@ where
                 let body_with_facts = vcx.body_mut().get_impure_fn_body_with_facts(local_def_id);
                 let body = &body_with_facts.body;
                 let local_defs =
-                    deps.require_local::<MirLocalDefEnc>((def_id, substs, caller_def_id, true))?;
+                    deps.require_local_spanned::<MirLocalDefEnc>((def_id, substs, caller_def_id, true), span)?;
 
                 let loop_analysis = LoopAnalysis::find_loops(&body);
                 let bc = NllBorrowCheckerImpl::new(vcx.tcx(), &body_with_facts);

--- a/prusti-encoder/src/encoder_traits/impure_function_enc.rs
+++ b/prusti-encoder/src/encoder_traits/impure_function_enc.rs
@@ -57,8 +57,8 @@ where
             let substs = Self::get_substs(vcx, &task_key);
             let trusted = crate::encoders::is_function_trusted(def_id, substs);
 
-            let local_defs =
-                deps.require_local::<MirLocalDefEnc>((def_id, substs, caller_def_id))?;
+            let arg_defs =
+                deps.require_ref::<MirLocalDefEnc>((def_id, substs, caller_def_id, false))?;
 
             // Argument count for the Viper method:
             // - one (`Ref`) for the return place;
@@ -71,7 +71,7 @@ where
             //
             // TODO: type parameters: for generic methods we will want to pass
             //   values of type `Type` as well`
-            let arg_count = local_defs.arg_count + 1;
+            let arg_count = arg_defs.arg_count + 1;
 
             // Create the identifier and use it as an output ref. This is what
             // is used when other methods call this one.
@@ -91,6 +91,9 @@ where
             let method_ref = MethodIdn::new(method_name, (ref_args, ty_args));
             deps.emit_output_ref(task_key, ImpureFunctionEncOutputRef { method_ref })?;
 
+            let arg_defs =
+                deps.require_local::<MirLocalDefEnc>((def_id, substs, caller_def_id, false))?;
+
             // Method contract. We will need to emit pre- and postconditions for
             // the permissions, the functional spec, and (in the postcondition)
             // wands in case of a reborrowing function.
@@ -105,18 +108,18 @@ where
             // without going through any dereferences.
             let mut args = Vec::with_capacity(arg_count + substs.len());
             for arg_idx in (0..arg_count).map(mir::Local::from) {
-                let name_p = local_defs[arg_idx].local.name;
+                let name_p = arg_defs[arg_idx].local.name;
                 args.push(vir::vir_local_decl! { vcx; [name_p] : Ref });
                 if arg_idx != mir::RETURN_PLACE {
-                    pres.push(local_defs[arg_idx].impure_pred);
+                    pres.push(arg_defs[arg_idx].impure_pred);
                 }
             }
-            posts.push(local_defs[mir::RETURN_PLACE].impure_pred);
+            posts.push(arg_defs[mir::RETURN_PLACE].impure_pred);
 
             // ..
-            pres.extend(wands.indirect_pres(vcx, &local_defs, deps));
-            posts.extend(wands.indirect_posts(vcx, &local_defs, deps));
-            posts.extend(wands.wand_posts(vcx, &local_defs, deps));
+            pres.extend(wands.indirect_pres(vcx, &arg_defs, deps));
+            posts.extend(wands.indirect_posts(vcx, &arg_defs, deps));
+            posts.extend(wands.wand_posts(vcx, &arg_defs, deps));
 
             // Do not encode the method body if it is external, trusted, just
             // a call stub, or a trait function without a default implementation
@@ -126,6 +129,8 @@ where
             let blocks = if let Some(local_def_id) = local_def_id {
                 let body_with_facts = vcx.body_mut().get_impure_fn_body_with_facts(local_def_id);
                 let body = &body_with_facts.body;
+                let local_defs =
+                    deps.require_local::<MirLocalDefEnc>((def_id, substs, caller_def_id, true))?;
 
                 let loop_analysis = LoopAnalysis::find_loops(&body);
                 let bc = NllBorrowCheckerImpl::new(vcx.tcx(), &body_with_facts);

--- a/prusti-encoder/src/encoder_traits/impure_function_enc.rs
+++ b/prusti-encoder/src/encoder_traits/impure_function_enc.rs
@@ -21,6 +21,7 @@ pub struct ImpureFunctionEncError;
 #[derive(Clone, Debug)]
 pub struct ImpureFunctionEncOutputRef<'vir> {
     pub method_ref: MethodIdn<'vir, (vir::ManyRef, vir::ManyTyVal)>,
+    pub should_be_verified: bool,
 }
 impl<'vir> task_encoder::OutputRefAny for ImpureFunctionEncOutputRef<'vir> {}
 
@@ -89,7 +90,17 @@ where
                     .collect::<Vec<_>>(),
             );
             let method_ref = MethodIdn::new(method_name, (ref_args, ty_args));
-            deps.emit_output_ref(task_key, ImpureFunctionEncOutputRef { method_ref })?;
+
+            // Do not encode the method body if it is external, trusted, just
+            // a call stub, or a trait function without a default implementation
+            let local_def_id = def_id
+                .as_local()
+                .filter(|_| !trusted && is_function_with_body(vcx.tcx(), def_id));
+
+            deps.emit_output_ref(task_key, ImpureFunctionEncOutputRef {
+                method_ref,
+                should_be_verified: local_def_id.is_some(),
+            })?;
 
             let arg_defs =
                 deps.require_local::<MirLocalDefEnc>((def_id, substs, caller_def_id, false))?;
@@ -121,11 +132,6 @@ where
             posts.extend(wands.indirect_posts(vcx, &arg_defs, deps));
             posts.extend(wands.wand_posts(vcx, &arg_defs, deps));
 
-            // Do not encode the method body if it is external, trusted, just
-            // a call stub, or a trait function without a default implementation
-            let local_def_id = def_id
-                .as_local()
-                .filter(|_| !trusted && is_function_with_body(vcx.tcx(), def_id));
             let blocks = if let Some(local_def_id) = local_def_id {
                 let body_with_facts = vcx.body_mut().get_impure_fn_body_with_facts(local_def_id);
                 let body = &body_with_facts.body;

--- a/prusti-encoder/src/encoder_traits/pure_function_enc.rs
+++ b/prusti-encoder/src/encoder_traits/pure_function_enc.rs
@@ -8,11 +8,9 @@ use task_encoder::{EncodeFullError, TaskEncoder, TaskEncoderDependencies};
 use vir::{ExprGenBool, ExprGenSnap, FunctionIdn, Reify, ViperIdent};
 
 use crate::encoders::{
-    lifted::{
+    MirLocalDefEnc, MirPureEnc, MirPureEncTask, MirSpecEnc, PureKind, lifted::{
         EncodeGenericsAsLifted, LiftedTy, LiftedTyEnc, LiftedTyEncTask, LiftedTyParamsEnc, TypeOfEnc,
-    },
-    most_generic_ty::extract_type_params,
-    MirLocalDefEnc, MirPureEnc, MirPureEncTask, MirSpecEnc, PureKind,
+    }, most_generic_ty::MostGenericTyEnc,
 };
 
 use super::function_enc::FunctionEnc;
@@ -55,7 +53,7 @@ where
         arg: ExprGenSnap<'vir, Curr, Next>, // Snapshot encoded argument
         ty: Ty<'vir>,
     ) -> Option<ExprGenBool<'vir, Curr, Next>> {
-        let generic_ty = extract_type_params(vcx.tcx(), ty).0;
+        let (generic_ty, _) = deps.require_local::<MostGenericTyEnc>(ty).unwrap();
         let typeof_ref = deps
             .require_ref::<TypeOfEnc>(generic_ty)
             .unwrap();
@@ -90,7 +88,7 @@ where
             let substs = Self::get_substs(vcx, &task_key);
             let trusted = crate::encoders::is_function_trusted(def_id, substs);
             let local_defs = deps
-                .require_local::<MirLocalDefEnc>((def_id, substs, caller_def_id))
+                .require_local::<MirLocalDefEnc>((def_id, substs, caller_def_id, true))
                 .unwrap();
 
             tracing::debug!("encoding {def_id:?}");

--- a/prusti-encoder/src/encoders/impure/fn_wand.rs
+++ b/prusti-encoder/src/encoders/impure/fn_wand.rs
@@ -325,6 +325,8 @@ impl TaskEncoder for WandEnc {
 
     type EncodingError = WandEncError;
 
+    const ENCODER_NAME: &'static str = "wand encoder";
+
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         WandEncTask {
             def_id: task.def_id,

--- a/prusti-encoder/src/encoders/impure/fn_wand.rs
+++ b/prusti-encoder/src/encoders/impure/fn_wand.rs
@@ -10,12 +10,15 @@ use prusti_rustc_interface::{
     middle::{mir, ty},
     span::{def_id::DefId, Span},
 };
-use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 
 /// Encodes the magic wands given a function signature.
 pub struct WandEnc;
 
-pub type WandEncError = ();
+#[derive(Clone, Debug)]
+pub enum WandEncError {
+    Unsupported(String),
+}
 
 type Pledges<'vir> = Vec<(
     Option<(vir::ExprBool<'vir>, Span)>,
@@ -28,6 +31,7 @@ pub struct WandEncOutput<'vir> {
     edges: WandEncEdges,
     pub generic_to_param: FxHashMap<IndirectKey, Vec<(mir::Local, ty::Ty<'vir>)>>,
     pub pledges: Pledges<'vir>,
+    wands: Vec<(Vec<IndirectKey>, Vec<IndirectKey>, Pledges<'vir>)>,
 }
 
 impl<'vir> WandEncOutput<'vir> {
@@ -455,7 +459,7 @@ impl TaskEncoder for WandEnc {
                     let (ty::RegionKind::ReEarlyParam(a), ty::RegionKind::ReEarlyParam(b)) =
                         (r_a.kind(), r_b.kind())
                     else {
-                        todo!("region bound pair: ({r_a:?}, {r_b:?})");
+                        return Err(EncodeFullError::EncodingError(WandEncError::Unsupported(format!("region bound pair: ({r_a:?}, {r_b:?})")), None));
                     };
                     insert_edge(IndirectKey::Early(a), IndirectKey::Early(b));
                 }
@@ -463,23 +467,75 @@ impl TaskEncoder for WandEnc {
 
             for pred in rbp {
                 let GenericKind::Param(b) = pred.0 else {
-                    todo!("region bound pair: {pred:?}");
+                    return Err(EncodeFullError::EncodingError(WandEncError::Unsupported(format!("region bound pair: {pred:?}")), None));
                 };
                 let Some(a) = IndirectKey::from_region(pred.1) else {
-                    // TODO: handle unexpected todo!("region bound pair: {pred:?}");
-                    continue;
+                    return Err(EncodeFullError::EncodingError(WandEncError::Unsupported(format!("region bound pair: {pred:?}")), None));
                 };
                 // This edge may be skipped, see TODO in `WandEncEdges::edge`.
                 insert_edge(a, IndirectKey::Param(b));
             }
 
             let spec = deps.require_local::<MirSpecEnc>((def_id, substs, None, false))?;
+            let pledges = spec.pledges;
+
+            // convert edges to viper-supported wands
+
+            // Indexed by the `rhs` of wands
+            let mut edge_rhs: FxHashMap<IndirectKey, Vec<IndirectKey>> = Default::default();
+            // Indexed by the `lhs` of wands
+            let mut edge_lhs: FxHashMap<IndirectKey, Vec<IndirectKey>> = Default::default();
+            let mut wands: Vec<(Vec<IndirectKey>, Vec<IndirectKey>, Pledges<'vir>)> =
+                Default::default();
+
+            for (lhs, rhs) in edges.edges.iter().copied() {
+                edge_lhs.entry(lhs).or_default().push(rhs);
+                edge_rhs.entry(rhs).or_default().push(lhs);
+            }
+
+            let mut skip = FxHashSet::default();
+            for rhs in edges.inputs.iter().copied() {
+                if !skip.insert(rhs) {
+                    continue;
+                }
+                let Some(lhss) = edge_rhs.get(&rhs) else {
+                    wands.push((vec![], vec![rhs], vec![]));
+                    continue;
+                };
+                let lhs = lhss.first().unwrap();
+                let rhss = &edge_lhs[lhs];
+                for lhs_other in lhss {
+                    let rhss_other = &edge_lhs[lhs_other];
+                    if rhss != rhss_other {
+                        return Err(EncodeFullError::EncodingError(WandEncError::Unsupported(format!("two outputs do not block the same set of inputs: {lhs:?} blocks {rhss:?}, {lhs_other:?} blocks {rhss_other:?}")), None));
+                    }
+                }
+                for rhs_other in rhss {
+                    let lhss_other = &edge_rhs[rhs_other];
+                    if lhss != lhss_other {
+                        return Err(EncodeFullError::EncodingError(WandEncError::Unsupported(format!("two inputs are not blocked by the same set of outputs: {rhs:?} blocked by {lhss:?}, {rhs_other:?} blocked by {lhss_other:?}")), None));
+                    }
+                }
+                wands.push((lhss.clone(), rhss.clone(), vec![]));
+                skip.extend(rhss);
+            }
+            if !pledges.is_empty() {
+                let mut actual_wands = wands.iter_mut().filter(|(lhs, ..)| !lhs.is_empty());
+                let wand = actual_wands.next();
+                assert!(wand.is_some(), "pledge for function with no wands");
+                assert!(
+                    actual_wands.next().is_none(),
+                    "pledge for function with multiple wands"
+                );
+                wand.unwrap().2 = pledges.clone();
+            }
 
             Ok((
                 WandEncOutput {
                     edges,
                     generic_to_param,
-                    pledges: spec.pledges,
+                    pledges,
+                    wands,
                 },
                 (),
             ))
@@ -500,52 +556,7 @@ impl<'vir> WandEncOutput<'vir> {
         self.edges.edges.iter().copied()
     }
 
-    /// convert edges to viper-supported wands
     pub fn viper_wands(&self) -> Vec<(Vec<IndirectKey>, Vec<IndirectKey>, Pledges<'vir>)> {
-        // Indexed by the `rhs` of wands
-        let mut edge_rhs: FxHashMap<IndirectKey, Vec<IndirectKey>> = Default::default();
-        // Indexed by the `lhs` of wands
-        let mut edge_lhs: FxHashMap<IndirectKey, Vec<IndirectKey>> = Default::default();
-        let mut wands: Vec<(Vec<IndirectKey>, Vec<IndirectKey>, Pledges<'vir>)> =
-            Default::default();
-
-        for (lhs, rhs) in self.edges() {
-            edge_lhs.entry(lhs).or_default().push(rhs);
-            edge_rhs.entry(rhs).or_default().push(lhs);
-        }
-
-        let mut skip = FxHashSet::default();
-        for rhs in self.inputs() {
-            if !skip.insert(rhs) {
-                continue;
-            }
-            let Some(lhss) = edge_rhs.get(&rhs) else {
-                wands.push((vec![], vec![rhs], vec![]));
-                continue;
-            };
-            let lhs = lhss.first().unwrap();
-            let rhss = &edge_lhs[lhs];
-            for lhs_other in lhss {
-                let rhss_other = &edge_lhs[lhs_other];
-                assert_eq!(rhss, rhss_other, "two outputs do not block the same set of inputs: {lhs:?} blocks {rhss:?}, {lhs_other:?} blocks {rhss_other:?}");
-            }
-            for rhs_other in rhss {
-                let lhss_other = &edge_rhs[rhs_other];
-                assert_eq!(lhss, lhss_other, "two inputs are not blocked by the same set of outputs: {rhs:?} blocked by {lhss:?}, {rhs_other:?} blocked by {lhss_other:?}");
-            }
-            wands.push((lhss.clone(), rhss.clone(), vec![]));
-            skip.extend(rhss);
-        }
-        if !self.pledges.is_empty() {
-            let mut actual_wands = wands.iter_mut().filter(|(lhs, ..)| !lhs.is_empty());
-            let wand = actual_wands.next();
-            assert!(wand.is_some(), "pledge for function with no wands");
-            assert!(
-                actual_wands.next().is_none(),
-                "pledge for function with multiple wands"
-            );
-            wand.unwrap().2 = self.pledges.clone();
-        }
-        wands
+        self.wands.clone()
     }
 }

--- a/prusti-encoder/src/encoders/impure/loop.rs
+++ b/prusti-encoder/src/encoders/impure/loop.rs
@@ -50,7 +50,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 }
                 let (place_res, snap, _, _) = self.encode_place_snap(*place);
                 let ty = (*place).ty(self.pcg_ctxt());
-                let ty_out = self.deps.require_ref::<TyImpureEnc>(ty.ty).unwrap();
+                let ty_out = self.deps.require_local::<TyImpureEnc>(ty.ty).unwrap();
                 let pred = ty_out.ref_to_pred(self.vcx, place_res.expr, None);
                 inv.push(pred);
 
@@ -112,7 +112,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             PcgNode::Place(place @ MaybeRemotePlace::Local(_)) => {
                 let p = Self::get_place(*place);
                 let ty = (*p).ty(self.local_decls, self.vcx.tcx());
-                let ty_out = self.deps.require_ref::<TyImpureEnc>(ty.ty).unwrap();
+                let ty_out = self.deps.require_local::<TyImpureEnc>(ty.ty).unwrap();
                 let p = self.encode_place(p);
                 let p = self.configure_old(*place, p.expr, old_outer);
 

--- a/prusti-encoder/src/encoders/local_def.rs
+++ b/prusti-encoder/src/encoders/local_def.rs
@@ -10,12 +10,19 @@ use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 
 use crate::{
     encoders::{
-        ty_impure::{TyImpureEnc, TyImpureEncOutputRef}, ty_pure::TyPureEncOutputRef, PredicateEncOutputRef
+        ty_impure::{TyImpureEnc, TyImpureEncOutputRef}
     },
     trait_support::is_function_with_body,
 };
 
 pub struct MirLocalDefEnc;
+
+#[derive(Clone, Debug)]
+pub struct MirLocalDefEncOutputRef {
+    pub arg_count: usize,
+}
+impl task_encoder::OutputRefAny for MirLocalDefEncOutputRef {}
+
 #[derive(Clone, Copy)]
 pub struct MirLocalDefEncOutput<'vir> {
     pub locals: &'vir IndexVec<mir::Local, LocalDef<'vir>>,
@@ -40,7 +47,10 @@ impl TaskEncoder for MirLocalDefEnc {
         DefId,                    // ID of the function
         ty::GenericArgsRef<'vir>, // ? this should be the "signature", after applying the env/substs
         Option<DefId>,            // ID of the caller function, if any
+        bool,                     // `true` = include non-argument locals (if available)
     );
+
+    type OutputRef<'vir> = MirLocalDefEncOutputRef;
 
     type OutputFullLocal<'vir> = MirLocalDefEncOutput<'vir>;
 
@@ -54,8 +64,7 @@ impl TaskEncoder for MirLocalDefEnc {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        let (def_id, substs, caller_def_id) = *task_key;
-        deps.emit_output_ref(*task_key, ())?;
+        let (def_id, substs, caller_def_id, all_locals) = *task_key;
 
         fn mk_local_def<'vir>(
             vcx: &'vir vir::VirCtxt<'vir>,
@@ -79,6 +88,8 @@ impl TaskEncoder for MirLocalDefEnc {
 
         let trusted = crate::encoders::spec::is_function_trusted(def_id, substs);
         vir::with_vcx(|vcx| {
+            // TODO: refactor this a bit: split into one encoder for arguments (only)
+            //   and one for locals (only)
             let data = if !trusted
                 && let Some(local_def_id) = def_id.as_local()
                 && is_function_with_body(vcx.tcx(), def_id)
@@ -86,15 +97,23 @@ impl TaskEncoder for MirLocalDefEnc {
                 let body = vcx
                     .body_mut()
                     .get_impure_fn_body(local_def_id, substs, caller_def_id);
+                deps.emit_output_ref(*task_key, MirLocalDefEncOutputRef {
+                    arg_count: body.arg_count,
+                })?;
                 let locals = IndexVec::from_fn_n(
                     |arg: mir::Local| {
                         let local = vir::vir_format!(vcx, "_{}p", arg.index());
                         let ty = deps
-                            .require_ref::<TyImpureEnc>(body.local_decls[arg].ty)
+                            .require_local::<TyImpureEnc>(body.local_decls[arg].ty)
                             .unwrap();
                         mk_local_def(vcx, local, ty)
                     },
-                    body.local_decls.len(),
+                    if all_locals {
+                        body.local_decls.len()
+                    } else {
+                        // return + arguments
+                        1 + body.arg_count
+                    },
                 );
                 MirLocalDefEncOutput {
                     locals: vcx.alloc(locals),
@@ -109,20 +128,23 @@ impl TaskEncoder for MirLocalDefEnc {
                     vcx.tcx().fn_sig(def_id),
                 );
                 let sig = sig.skip_binder();
+                deps.emit_output_ref(*task_key, MirLocalDefEncOutputRef {
+                    arg_count: sig.inputs().len(),
+                })?;
 
-                let locals = IndexVec::from_fn_n(
-                    |arg: mir::Local| {
+                let locals = (0..sig.inputs_and_output.len())
+                    .map(mir::Local::from)
+                    .map(|arg: mir::Local| {
                         let local = vir::vir_format!(vcx, "_{}p", arg.index());
                         let ty = if arg.index() == 0 {
                             sig.output()
                         } else {
                             sig.inputs()[arg.index() - 1]
                         };
-                        let ty = deps.require_ref::<TyImpureEnc>(ty).unwrap();
-                        mk_local_def(vcx, local, ty)
-                    },
-                    sig.inputs_and_output.len(),
-                );
+                        let ty = deps.require_local::<TyImpureEnc>(ty)?;
+                        Ok(mk_local_def(vcx, local, ty))
+                    })
+                    .collect::<Result<IndexVec<_, _>, _>>()?;
 
                 MirLocalDefEncOutput {
                     locals: vcx.alloc(locals),

--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -84,7 +84,7 @@ impl TaskEncoder for MirBuiltinEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local() {
+        for output in Self::all_outputs_local_no_errors() {
             program.add_function(output.function);
         }
     }

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -273,7 +273,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
         let place_ty = ref_p.ty;
         let place_ty_out = self
             .deps
-            .require_ref::<TyImpureEnc>(place_ty.ty)
+            .require_local::<TyImpureEnc>(place_ty.ty)
             .unwrap();
         let data = place_ty_out.expect_variant_opt(place_ty.variant_index);
 
@@ -491,7 +491,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 let place_ty = place_enc.ty;
                 let place_ty_out = self
                     .deps
-                    .require_ref::<TyImpureEnc>(place_ty.ty)
+                    .require_local::<TyImpureEnc>(place_ty.ty)
                     .unwrap();
                 let data = place_ty_out.expect_variant_opt(place_ty.variant_index);
                 if matches!(repack_op, pcg::free_pcs::RepackOp::Expand(..)) {
@@ -510,7 +510,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
 
                 let place_ty_out = self
                     .deps
-                    .require_ref::<TyImpureEnc>(place_ty.ty)
+                    .require_local::<TyImpureEnc>(place_ty.ty)
                     .unwrap();
 
                 let place_enc = self.encode_place(*place);
@@ -573,7 +573,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                     if crossed_ref {
                         let ty_out = self
                             .deps
-                            .require_ref::<TyImpureEnc>(place_ty.ty)
+                            .require_local::<TyImpureEnc>(place_ty.ty)
                             .unwrap();
                         let snap_val = ty_out
                             .ref_to_snap(self.vcx, self.local_defs[place.local].local_ex);
@@ -605,7 +605,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                     {
                         let ty_out = self
                             .deps
-                            .require_ref::<TyImpureEnc>(place_ty.ty)
+                            .require_local::<TyImpureEnc>(place_ty.ty)
                             .unwrap();
                         result = ty_out.ref_to_snap(self.vcx, result.downcast_ty()).as_dyn();
                         crossed_ref = true;
@@ -614,7 +614,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 if !crossed_ref {
                     let ty_out = self
                         .deps
-                        .require_ref::<TyImpureEnc>(place_ty.ty)
+                        .require_local::<TyImpureEnc>(place_ty.ty)
                         .unwrap();
                     result = ty_out.ref_to_snap(self.vcx, result.downcast_ty()).as_dyn();
                 }
@@ -629,11 +629,11 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
         let (encode_place_result, ty_out) = match operand {
             &mir::Operand::Move(source) => return self.encode_place(Place::from(source)).expr,
             &mir::Operand::Copy(_source) => {
-                let ty_out = self.deps.require_ref::<TyImpureEnc>(ty).unwrap();
+                let ty_out = self.deps.require_local::<TyImpureEnc>(ty).unwrap();
                 (self.encode_operand_snap(operand), ty_out)
             }
             mir::Operand::Constant(box constant) => {
-                let ty_out = self.deps.require_ref::<TyImpureEnc>(ty).unwrap();
+                let ty_out = self.deps.require_local::<TyImpureEnc>(ty).unwrap();
                 let constant = self.encode_constant(constant);
                 (constant.upcast_ty(), ty_out)
             }
@@ -694,7 +694,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
         let ty = (*place).ty(self.local_decls, self.vcx.tcx());
         assert!(ty.variant_index.is_none());
 
-        let ty_out = self.deps.require_ref::<TyImpureEnc>(ty.ty).unwrap();
+        let ty_out = self.deps.require_local::<TyImpureEnc>(ty.ty).unwrap();
         let result = self.encode_place(place);
         let snap = ty_out.ref_to_snap(self.vcx, result.expr);
         (result, snap, ty, ty_out)
@@ -710,7 +710,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             mir::ProjectionElem::Field(field_idx, _) => {
                 let e_ty = self
                     .deps
-                    .require_ref::<TyImpureEnc>(place_ty.ty)
+                    .require_local::<TyImpureEnc>(place_ty.ty)
                     .unwrap();
                 let field_access = e_ty
                     .expect_variant_opt(place_ty.variant_index);
@@ -722,7 +722,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 assert!(place_ty.variant_index.is_none());
                 let e_ty = self
                     .deps
-                    .require_ref::<TyImpureEnc>(place_ty.ty)
+                    .require_local::<TyImpureEnc>(place_ty.ty)
                     .unwrap();
                 // println!("  trying to deref place elem {elem:?}");
                 // println!("    place_ty: {place_ty:?}");
@@ -930,7 +930,7 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
 
                 // The snapshot of the value that we are assigning.
                 let rval_enc = match rvalue {
-                    mir::Rvalue::Use(op) => self.encode_operand_snap(op),
+                    mir::Rvalue::Use(op) => Some(self.encode_operand_snap(op)),
 
                     //mir::Rvalue::Repeat(Operand<'vir>, Const<'vir>) => {}
                     //mir::Rvalue::ThreadLocalRef(DefId) => {}
@@ -950,10 +950,10 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
                         let binop_function = self.deps.require_ref::<MirBuiltinEnc>(
                             task
                         ).unwrap().bin_op().unwrap();
-                        binop_function(
+                        Some(binop_function(
                             self.encode_operand_snap(l).downcast_ty(),
                             self.encode_operand_snap(r).downcast_ty(),
-                        ).upcast_ty()
+                        ).upcast_ty())
                     }
 
                     //mir::Rvalue::NullaryOp(NullOp, Ty<'vir>) => {}
@@ -967,7 +967,7 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
                                 operand_ty,
                             ),
                         ).unwrap().un_op().unwrap();
-                        unop_function(self.encode_operand_snap(operand).downcast_ty()).upcast_ty()
+                        Some(unop_function(self.encode_operand_snap(operand).downcast_ty()).upcast_ty())
                         /*
                         assert!(source.projection.is_empty());
                         let source_version = self.ssa_analysis.version.get(&(location, source.local)).unwrap();
@@ -1009,18 +1009,18 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
                         // ).unwrap();
                         let field_snaps = fields.iter().map(|field| self.encode_operand_snap(field)).collect::<Vec<_>>();
                         // let casted_args = ty_caster.apply_casts(self.vcx, field_snaps.into_iter());
-                        sl.field_snaps_to_snap(field_snaps).upcast_ty()
+                        Some(sl.field_snaps_to_snap(field_snaps).upcast_ty())
                     }
                     mir::Rvalue::Discriminant(place) => {
                         let e_rvalue_ty = self.deps.require_local::<TyPureEnc>(rvalue_ty).unwrap();
                         let place_ty = place.ty(self.local_decls, self.vcx.tcx());
-                        let ty = self.deps.require_ref::<TyImpureEnc>(place_ty.ty).unwrap();
+                        let ty = self.deps.require_local::<TyImpureEnc>(place_ty.ty).unwrap();
                         let place_expr = self.encode_place(Place::from(*place)).expr;
 
-                        match ty.get_enumlike().filter(|_| place_ty.variant_index.is_none()) {
+                        Some(match ty.get_enumlike().filter(|_| place_ty.variant_index.is_none()) {
                             Some(el) => {
                                 let discr_ty = place_ty.ty.discriminant_ty(self.vcx.tcx());
-                                let discr_ty_out = self.deps.require_ref::<TyImpureEnc>(discr_ty).unwrap();
+                                let discr_ty_out = self.deps.require_local::<TyImpureEnc>(discr_ty).unwrap();
                                 let discr_expr = discr_ty_out.ref_to_snap(self.vcx, el.as_ref().unwrap().discr(place_expr));
                                 self.vcx.mk_unfolding_expr(ty.ref_to_pred_app(self.vcx, place_expr, Some(self.vcx.mk_wildcard())), discr_expr)
                             }
@@ -1029,10 +1029,10 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
                                 let zero = self.vcx.mk_uint::<0>();
                                 (e_rvalue_ty.expect_primitive().prim_to_snap)(zero.upcast_ty()).upcast_ty()
                             }
-                        }
+                        })
                     }
                     mir::Rvalue::Ref(_reg, _kind, place) => {
-                        match rvalue_ty.kind() {
+                        Some(match rvalue_ty.kind() {
                             TyKind::Ref(_, inner_ty, ty::Mutability::Not) => {
                                 let e_rvalue_ty = self.deps.require_local::<TyPureEnc>(rvalue_ty).unwrap();
                                 let ep = self.encode_place(Place::from(*place));
@@ -1050,36 +1050,42 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
                                 inner.prim_to_snap(place_expr.expr, snap).upcast_ty()
                             }
                             _ => unreachable!(),
-                        }
+                        })
                     }
 
                     //mir::Rvalue::Discriminant(Place<'vir>) => {}
                     //mir::Rvalue::ShallowInitBox(Operand<'vir>, Ty<'vir>) => {}
                     //mir::Rvalue::CopyForDeref(Place<'vir>) => {}
-                    other => {
-                        let e_rvalue_ty = self.deps.require_ref::<TyImpureEnc>(rvalue_ty).unwrap();
-                        tracing::error!("unsupported rvalue {other:?}");
-                        self.vcx.mk_todo_expr(vir::vir_format!(self.vcx, "rvalue {rvalue:?}"), e_rvalue_ty.snapshot())
-                    }
+                    _ => None,
                 };
 
-                // TODO: this is to do FPCS repacks after accessing the rvalue
-                //let e_rvalue_ty = self.deps.require_ref::<TyImpureEnc>(rvalue_ty).unwrap();
-                //let (rval_var, rval_expr) = self.new_tmp(e_rvalue_ty.snapshot());
-                //self.stmt(self.vcx.mk_pure_assign_stmt(rval_expr, expr));
+                if let Some(rval_enc) = rval_enc {
+                    // TODO: this is to do FPCS repacks after accessing the rvalue
+                    //let e_rvalue_ty = self.deps.require_local::<TyImpureEnc>(rvalue_ty).unwrap();
+                    //let (rval_var, rval_expr) = self.new_tmp(e_rvalue_ty.snapshot());
+                    //self.stmt(self.vcx.mk_pure_assign_stmt(rval_expr, expr));
 
-                //self.fpcs_repacks_location(location, |loc| &loc.repacks_middle);
+                    //self.fpcs_repacks_location(location, |loc| &loc.repacks_middle);
 
-                let dest_ty = dest.ty(self.local_decls, self.vcx.tcx());
-                assert!(dest_ty.variant_index.is_none());
-                let dest_ty_out = self.deps.require_ref::<TyImpureEnc>(dest_ty.ty).unwrap();
-                let method_assign_app = dest_ty_out.apply_method_assign(
-                    self.vcx,
-                    proj_enc.expr,
-                    rval_enc,
-                );
+                    let dest_ty = dest.ty(self.local_decls, self.vcx.tcx());
+                    assert!(dest_ty.variant_index.is_none());
+                    let dest_ty_out = self.deps.require_local::<TyImpureEnc>(dest_ty.ty).unwrap();
+                    let method_assign_app = dest_ty_out.apply_method_assign(
+                        self.vcx,
+                        proj_enc.expr,
+                        rval_enc,
+                    );
 
-                self.stmt(method_assign_app);
+                    self.stmt(method_assign_app);
+                } else {
+                    self.vcx.with_span(span, |vcx| {
+                        let error_msg = format!("unsupported rvalue {rvalue:?} might be reached");
+                        vcx.handle_error("exhale.failed:assertion.false", move |_| {
+                            Some(vec![PrustiError::verification(&error_msg, span.into())])
+                        });
+                        self.stmt(self.vcx.mk_exhale_stmt(self.vcx.mk_bool::<false>()));
+                    });
+                }
             }
 
             // no-ops
@@ -1306,7 +1312,7 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
                     let return_ty = destination.ty(self.local_decls, self.vcx.tcx()).ty;
                     let assign_stmt = self
                         .deps
-                        .require_ref::<TyImpureEnc>(return_ty)
+                        .require_local::<TyImpureEnc>(return_ty)
                         .unwrap()
                         .apply_method_assign(self.vcx, dest, pure_func_app);
 

--- a/prusti-encoder/src/encoders/mir_poly_impure.rs
+++ b/prusti-encoder/src/encoders/mir_poly_impure.rs
@@ -1,3 +1,4 @@
+use prusti_interface::PrustiError;
 use prusti_rustc_interface::span::def_id::DefId;
 use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 
@@ -41,8 +42,42 @@ impl TaskEncoder for MirPolyImpureEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local() {
+        let (outputs, errored) = Self::all_outputs_local();
+        for output in outputs {
             program.add_method(output.method);
+        }
+        for (error_key, output_ref) in errored {
+            vir::with_vcx(|vcx| {
+                use vir::CallableIdn;
+                let span = vcx.tcx().def_span(error_key);
+                let method_stub = vcx.mk_method(
+                    output_ref.method_ref,
+                    (
+                        vcx.alloc_slice(&output_ref.method_ref.arity().0.iter()
+                            .enumerate()
+                            .map(|(idx, ty)| vcx.mk_local_decl(vir::vir_format!(vcx, "_0_{idx}"), ty))
+                            .collect::<Vec<_>>()),
+                        vcx.alloc_slice(&output_ref.method_ref.arity().1.iter()
+                            .enumerate()
+                            .map(|(idx, ty)| vcx.mk_local_decl(vir::vir_format!(vcx, "_1_{idx}"), ty))
+                            .collect::<Vec<_>>()),
+                    ),
+                    &[],
+                    vcx.alloc_slice(&[
+                        // TODO: the strange false == true expression is constructed
+                        //   here because a const bool false doesn't get a span attached
+                        //   to it. (Maybe we don't need the const bool optimisation.)
+                        // TODO: this should instead be a span + error handler at the
+                        //   call site. We should change this once there is an encoder
+                        //   for method calls, which will encode a call to a stub method
+                        //   differently (if it can know that it failed?).
+                        vcx.with_span(span, |vcx| vcx.mk_eq_expr(vcx.mk_bool::<false>(), vcx.mk_bool::<true>())),
+                    ]),
+                    &[],
+                    None,
+                );
+                program.add_method(method_stub);
+            });
         }
     }
 }

--- a/prusti-encoder/src/encoders/mir_poly_impure.rs
+++ b/prusti-encoder/src/encoders/mir_poly_impure.rs
@@ -1,6 +1,6 @@
 use prusti_interface::PrustiError;
 use prusti_rustc_interface::span::def_id::DefId;
-use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies, TaskEncoderError};
 
 /// Encodes a Rust function as a Viper method using the polymorphic encoding of generics.
 pub struct MirPolyImpureEnc;
@@ -30,6 +30,8 @@ impl TaskEncoder for MirPolyImpureEnc {
 
     type EncodingError = ImpureFunctionEncError;
 
+    const ENCODER_NAME: &'static str = "impure method encoder";
+
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         *task
     }
@@ -46,7 +48,7 @@ impl TaskEncoder for MirPolyImpureEnc {
         for output in outputs {
             program.add_method(output.method);
         }
-        for (error_key, output_ref) in errored {
+        for (error_key, output_ref, error) in errored {
             vir::with_vcx(|vcx| {
                 use vir::CallableIdn;
                 let span = vcx.tcx().def_span(error_key);
@@ -77,10 +79,30 @@ impl TaskEncoder for MirPolyImpureEnc {
                     None,
                 );
                 if output_ref.should_be_verified {
-                    vcx.emit_early_error(PrustiError::verification("method was not verified", span.into()));
+                    let mut prusti_error = PrustiError::verification("method was not verified", span.into());
+                    explain(error, &mut prusti_error);
+                    vcx.emit_early_error(prusti_error);
                 }
                 program.add_method(method_stub);
             });
         }
+    }
+}
+
+/// Format the error nicely to be displayed to the user.
+/// TODO: should be elsewhere
+pub fn explain<E: TaskEncoder + ?Sized>(error: TaskEncoderError<E>, prusti_error: &mut PrustiError) {
+    // TODO: the other cases will not happen in this encoder (it does not
+    //   directly return `Err`) but should probably be handled for other encoders
+    match error {
+        TaskEncoderError::EnqueueingError(..) => (),
+        TaskEncoderError::EncodingError(..) => (),
+        TaskEncoderError::DependencyError(stack) => {
+            // skip the first one since that is already the main error and span
+            for (encoder, desc, spans) in &stack[1..] {
+                prusti_error.add_note_mut(format!("{desc} ({encoder})"), spans.first().cloned().map(|s| s.into()));
+            }
+        }
+        TaskEncoderError::CyclicError => (),
     }
 }

--- a/prusti-encoder/src/encoders/mir_poly_impure.rs
+++ b/prusti-encoder/src/encoders/mir_poly_impure.rs
@@ -76,6 +76,9 @@ impl TaskEncoder for MirPolyImpureEnc {
                     &[],
                     None,
                 );
+                if output_ref.should_be_verified {
+                    vcx.emit_early_error(PrustiError::verification("method was not verified", span.into()));
+                }
                 program.add_method(method_stub);
             });
         }

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -1232,7 +1232,7 @@ pub fn encode_place_element<'vir, 'enc, T: TaskEncoder>(
             match place_ty.ty.kind() {
                 TyKind::Adt(adt, _) if adt.is_box() => {
                     let e_ty_impure = deps
-                        .require_ref::<TyImpureEnc>(place_ty.ty)
+                        .require_local::<TyImpureEnc>(place_ty.ty)
                         .unwrap();
                     let struct_like = e_ty_impure
                         .expect_variant_opt(place_ty.variant_index);
@@ -1258,7 +1258,7 @@ pub fn encode_place_element<'vir, 'enc, T: TaskEncoder>(
                         .require_local::<TyPureEnc>(place_ty.ty)
                         .unwrap()
                         .expect_mutref();
-                    let inner_ty_out = deps.require_ref::<TyImpureEnc>(*inner_ty).unwrap();
+                    let inner_ty_out = deps.require_local::<TyImpureEnc>(*inner_ty).unwrap();
                     //let ref_expr = Some(e_ty.deref_access.apply(vcx, [expr]));
                     let ref_expr = e_ty.deref_access(expr);
                     // let val_expr = e_ty.value_access.apply(vcx, [expr]);
@@ -1280,7 +1280,7 @@ pub fn encode_place_element<'vir, 'enc, T: TaskEncoder>(
         }
         mir::ProjectionElem::Field(field_idx, ty) => {
             let e_ty = deps
-                .require_ref::<TyImpureEnc>(place_ty.ty)
+                .require_local::<TyImpureEnc>(place_ty.ty)
                 .unwrap();
             let struct_like = e_ty
                 .expect_variant_opt(place_ty.variant_index);

--- a/prusti-encoder/src/encoders/mir_pure_function.rs
+++ b/prusti-encoder/src/encoders/mir_pure_function.rs
@@ -47,7 +47,7 @@ impl TaskEncoder for MirFunctionEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local() {
+        for output in Self::all_outputs_local_no_errors() {
             program.add_function(output.function);
         }
     }

--- a/prusti-encoder/src/encoders/pure/spec.rs
+++ b/prusti-encoder/src/encoders/pure/spec.rs
@@ -53,6 +53,7 @@ impl TaskEncoder for MirSpecEnc {
             def_id,
             substs,
             caller_def_id,
+            true,
         ))?;
         let specs = deps
             .require_local::<crate::encoders::SpecEnc>(crate::encoders::SpecEncTask { def_id })?;

--- a/prusti-encoder/src/encoders/type/domain.rs
+++ b/prusti-encoder/src/encoders/type/domain.rs
@@ -11,13 +11,13 @@ use prusti_rustc_interface::{
 };
 use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 use vir::{
-    AdtDestructor, Arity, CallableIdn, CastType, CompType, DomainAxiomData, DomainIdnCSnap, DomainIdnSnap, FunctionIdn, Type
+    AdtDestructor, Arity, CastType, CompType, DomainAxiomData, DomainIdnSnap, FunctionIdn, Type
 };
 
-use crate::encoders::lifted::{ty_constructor::TyConstructorEnc, TypeOfEnc};
+use crate::encoders::{most_generic_ty::MostGenericTyEnc};
 
 use super::{
-    most_generic_ty::{extract_type_params, get_vir_base_name_kind, MostGenericTy},
+    most_generic_ty::{get_vir_base_name_kind, MostGenericTy},
 };
 
 /// You probably never want to use this, use `TyPureEnc` instead.
@@ -247,7 +247,7 @@ impl TaskEncoder for DomainEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in DomainEnc::all_outputs_local() {
+        for output in Self::all_outputs_local_no_errors() {
             program.add_function(output.unreachable_to_snap);
             match output.kind {
                 DomainEncLocalKind::Domain {
@@ -677,10 +677,10 @@ impl<'vir> FieldTy<'vir> {
         deps: &mut TaskEncoderDependencies<'vir, T>,
         ty: ty::Ty<'vir>,
     ) -> Result<FieldTy<'vir>, EncodeFullError<'vir, T>> {
-        let gen_ty = vir::with_vcx(|vcx| extract_type_params(vcx.tcx(), ty).0);
-        let fd = deps.require_ref::<DomainEnc>(gen_ty)?;
+        let (generic_ty, _) = deps.require_local::<MostGenericTyEnc>(ty)?;
+        let fd = deps.require_ref::<DomainEnc>(generic_ty)?;
         let vir_ty = (fd.domain)();
-        // let fd = deps.require_ref::<TyConstructorEnc>(gen_ty)?;
+        // let fd = deps.require_ref::<TyConstructorEnc>(generic_ty)?;
         // let typeof_function = fd.typeof_function;
         // let lifted_ty = deps.require_local::<LiftedTyEnc<EncodeGenericsAsParamTy>>(ty)?;
         Ok(FieldTy {

--- a/prusti-encoder/src/encoders/type/indirect.rs
+++ b/prusti-encoder/src/encoders/type/indirect.rs
@@ -85,7 +85,7 @@ impl TaskEncoder for IndirectPredicatesEnc {
                     if IndirectKey::from_region(*ref_region)
                         .is_some_and(|indirect| &indirect == proj_region)
                     {
-                        let inner_ty_enc = deps.require_ref::<TyImpureEnc>(*inner_ty)?;
+                        let inner_ty_enc = deps.require_local::<TyImpureEnc>(*inner_ty)?;
                         covariant.push(vcx.mk_lazy_expr(
                             "ref_indirect",
                             vir::TYPE_BOOL,

--- a/prusti-encoder/src/encoders/type/kinds/adt.rs
+++ b/prusti-encoder/src/encoders/type/kinds/adt.rs
@@ -183,12 +183,12 @@ pub(crate) fn predicate<'vir>(
             //let fields = variant
             //    .fields
             //    .iter()
-            //    .map(|f| deps.require_ref::<TyImpureEnc>(f.ty(builder.vcx.tcx(), params)).unwrap())
+            //    .map(|f| deps.require_local::<TyImpureEnc>(f.ty(builder.vcx.tcx(), params)).unwrap())
             //    .collect::<Vec<_>>();
 
             let (field_accessors, self_pred, snap_expr) = super::structlike::predicate(
                 "",
-                &[deps.require_ref::<TyImpureEnc>(params[0].expect_ty())?],
+                &[deps.require_local::<TyImpureEnc>(params[0].expect_ty())?],
                 task_key,
                 &snap,
                 snap_data,
@@ -255,7 +255,7 @@ pub(crate) fn predicate<'vir>(
                 .fields
                 .iter()
                 .map(|f| {
-                    deps.require_ref::<TyImpureEnc>(f.ty(builder.vcx.tcx(), params))
+                    deps.require_local::<TyImpureEnc>(f.ty(builder.vcx.tcx(), params))
                         .unwrap()
                 })
                 .collect::<Vec<_>>();
@@ -301,7 +301,7 @@ pub(crate) fn predicate<'vir>(
                                     if *field_reg != reg {
                                         return None;
                                     }
-                                    let inner_ty_enc = deps.require_ref::<TyImpureEnc>(*inner_ty).unwrap();
+                                    let inner_ty_enc = deps.require_local::<TyImpureEnc>(*inner_ty).unwrap();
                                     Some(inner_ty_enc.ref_to_pred(
                                         builder.vcx,
                                         field.generic_predicate.expect_ref().snap_data.deref_access.apply(builder.vcx, [
@@ -332,7 +332,7 @@ pub(crate) fn predicate<'vir>(
             let discr_ty = ty.discriminant_ty(builder.vcx.tcx());
             let discr_ty_snap = deps.require_local::<TyPureEnc>(discr_ty)?;
             let discr_ty_snap_prim = discr_ty_snap.expect_primitive();
-            let discr_ty_out = deps.require_ref::<TyImpureEnc>(discr_ty)?;
+            let discr_ty_out = deps.require_local::<TyImpureEnc>(discr_ty)?;
 
             // Ref-to-Ref function for the discriminant field
             let fdisc_func = builder.function(
@@ -355,7 +355,7 @@ pub(crate) fn predicate<'vir>(
                     let fields = variant
                         .fields
                         .iter()
-                        .map(|f| deps.require_ref::<TyImpureEnc>(f.ty(builder.vcx.tcx(), params)).unwrap())
+                        .map(|f| deps.require_local::<TyImpureEnc>(f.ty(builder.vcx.tcx(), params)).unwrap())
                         .collect::<Vec<_>>();
 
                     let (

--- a/prusti-encoder/src/encoders/type/kinds/closure.rs
+++ b/prusti-encoder/src/encoders/type/kinds/closure.rs
@@ -85,7 +85,7 @@ pub(crate) fn predicate<'vir>(
     let fields = cl_args
         .upvar_tys()
         .iter()
-        .map(|ty| deps.require_ref::<TyImpureEnc>(ty))
+        .map(|ty| deps.require_local::<TyImpureEnc>(ty))
         .collect::<Result<Vec<_>, _>>()?;
 
     let (field_accessors, self_pred, snap_expr) = super::structlike::predicate(

--- a/prusti-encoder/src/encoders/type/kinds/tuple.rs
+++ b/prusti-encoder/src/encoders/type/kinds/tuple.rs
@@ -120,7 +120,7 @@ pub(crate) fn predicate<'vir>(
 
     let fields = params
         .iter()
-        .map(|ty| deps.require_ref::<TyImpureEnc>(ty))
+        .map(|ty| deps.require_local::<TyImpureEnc>(ty))
         .collect::<Result<Vec<_>, _>>()?;
 
     let (field_accessors, self_pred, snap_expr) = super::structlike::predicate(

--- a/prusti-encoder/src/encoders/type/lifted/casters.rs
+++ b/prusti-encoder/src/encoders/type/lifted/casters.rs
@@ -352,7 +352,7 @@ impl TaskEncoder for CastersEnc<CastTypePure> {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local() {
+        for output in Self::all_outputs_local_no_errors() {
             for function in output {
                 program.add_function(function);
             }
@@ -468,7 +468,7 @@ impl TaskEncoder for CastersEnc<CastTypeImpure> {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local() {
+        for output in Self::all_outputs_local_no_errors() {
             for method in output {
                 program.add_method(method);
             }

--- a/prusti-encoder/src/encoders/type/lifted/const.rs
+++ b/prusti-encoder/src/encoders/type/lifted/const.rs
@@ -81,7 +81,7 @@ impl TaskEncoder for LiftedConstEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local() {
+        for output in Self::all_outputs_local_no_errors() {
             program.add_domain(output.domain);
         }
     }

--- a/prusti-encoder/src/encoders/type/lifted/func_app_ty_params.rs
+++ b/prusti-encoder/src/encoders/type/lifted/func_app_ty_params.rs
@@ -69,6 +69,6 @@ impl TaskEncoder for LiftedFuncAppTyParamsEnc {
     }
 
     fn emit_outputs<'vir>(_program: &mut Program<'vir>) {
-        let _outputs = Self::all_outputs_local();
+        let _outputs = Self::all_outputs_local_no_errors();
     }
 }

--- a/prusti-encoder/src/encoders/type/lifted/generic.rs
+++ b/prusti-encoder/src/encoders/type/lifted/generic.rs
@@ -58,12 +58,12 @@ impl TaskEncoder for LiftedGenericEnc {
         with_vcx(|vcx| {
             let output_ref = LiftedGeneric(match task_key {
                 LiftedGenericEncTask::Param(param) => vcx.mk_local_decl(
-                    vcx.alloc_str(param.name.as_str()),
+                    vir::ViperIdent::sanitize(vcx, param.name.as_str().to_string()).to_str(),
                     vir::TYPE_TYVAL,
                 ),
                 LiftedGenericEncTask::Const(c) => match c.kind() {
                     ty::ConstKind::Param(param) => vcx.mk_local_decl(
-                        vcx.alloc_str(param.name.as_str()),
+                        vir::ViperIdent::sanitize(vcx, param.name.as_str().to_string()).to_str(),
                         vir::TYPE_TYVAL,
                     ),
                     _ => todo!("lifted generic const {c:?}")

--- a/prusti-encoder/src/encoders/type/lifted/rust_ty_cast.rs
+++ b/prusti-encoder/src/encoders/type/lifted/rust_ty_cast.rs
@@ -4,7 +4,7 @@ use prusti_rustc_interface::middle::ty;
 use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderError};
 use vir::with_vcx;
 
-use crate::encoders::most_generic_ty::{extract_type_params, MostGenericTy};
+use crate::encoders::most_generic_ty::{MostGenericTy, MostGenericTyEnc};
 
 use super::{
     cast::Cast,
@@ -95,7 +95,7 @@ where
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> RustTyGenericCastEncOutput<'vir, Casters<'vir, T>> {
         with_vcx(|vcx| {
-            let (generic_ty, args) = extract_type_params(vcx.tcx(), *task_key);
+            let (generic_ty, args) = deps.require_local::<MostGenericTyEnc>(*task_key).unwrap();
             let cast = deps.require_ref::<CastersEnc<T>>(generic_ty).unwrap();
             let ty_args = args
                 .iter()

--- a/prusti-encoder/src/encoders/type/lifted/ty.rs
+++ b/prusti-encoder/src/encoders/type/lifted/ty.rs
@@ -5,9 +5,9 @@ use task_encoder::{EncodeFullResult, TaskEncoder};
 use vir::{with_vcx, FunctionIdn, CastType};
 
 use crate::encoders::{
-    r#const::ConstEncTask, lifted::{
-        generic::{LiftedGeneric, LiftedGenericEnc}, ty_constructor::TyConstructorEnc, LiftedConstEnc
-    }, most_generic_ty::extract_type_params, ConstEnc,
+    ConstEnc, r#const::ConstEncTask, lifted::{
+        LiftedConstEnc, generic::{LiftedGeneric, LiftedGenericEnc}, ty_constructor::TyConstructorEnc
+    }, most_generic_ty::MostGenericTyEnc,
 };
 
 use super::generic::LiftedGenericEncTask;
@@ -181,9 +181,9 @@ impl TaskEncoder for LiftedTyEnc<EncodeGenericsAsParamTy> {
                 if let TyKind::Param(p) = ty.kind() {
                     return Ok((LiftedTy::Generic(*p), ()));
                 }
-                let (ty_constructor, args) = extract_type_params(vcx.tcx(), *ty);
+                let (generic_ty, args) = deps.require_local::<MostGenericTyEnc>(*ty)?;
                 let ty_constructor = deps
-                    .require_ref::<TyConstructorEnc>(ty_constructor)?
+                    .require_ref::<TyConstructorEnc>(generic_ty)?
                     .ty_constructor;
                 let args = args
                     .into_iter()

--- a/prusti-encoder/src/encoders/type/lifted/ty_constructor.rs
+++ b/prusti-encoder/src/encoders/type/lifted/ty_constructor.rs
@@ -1,8 +1,8 @@
 use task_encoder::{EncodeFullResult, OutputRefAny, TaskEncoder};
-use vir::{vir_format_identifier, Arity, CallableIdn, CastType, FunctionIdn};
+use vir::{Arity, CallableIdn, CastType, FunctionIdn};
 
 use crate::encoders::{
-    domain::DomainEnc, lifted::r#typeof::{TypeOfEnc, TypeOfEncOutputRef}, most_generic_ty::{extract_type_params, MostGenericTy}
+    lifted::r#typeof::{TypeOfEnc, TypeOfEncOutputRef}, most_generic_ty::{MostGenericTy, MostGenericTyEnc}
 };
 
 #[derive(Clone)]
@@ -70,9 +70,9 @@ impl TaskEncoder for TyConstructorEnc {
     ) -> EncodeFullResult<'vir, Self> {
         assert!(!task_key.is_generic());
         vir::with_vcx(|vcx| {
-            let (ty_constructor, _) = extract_type_params(vcx.tcx(), task_key.ty());
-            let base_name = ty_constructor.get_vir_base_name(vcx);
-            let args = ty_constructor.generics();
+            let (generic_ty, _) = deps.require_local::<MostGenericTyEnc>(task_key.ty())?;
+            let base_name = generic_ty.get_vir_base_name(vcx);
+            let args = generic_ty.generics();
             let type_function_args = vcx.alloc_slice(&vec![vir::TYPE_TYVAL; args.len()]);
             let type_function_ident = FunctionIdn::new(
                 vir::vir_format_identifier!(vcx, "s_{base_name}_type",),
@@ -110,7 +110,7 @@ impl TaskEncoder for TyConstructorEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        let mut constructors = Self::all_outputs_local();
+        let mut constructors = Self::all_outputs_local_no_errors();
         vir::with_vcx(|vcx| {
             let args = vcx.alloc_array(&[vcx.mk_local_decl("non_unit", vir::TYPE_INT)]);
             let unknown = vcx.mk_adt_constructor("Unknown_type", args);

--- a/prusti-encoder/src/encoders/type/lifted/typeof.rs
+++ b/prusti-encoder/src/encoders/type/lifted/typeof.rs
@@ -1,9 +1,9 @@
 use task_encoder::{EncodeFullResult, OutputRefAny, TaskEncoder, TaskEncoderDependencies};
-use vir::{vir_format_identifier, Arity, CallableIdn, CastType, FunctionIdn};
+use vir::{CallableIdn, CastType, FunctionIdn};
 
 use crate::encoders::{
     domain::DomainEnc,
-    most_generic_ty::{extract_type_params, MostGenericTy},
+    most_generic_ty::{MostGenericTy, MostGenericTyEnc},
 };
 
 #[derive(Clone)]
@@ -46,8 +46,8 @@ impl TaskEncoder for TypeOfEnc {
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         vir::with_vcx(|vcx| {
-            let (ty_constructor, _) = extract_type_params(vcx.tcx(), task_key.ty());
-            let base_name = ty_constructor.get_vir_base_name(vcx);
+            let (generic_ty, args) = deps.require_local::<MostGenericTyEnc>(task_key.ty())?;
+            let base_name = generic_ty.get_vir_base_name(vcx);
 
             let domain = deps.require_ref::<DomainEnc>(*task_key)?;
             let snap = (domain.domain)();
@@ -69,7 +69,7 @@ impl TaskEncoder for TypeOfEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        let typeof_fns = Self::all_outputs_local();
+        let typeof_fns = Self::all_outputs_local_no_errors();
         vir::with_vcx(|vcx| {
             let domain = vcx.mk_domain(vir::ViperIdent::new("TypeOf"), &[], &[], vcx.alloc_slice(&typeof_fns));
             program.add_domain(domain);

--- a/prusti-encoder/src/encoders/type/most_generic_ty.rs
+++ b/prusti-encoder/src/encoders/type/most_generic_ty.rs
@@ -3,23 +3,139 @@ use prusti_rustc_interface::{
     middle::ty::{self, TyKind},
     span::symbol,
 };
+use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
+
+
+pub struct MostGenericTyEnc;
 
 /// The "most generic" version of a type is one that uses "identity
 /// substitutions" for all type parameters. For example, the most generic
 /// version of `Vec<u32>` is `Vec<T>`, the most generic version of
 /// `Option<Vec<U>>` is `Option<T>`, etc.
-///
-/// To construct an instance, use [`extract_type_params`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct MostGenericTy<'tcx>(ty::Ty<'tcx>);
 
-impl<'tcx: 'vir, 'vir> MostGenericTy<'tcx> {
-    pub fn get_vir_domain_ident(
-        &self,
-        vcx: &'vir vir::VirCtxt<'tcx>,
-    ) -> vir::DomainIdn<'vir, vir::Snap> {
-        let base_name = self.get_vir_base_name(vcx);
-        vir::DomainIdn::new(vir::vir_format_identifier!(vcx, "s_{base_name}"))
+pub type MostGenericTyEncError = ();
+
+impl TaskEncoder for MostGenericTyEnc {
+    task_encoder::encoder_cache!(MostGenericTyEnc);
+
+    type TaskDescription<'vir> = ty::Ty<'vir>;
+
+    type OutputFullLocal<'vir> = (MostGenericTy<'vir>, Vec<ty::Ty<'vir>>);
+
+    type EncodingError = MostGenericTyEncError;
+
+    fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
+        vir::with_vcx(|vcx| {
+            vcx.tcx().erase_regions(*task)
+        })
+    }
+
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
+    ) -> EncodeFullResult<'vir, Self> {
+        deps.emit_output_ref(*task_key, ())?;
+        vir::with_vcx(|vcx| {
+            Ok((Self::extract_type_params(vcx.tcx(), *task_key).ok_or(EncodeFullError::EncodingError((), None))?, ()))
+        })
+    }
+}
+
+impl MostGenericTyEnc {
+    pub fn extract_type_params<'tcx>(
+        tcx: ty::TyCtxt<'tcx>,
+        ty: ty::Ty<'tcx>,
+    ) -> Option<(MostGenericTy<'tcx>, Vec<ty::Ty<'tcx>>)> {
+        Some(match *ty.kind() {
+            TyKind::Adt(adt, args) => {
+                let id = ty::List::identity_for_item(tcx, adt.did()).iter();
+                let id = tcx.mk_args_from_iter(id);
+                let ty = tcx.mk_ty_from_kind(TyKind::Adt(adt, id));
+                (
+                    MostGenericTy(ty),
+                    args.into_iter().flat_map(ty::GenericArg::as_type).collect(),
+                )
+            }
+            TyKind::Tuple(tys) => {
+                let new_tys = tcx.mk_type_list_from_iter(
+                    (0..tys.len()).map(|index| to_placeholder(tcx, Some(index))),
+                );
+                let ty = tcx.mk_ty_from_kind(TyKind::Tuple(new_tys));
+                (MostGenericTy(ty), tys.to_vec())
+            }
+            TyKind::Array(inner, val) => {
+                let ty = to_placeholder(tcx, None);
+                let ty = tcx.mk_ty_from_kind(TyKind::Array(ty, val));
+                (MostGenericTy(ty), vec![inner])
+            }
+            TyKind::Slice(inner) => {
+                let ty = to_placeholder(tcx, None);
+                let ty = tcx.mk_ty_from_kind(TyKind::Slice(ty));
+                (MostGenericTy(ty), vec![inner])
+            }
+            TyKind::Ref(_, inner, ty::Mutability::Not) => {
+                let ty = to_placeholder(tcx, None);
+                let ty = tcx.mk_ty_from_kind(TyKind::Ref(
+                    tcx.lifetimes.re_erased,
+                    ty,
+                    ty::Mutability::Not,
+                ));
+                (MostGenericTy(ty), vec![inner])
+            }
+            TyKind::Ref(_, _, ty::Mutability::Mut) => {
+                let ty = to_placeholder(tcx, None);
+                let ty = tcx.mk_ty_from_kind(TyKind::Ref(
+                    tcx.lifetimes.re_erased,
+                    ty,
+                    ty::Mutability::Mut,
+                ));
+                (MostGenericTy(ty), vec![]) // vec![inner])
+            }
+            TyKind::RawPtr(inner, m) => {
+                let ty = to_placeholder(tcx, None);
+                let ty = tcx.mk_ty_from_kind(TyKind::RawPtr(ty, m));
+                (MostGenericTy(ty), vec![inner])
+            }
+            TyKind::Param(_) => (MostGenericTy(to_placeholder(tcx, None)), Vec::new()),
+            TyKind::Closure(_, args) => {
+                let args = args.as_closure()
+                    .parent_args()
+                    .iter()
+                    .copied()
+                    .filter_map(ty::GenericArg::as_type)
+                    .collect();
+                (MostGenericTy(ty), args)
+            }
+            TyKind::Bool
+            | TyKind::Char
+            | TyKind::Int(_)
+            | TyKind::Uint(_)
+            | TyKind::Float(_)
+            | TyKind::Never
+            | TyKind::Str
+            | TyKind::FnPtr(..) => (MostGenericTy(ty), Vec::new()),
+
+            // `extern type`s will probably not have generics, but this will be
+            // resolved in https://github.com/rust-lang/rust/issues/43467.
+            TyKind::Foreign(..) => (MostGenericTy(ty), Vec::new()),
+
+            TyKind::Pat(base_ty, _) => return Self::extract_type_params(tcx, base_ty),
+
+            TyKind::FnDef(..) => return None,
+            TyKind::UnsafeBinder(..) => return None,
+            TyKind::Dynamic(..) => return None,
+            TyKind::Coroutine(..) => return None,
+            TyKind::CoroutineClosure(..) => return None,
+            TyKind::CoroutineWitness(..) => return None,
+            TyKind::Alias(..) => return None,
+
+            kind @ (TyKind::Placeholder(..)
+            | TyKind::Error(..)
+            | TyKind::Infer(..)
+            | TyKind::Bound(..)) => unreachable!("found unexpected type kind {kind:?} (should not appear in Prusti-consumed MIR)"),
+        })
     }
 }
 
@@ -57,6 +173,16 @@ pub fn get_vir_base_name_kind<'tcx>(kind: &ty::TyKind<'tcx>, vcx: &vir::VirCtxt<
         }
         TyKind::FnPtr(..) => String::from("FnPtr"),
         other => unimplemented!("get_vir_base_name for {:?}", other),
+    }
+}
+
+impl<'tcx: 'vir, 'vir> MostGenericTy<'tcx> {
+    pub fn get_vir_domain_ident(
+        &self,
+        vcx: &'vir vir::VirCtxt<'tcx>,
+    ) -> vir::DomainIdn<'vir, vir::Snap> {
+        let base_name = self.get_vir_base_name(vcx);
+        vir::DomainIdn::new(vir::vir_format_identifier!(vcx, "s_{base_name}"))
     }
 }
 
@@ -162,80 +288,4 @@ fn to_placeholder(tcx: ty::TyCtxt<'_>, idx: Option<usize>) -> ty::Ty<'_> {
         index: idx.unwrap_or_default() as u32,
         name: symbol::Symbol::intern(&name),
     }))
-}
-
-pub fn extract_type_params<'tcx>(
-    tcx: ty::TyCtxt<'tcx>,
-    ty: ty::Ty<'tcx>,
-) -> (MostGenericTy<'tcx>, Vec<ty::Ty<'tcx>>) {
-    match *ty.kind() {
-        TyKind::Adt(adt, args) => {
-            let id = ty::List::identity_for_item(tcx, adt.did()).iter();
-            let id = tcx.mk_args_from_iter(id);
-            let ty = tcx.mk_ty_from_kind(TyKind::Adt(adt, id));
-            (
-                MostGenericTy(ty),
-                args.into_iter().flat_map(ty::GenericArg::as_type).collect(),
-            )
-        }
-        TyKind::Tuple(tys) => {
-            let new_tys = tcx.mk_type_list_from_iter(
-                (0..tys.len()).map(|index| to_placeholder(tcx, Some(index))),
-            );
-            let ty = tcx.mk_ty_from_kind(TyKind::Tuple(new_tys));
-            (MostGenericTy(ty), tys.to_vec())
-        }
-        TyKind::Array(inner, val) => {
-            let ty = to_placeholder(tcx, None);
-            let ty = tcx.mk_ty_from_kind(TyKind::Array(ty, val));
-            (MostGenericTy(ty), vec![inner])
-        }
-        TyKind::Slice(inner) => {
-            let ty = to_placeholder(tcx, None);
-            let ty = tcx.mk_ty_from_kind(TyKind::Slice(ty));
-            (MostGenericTy(ty), vec![inner])
-        }
-        TyKind::Ref(_, inner, ty::Mutability::Not) => {
-            let ty = to_placeholder(tcx, None);
-            let ty = tcx.mk_ty_from_kind(TyKind::Ref(
-                tcx.lifetimes.re_erased,
-                ty,
-                ty::Mutability::Not,
-            ));
-            (MostGenericTy(ty), vec![inner])
-        }
-        TyKind::Ref(_, _, ty::Mutability::Mut) => {
-            let ty = to_placeholder(tcx, None);
-            let ty = tcx.mk_ty_from_kind(TyKind::Ref(
-                tcx.lifetimes.re_erased,
-                ty,
-                ty::Mutability::Mut,
-            ));
-            (MostGenericTy(ty), vec![]) // vec![inner])
-        }
-        TyKind::RawPtr(inner, m) => {
-            let ty = to_placeholder(tcx, None);
-            let ty = tcx.mk_ty_from_kind(TyKind::RawPtr(ty, m));
-            (MostGenericTy(ty), vec![inner])
-        }
-        TyKind::Param(_) => (MostGenericTy(to_placeholder(tcx, None)), Vec::new()),
-        TyKind::Closure(_, args) => {
-            let args = args.as_closure()
-                .parent_args()
-                .iter()
-                .copied()
-                .filter_map(ty::GenericArg::as_type)
-                .collect();
-            (MostGenericTy(ty), args)
-        }
-        TyKind::Bool
-        | TyKind::Char
-        | TyKind::Int(_)
-        | TyKind::Uint(_)
-        | TyKind::Float(_)
-        | TyKind::Never
-        | TyKind::Str
-        | TyKind::FnPtr(..) => (MostGenericTy(ty), Vec::new()),
-        _ => todo!("extract_type_params for {:?}", ty),
-    }
 }

--- a/prusti-encoder/src/encoders/type/predicate.rs
+++ b/prusti-encoder/src/encoders/type/predicate.rs
@@ -587,7 +587,7 @@ impl TaskEncoder for PredicateEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local() {
+        for output in Self::all_outputs_local_no_errors() {
             for field in output.fields {
                 program.add_field(field);
             }

--- a/prusti-encoder/src/encoders/type/pure.rs
+++ b/prusti-encoder/src/encoders/type/pure.rs
@@ -48,7 +48,7 @@ impl TaskEncoder for SnapshotEnc {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         vir::with_vcx(|vcx| {
-            let (ty, generics) = extract_type_params(vcx.tcx(), *task_key);
+            let (ty, generics) = extract_type_params(vcx.tcx(), *task_key).unwrap();
             let out = deps.require_ref::<DomainEnc>(ty)?;
             let snapshot = (out.domain)();
             deps.emit_output_ref(*task_key, SnapshotEncOutputRef { snapshot, typeof_function: out.typeof_function })?;

--- a/prusti-encoder/src/encoders/type/ty_impure.rs
+++ b/prusti-encoder/src/encoders/type/ty_impure.rs
@@ -4,14 +4,13 @@ use prusti_rustc_interface::{
 };
 use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 
-use crate::encoders::{lifted::{casters::{CastTypeImpure, CastTypePure}, rust_ty_cast::{GenericCasterImpure, GenericCasterPure, RustTyCastersEnc}, LiftedTyEncTask}, predicate::{PredicateEnc, PredicateEncDataEnum, PredicateEncDataImmRef, PredicateEncDataMutRef, PredicateEncDataStruct}, PredicateEncOutput, PredicateEncOutputRef};
+use crate::encoders::{PredicateEncOutputRef, lifted::{LiftedTyEncTask, casters::{CastTypeImpure, CastTypePure}, rust_ty_cast::{GenericCasterImpure, GenericCasterPure, RustTyCastersEnc}}, most_generic_ty::MostGenericTyEnc, predicate::{PredicateEnc, PredicateEncDataEnum, PredicateEncDataImmRef, PredicateEncDataMutRef, PredicateEncDataStruct}};
 
 use super::{
     lifted::{
         generic::LiftedGeneric,
         ty::{EncodeGenericsAsLifted, LiftedTy, LiftedTyEnc},
     },
-    most_generic_ty::extract_type_params,
 };
 
 /// Encodes a type into the predicate representation. Takes an arbitrary Rust
@@ -246,63 +245,58 @@ impl TaskEncoder for TyImpureEnc {
 
     type TaskDescription<'vir> = ty::Ty<'vir>;
 
-    type OutputRef<'vir> = TyImpureEncOutputRef<'vir>;
-    type OutputFullLocal<'vir> = ();
+    type OutputRef<'vir> = ();
+    type OutputFullLocal<'vir> = TyImpureEncOutputRef<'vir>;
+
+    type TaskKey<'tcx> = Self::TaskDescription<'tcx>;
+
+    type EncodingError = ();
 
     fn do_encode_full<'vir>(
         task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        vir::with_vcx(|vcx| {
-            let (generic_ty, args) = extract_type_params(vcx.tcx(), *task_key);
-            let generic_predicate = deps.require_ref::<PredicateEnc>(generic_ty)?;
-            /*
-            let indirect_predicate = if let ty::TyKind::Ref(_, inner_ty, _) = task_key.kind() {
-                let inner_ty_enc = deps.require_ref::<TyImpureEnc>(*inner_ty).unwrap();
-                let deref_access = generic_predicate.expect_ref().deref_func;
-                let inner_ty_enc_c = inner_ty_enc.clone();
-                Some((
-                    vcx.mk_lazy_expr("ref_indirect", Box::new(move |vcx, self_expr| inner_ty_enc.ref_to_pred(
-                        vcx,
-                        deref_access.apply(vcx, [self_expr]),
-                        None,
-                    ).kind)),
-                    vcx.mk_lazy_expr("ref_indirect_post", Box::new(move |vcx, self_expr| inner_ty_enc_c.ref_to_pred(
-                        vcx,
-                        vcx.mk_old_expr(deref_access.apply(vcx, [self_expr])),
-                        None,
-                    ).kind)),
-                ))
-            } else {
-                None
-            };
-            */
-            let ty = deps.require_local::<LiftedTyEnc<EncodeGenericsAsLifted>>(LiftedTyEncTask::Ty(*task_key))?;
-            let f_ty = deps.require_local::<RustTyCastersEnc<CastTypePure>>(*task_key)?;
-            let params = args
-                        .iter()
-                        .map(|arg| {
-                            deps.require_local::<RustTyCastersEnc<CastTypeImpure>>(*arg)
-                                .unwrap()
-                        })
-                        .collect();
-            deps.emit_output_ref(
-                *task_key,
-                TyImpureEncOutputRef {
-                    generic_predicate,
-                    indirect_predicate: None,
-                    ty,
-                    f_ty,
-                    params,
-                },
-            )?;
-            Ok(((), ()))
-        })
+        deps.emit_output_ref(*task_key, ())?;
+        let (generic_ty, args) = deps.require_local::<MostGenericTyEnc>(*task_key)?;
+        let generic_predicate = deps.require_ref::<PredicateEnc>(generic_ty)?;
+        /*
+        let indirect_predicate = if let ty::TyKind::Ref(_, inner_ty, _) = task_key.kind() {
+            let inner_ty_enc = deps.require_ref::<TyImpureEnc>(*inner_ty).unwrap();
+            let deref_access = generic_predicate.expect_ref().deref_func;
+            let inner_ty_enc_c = inner_ty_enc.clone();
+            Some((
+                vcx.mk_lazy_expr("ref_indirect", Box::new(move |vcx, self_expr| inner_ty_enc.ref_to_pred(
+                    vcx,
+                    deref_access.apply(vcx, [self_expr]),
+                    None,
+                ).kind)),
+                vcx.mk_lazy_expr("ref_indirect_post", Box::new(move |vcx, self_expr| inner_ty_enc_c.ref_to_pred(
+                    vcx,
+                    vcx.mk_old_expr(deref_access.apply(vcx, [self_expr])),
+                    None,
+                ).kind)),
+            ))
+        } else {
+            None
+        };
+        */
+        let ty = deps.require_local::<LiftedTyEnc<EncodeGenericsAsLifted>>(LiftedTyEncTask::Ty(*task_key))?;
+        let f_ty = deps.require_local::<RustTyCastersEnc<CastTypePure>>(*task_key)?;
+        let params = args
+                    .iter()
+                    .map(|arg| {
+                        deps.require_local::<RustTyCastersEnc<CastTypeImpure>>(*arg)
+                            .unwrap()
+                    })
+                    .collect();
+        Ok((TyImpureEncOutputRef {
+            generic_predicate,
+            indirect_predicate: None,
+            ty,
+            f_ty,
+            params,
+        }, ()))
     }
-
-    type TaskKey<'tcx> = Self::TaskDescription<'tcx>;
-
-    type EncodingError = ();
 
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         *task

--- a/prusti-encoder/src/encoders/type/ty_impure.rs
+++ b/prusti-encoder/src/encoders/type/ty_impure.rs
@@ -252,6 +252,8 @@ impl TaskEncoder for TyImpureEnc {
 
     type EncodingError = ();
 
+    const ENCODER_NAME: &'static str = "impure type encoder";
+
     fn do_encode_full<'vir>(
         task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,

--- a/prusti-encoder/src/encoders/type/ty_pure.rs
+++ b/prusti-encoder/src/encoders/type/ty_pure.rs
@@ -8,11 +8,7 @@ use prusti_rustc_interface::{
     abi,
 };
 
-use crate::encoders::{domain::{DomainDataEnum, DomainDataField, DomainDataImmRef, DomainDataMutRef, DomainDataPrim, DomainDataStruct, DomainEnc, DomainEncOutput, DomainEncOutputRef, DomainEncSpecifics}, lifted::{casters::{CastFunctionsOutputRef, CastTypePure}, rust_ty_cast::{GenericCasterPure, RustTyCastersEnc}}};
-
-use super::{
-    most_generic_ty::extract_type_params,
-};
+use crate::encoders::{domain::{DomainDataEnum, DomainDataField, DomainDataImmRef, DomainDataMutRef, DomainDataPrim, DomainDataStruct, DomainEnc, DomainEncOutput, DomainEncOutputRef}, lifted::{casters::CastTypePure, rust_ty_cast::{GenericCasterPure, RustTyCastersEnc}}, most_generic_ty::MostGenericTyEnc};
 
 #[derive(Debug, Clone, Copy)]
 pub struct TyPureDataImmRef<'vir> {
@@ -91,7 +87,7 @@ impl TaskEncoder for TyPureEnc {
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         with_vcx(|vcx| {
-            let (generic_ty, args) = extract_type_params(vcx.tcx(), *task_key);
+            let (generic_ty, args) = deps.require_local::<MostGenericTyEnc>(*task_key)?;
             let domain = deps.require_ref::<DomainEnc>(generic_ty)?;
             let snapshot = (domain.domain)();
             let inner = TyPureEncOutputRef { snapshot, domain };

--- a/prusti-encoder/src/encoders/type/ty_pure.rs
+++ b/prusti-encoder/src/encoders/type/ty_pure.rs
@@ -78,6 +78,8 @@ impl TaskEncoder for TyPureEnc {
 
     type EncodingError = ();
 
+    const ENCODER_NAME: &'static str = "pure type encoder";
+
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         *task
     }

--- a/prusti-encoder/src/encoders/type/viper_tuple.rs
+++ b/prusti-encoder/src/encoders/type/viper_tuple.rs
@@ -6,12 +6,9 @@ use prusti_rustc_interface::{
     abi,
 };
 
-use crate::encoders::{lifted::rust_ty_cast::GenericCasterPure, ty_pure::{TyPureDataStruct, TyPureEncOutput}};
+use crate::encoders::ty_pure::{TyPureDataStruct, TyPureEncOutput};
 
 use super::{
-    domain::{DomainDataStruct, DomainEnc},
-    predicate::PredicateEnc,
-    most_generic_ty::{MostGenericTy, extract_type_params},
     ty_pure::TyPureEnc,
 };
 

--- a/prusti-encoder/src/lib.rs
+++ b/prusti-encoder/src/lib.rs
@@ -51,8 +51,7 @@ pub fn test_entrypoint<'tcx>(
                 .unwrap_or_default();
 
                 if !(is_trusted && is_pure) {
-                    let res = MirPolyImpureEnc::encode(def_id, false);
-                    assert!(res.is_ok());
+                    let _ = MirPolyImpureEnc::encode(def_id, false);
                 }
             }
             unsupported_item_kind => {
@@ -114,6 +113,10 @@ pub fn test_entrypoint<'tcx>(
     request::RequestWithContext {
         program: program.to_ref(),
     }
+}
+
+pub fn early_errors() -> Vec<PrustiError> {
+    vir::with_vcx(|vcx| vcx.early_errors())
 }
 
 pub fn backtranslate_error(

--- a/prusti/src/verifier.rs
+++ b/prusti/src/verifier.rs
@@ -43,6 +43,12 @@ pub fn verify(env: Environment<'_>, def_spec: typed::DefSpecificationMap) {
         //   which is constructed further inside `prusti_server`)
         let request = prusti_encoder::test_entrypoint(env.tcx(), env.body, def_spec);
         let program = request.program;
+        let mut success = true;
+
+        for prusti_error in prusti_encoder::early_errors() {
+            success = false;
+            prusti_error.emit(&env.diagnostic);
+        }
 
         let mut results = prusti_server::verify_programs(vec![program]);
         assert_eq!(results.len(), 1); // TODO: eventually verify separate methods as separate programs again?
@@ -51,7 +57,7 @@ pub fn verify(env: Environment<'_>, def_spec: typed::DefSpecificationMap) {
         if std::env::var("LOCAL_TESTING").is_ok() {
             println!("raw result: {result:?}");
         }
-        let success = match result {
+        success &= match result {
             viper::VerificationResult::Success => true,
             viper::VerificationResult::JavaException(_e) => false,
             viper::VerificationResult::ConsistencyErrors(_e) => false,

--- a/task-encoder/Cargo.toml
+++ b/task-encoder/Cargo.toml
@@ -11,7 +11,12 @@ license = "MPL-2.0"
 test = false # no unit tests
 doctest = false # no doc tests
 
+[package.metadata.rust-analyzer]
+# This crate uses #[feature(rustc_private)]
+rustc_private = true
+
 [dependencies]
+prusti-rustc-interface = { path = "../prusti-rustc-interface" }
 # once_cell = "1.17.0"
 # rustc-hash = "1.1.0"
 hashlink = "0.8.1"

--- a/task-encoder/src/dependencies.rs
+++ b/task-encoder/src/dependencies.rs
@@ -36,44 +36,79 @@ impl<'vir, E: TaskEncoder + 'vir + ?Sized> TaskEncoderDependencies<'vir, E> {
         Ok(())
     }
 
-    pub fn require_ref<EOther: TaskEncoder>(
+    fn require_common<T, EOther: TaskEncoder>(
         &mut self,
         task: <EOther as TaskEncoder>::TaskDescription<'vir>,
-    ) -> Result<<EOther as TaskEncoder>::OutputRef<'vir>, EncodeFullError<'vir, E>> {
-        EOther::encode_ref(task)
-            .map_err(|_| EncodeFullError::DependencyError)
+        span: Option<Span>,
+        res: Result<T, TaskEncoderError<EOther>>,
+    ) -> Result<T, EncodeFullError<'vir, E>> {
+        res
+            .map_err(|err| EncodeFullError::DependencyError(vec![
+                (EOther::ENCODER_NAME, EOther::describe_task(task), span.into_iter().collect()),
+                (EOther::ENCODER_NAME, match err {
+                    TaskEncoderError::EnqueueingError(_) => "? EnqueueingError".to_string(),
+                    TaskEncoderError::EncodingError(err) => EOther::describe_error(err),
+                    TaskEncoderError::DependencyError(_items) => "? DependencyError".to_string(),
+                    TaskEncoderError::CyclicError => "? CyclicError".to_string(),
+                }, Vec::new()),
+            ]))
             .and_then(|result| {
                 self.check_cycle()?;
                 Ok(result)
             })
+    }
+
+    pub fn require_ref<EOther: TaskEncoder>(
+        &mut self,
+        task: <EOther as TaskEncoder>::TaskDescription<'vir>,
+    ) -> Result<<EOther as TaskEncoder>::OutputRef<'vir>, EncodeFullError<'vir, E>> {
+        self.require_common(task.clone(), None, EOther::encode_ref(task))
     }
 
     pub fn require_local<EOther: TaskEncoder + 'vir>(
         &mut self,
         task: <EOther as TaskEncoder>::TaskDescription<'vir>,
     ) -> Result<<EOther as TaskEncoder>::OutputFullLocal<'vir>, EncodeFullError<'vir, E>> {
-        EOther::encode(task, true)
+        self.require_common(task.clone(), None, EOther::encode(task, true)
             .map(Option::unwrap)
-            .map(|(_output_ref, output_local, _output_dep)| output_local)
-            .map_err(|_| EncodeFullError::DependencyError)
-            .and_then(|result| {
-                self.check_cycle()?;
-                Ok(result)
-            })
+            .map(|(_output_ref, output_local, _output_dep)| output_local))
     }
 
     pub fn require_dep<EOther: TaskEncoder + 'vir>(
         &mut self,
         task: <EOther as TaskEncoder>::TaskDescription<'vir>,
     ) -> Result<<EOther as TaskEncoder>::OutputFullDependency<'vir>, EncodeFullError<'vir, E>> {
-        EOther::encode(task, true)
+        self.require_common(task.clone(), None, EOther::encode(task, true)
             .map(Option::unwrap)
-            .map(|(_output_ref, _output_local, output_dep)| output_dep)
-            .map_err(|_| EncodeFullError::DependencyError)
-            .and_then(|result| {
-                self.check_cycle()?;
-                Ok(result)
-            })
+            .map(|(_output_ref, _output_local, output_dep)| output_dep))
+    }
+
+    pub fn require_ref_spanned<EOther: TaskEncoder>(
+        &mut self,
+        task: <EOther as TaskEncoder>::TaskDescription<'vir>,
+        span: Span,
+    ) -> Result<<EOther as TaskEncoder>::OutputRef<'vir>, EncodeFullError<'vir, E>> {
+        self.require_common(task.clone(), Some(span), EOther::encode_ref(task))
+    }
+
+    pub fn require_local_spanned<EOther: TaskEncoder + 'vir>(
+        &mut self,
+        task: <EOther as TaskEncoder>::TaskDescription<'vir>,
+        span: Span,
+    ) -> Result<<EOther as TaskEncoder>::OutputFullLocal<'vir>, EncodeFullError<'vir, E>> {
+        self.require_common(task.clone(), Some(span), EOther::encode(task, true)
+            .map(Option::unwrap)
+            .map(|(_output_ref, output_local, _output_dep)| output_local))
+    }
+
+    pub fn require_dep_spanned<EOther: TaskEncoder + 'vir>(
+        &mut self,
+        task: <EOther as TaskEncoder>::TaskDescription<'vir>,
+        span: Span,
+    ) -> Result<<EOther as TaskEncoder>::OutputFullDependency<'vir>, EncodeFullError<'vir, E>> {
+        self.require_common(task.clone(), Some(span), EOther::encode(task, true)
+            .map(Option::unwrap)
+            .map(|(_output_ref, _output_local, output_dep)| output_dep))
     }
 
     pub fn emit_output_ref(

--- a/task-encoder/src/lib.rs
+++ b/task-encoder/src/lib.rs
@@ -179,7 +179,12 @@ pub trait TaskEncoder {
         // same task was (recursively) requested from the same encoder, before
         // its first invocation reached a call to `emit_output_ref`.
         // TODO: we should still make sure that *some* progress is done, because an actual cyclic dependency could cause a stack overflow?
-        Self::encode(task, false)?;
+        let encode_res = Self::encode(task, false);
+        match encode_res {
+            Ok(_)
+            | Err(TaskEncoderError::DependencyError) => (), // pass, check for output ref
+            Err(err) => return Err(err),
+        }
 
         let task_key_clone = task_key.clone();
         if let Some(output_ref) =
@@ -312,7 +317,7 @@ pub trait TaskEncoder {
                     }
                 })
             }
-            Err(EncodeFullError::DependencyError) => todo!(),
+            Err(EncodeFullError::DependencyError) => Err(TaskEncoderError::DependencyError),
             Err(EncodeFullError::EncodingError(err, maybe_output_dep)) => {
                 Self::with_cache(|cache| {
                     cache.borrow_mut().insert(
@@ -442,23 +447,41 @@ pub trait TaskEncoder {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self>;
 
-    fn all_outputs_local<'vir>() -> Vec<Self::OutputFullLocal<'vir>>
+    #[track_caller]
+    fn all_outputs_local_no_errors<'vir>() -> Vec<Self::OutputFullLocal<'vir>>
+    where
+        Self: 'vir,
+    {
+        let (outputs, errored) = Self::all_outputs_local();
+        assert!(errored.is_empty());
+        outputs
+    }
+
+    fn all_outputs_local<'vir>() -> (
+        Vec<Self::OutputFullLocal<'vir>>,
+        Vec<(Self::TaskKey<'vir>, Self::OutputRef<'vir>)>,
+    )
     where
         Self: 'vir,
     {
         Self::with_cache(|cache| {
-            cache
-                .borrow()
-                .iter()
-                .map(|(_, cache_state)| {
-                    if let TaskEncoderCacheState::Encoded { output_local, .. } = cache_state {
-                        output_local
-                    } else {
-                        panic!("task encoder not completed")
+            let mut outputs = Vec::new();
+            let mut errored = Vec::new();
+            for (key, cache_state) in cache.borrow().iter() {
+                match cache_state {
+                    TaskEncoderCacheState::Encoded { output_local, .. } => {
+                        outputs.push(output_local.clone());
                     }
-                })
-                .cloned()
-                .collect()
+                    TaskEncoderCacheState::Started { output_ref }
+                    | TaskEncoderCacheState::ErrorEncode { output_ref, .. } => {
+                        errored.push((key.clone(), output_ref.clone()));
+                    },
+                    //TaskEncoderCacheState::Enqueued => todo!(),
+                    //TaskEncoderCacheState::ErrorEnqueue { error } => todo!(),
+                    _ => panic!("task encoder not completed"),
+                }
+            }
+            (outputs, errored)
         })
     }
 

--- a/task-encoder/src/lib.rs
+++ b/task-encoder/src/lib.rs
@@ -1,7 +1,9 @@
+#![feature(rustc_private)]
 #![feature(associated_type_defaults)]
 
 use hashlink::LinkedHashMap;
 use std::cell::RefCell;
+use prusti_rustc_interface::span::Span;
 
 mod cache;
 mod dependencies;
@@ -119,6 +121,17 @@ pub trait TaskEncoder {
     type EnqueueingError: Clone + std::fmt::Debug = ();
     type EncodingError: Clone + std::fmt::Debug;
 
+    /// User-presentable name of this encoder.
+    const ENCODER_NAME: &'static str = "<untitled encoder>";
+
+    fn describe_task<'vir>(task: Self::TaskDescription<'vir>) -> String {
+        format!("{task:?}")
+    }
+
+    fn describe_error<'vir>(error: Self::EncodingError) -> String {
+        format!("{error:?}")
+    }
+
     /// Enters the given function with a reference to the cache for this
     /// encoder.
     fn with_cache<'vir, F, R>(f: F) -> R
@@ -182,7 +195,7 @@ pub trait TaskEncoder {
         let encode_res = Self::encode(task, false);
         match encode_res {
             Ok(_)
-            | Err(TaskEncoderError::DependencyError) => (), // pass, check for output ref
+            | Err(TaskEncoderError::DependencyError(..)) => (), // pass, check for output ref
             Err(err) => return Err(err),
         }
 
@@ -317,7 +330,23 @@ pub trait TaskEncoder {
                     }
                 })
             }
-            Err(EncodeFullError::DependencyError) => Err(TaskEncoderError::DependencyError),
+            Err(EncodeFullError::DependencyError(stack)) => {
+                let owned_stack = std::iter::once((Self::ENCODER_NAME, Self::describe_task(task), Vec::new())).chain(stack.into_iter()
+                    .map(|(encoder, task, spans)| (encoder, task, spans.clone())))
+                    .collect::<Vec<_>>();
+                Self::with_cache(|cache| {
+                    cache.borrow_mut().insert(
+                        task_key,
+                        TaskEncoderCacheState::ErrorEncode {
+                            output_ref: output_ref.clone(),
+                            deps,
+                            error: TaskEncoderError::DependencyError(owned_stack.clone()),
+                            output_dep: None,
+                        },
+                    )
+                });
+                Err(TaskEncoderError::DependencyError(owned_stack))
+            }
             Err(EncodeFullError::EncodingError(err, maybe_output_dep)) => {
                 Self::with_cache(|cache| {
                     cache.borrow_mut().insert(
@@ -459,7 +488,7 @@ pub trait TaskEncoder {
 
     fn all_outputs_local<'vir>() -> (
         Vec<Self::OutputFullLocal<'vir>>,
-        Vec<(Self::TaskKey<'vir>, Self::OutputRef<'vir>)>,
+        Vec<(Self::TaskKey<'vir>, Self::OutputRef<'vir>, TaskEncoderError<Self>)>,
     )
     where
         Self: 'vir,
@@ -472,13 +501,10 @@ pub trait TaskEncoder {
                     TaskEncoderCacheState::Encoded { output_local, .. } => {
                         outputs.push(output_local.clone());
                     }
-                    TaskEncoderCacheState::Started { output_ref }
-                    | TaskEncoderCacheState::ErrorEncode { output_ref, .. } => {
-                        errored.push((key.clone(), output_ref.clone()));
+                    TaskEncoderCacheState::ErrorEncode { output_ref, error, .. } => {
+                        errored.push((key.clone(), output_ref.clone(), error.clone()));
                     },
-                    //TaskEncoderCacheState::Enqueued => todo!(),
-                    //TaskEncoderCacheState::ErrorEnqueue { error } => todo!(),
-                    _ => panic!("task encoder not completed"),
+                    _ => panic!("task encoder not completed: {key:?}"),
                 }
             }
             (outputs, errored)

--- a/task-encoder/src/result.rs
+++ b/task-encoder/src/result.rs
@@ -58,7 +58,7 @@ impl<'vir, E: TaskEncoder + 'vir + ?Sized> std::fmt::Debug for EncodeFullError<'
 pub enum TaskEncoderError<E: TaskEncoder + ?Sized> {
     EnqueueingError(<E as TaskEncoder>::EnqueueingError),
     EncodingError(<E as TaskEncoder>::EncodingError),
-    // TODO: error of another task encoder?
+    DependencyError, // TODO: should this have any value attached?
     CyclicError,
 }
 
@@ -71,6 +71,7 @@ where
         match self {
             Self::EncodingError(err) => helper.field("EncodingError", err),
             Self::EnqueueingError(err) => helper.field("EnqueueingError", err),
+            Self::DependencyError => helper.field("DependencyError", &""),
             Self::CyclicError => helper.field("CyclicError", &""),
         };
         helper.finish()
@@ -83,6 +84,7 @@ impl<E: TaskEncoder + ?Sized> Clone for TaskEncoderError<E> {
         match self {
             Self::EncodingError(err) => Self::EncodingError(err.clone()),
             Self::EnqueueingError(err) => Self::EnqueueingError(err.clone()),
+            Self::DependencyError => Self::DependencyError,
             Self::CyclicError => Self::CyclicError,
         }
     }

--- a/task-encoder/src/result.rs
+++ b/task-encoder/src/result.rs
@@ -1,3 +1,5 @@
+use prusti_rustc_interface::span::Span;
+
 use super::*;
 
 /// The result of an `encode` call.
@@ -37,7 +39,9 @@ pub enum EncodeFullError<'vir, E: TaskEncoder + 'vir + ?Sized> {
         Option<E::OutputFullDependency<'vir>>,
     ),
 
-    DependencyError,
+    DependencyError(
+        Vec<(&'static str, String, Vec<Span>)>,
+    ),
 }
 
 // Manual implementation, since neither `E` nor `E::OutputFullDependency` are
@@ -50,7 +54,7 @@ impl<'vir, E: TaskEncoder + 'vir + ?Sized> std::fmt::Debug for EncodeFullError<'
                 .debug_tuple("EncodingError")
                 .field(err) /*.field(output_dep)*/
                 .finish(),
-            Self::DependencyError => write!(f, "DependencyError"),
+            Self::DependencyError(..) => write!(f, "DependencyError"),
         }
     }
 }
@@ -58,7 +62,7 @@ impl<'vir, E: TaskEncoder + 'vir + ?Sized> std::fmt::Debug for EncodeFullError<'
 pub enum TaskEncoderError<E: TaskEncoder + ?Sized> {
     EnqueueingError(<E as TaskEncoder>::EnqueueingError),
     EncodingError(<E as TaskEncoder>::EncodingError),
-    DependencyError, // TODO: should this have any value attached?
+    DependencyError(Vec<(&'static str, String, Vec<Span>)>),
     CyclicError,
 }
 
@@ -71,7 +75,7 @@ where
         match self {
             Self::EncodingError(err) => helper.field("EncodingError", err),
             Self::EnqueueingError(err) => helper.field("EnqueueingError", err),
-            Self::DependencyError => helper.field("DependencyError", &""),
+            Self::DependencyError(..) => helper.field("DependencyError", &""),
             Self::CyclicError => helper.field("CyclicError", &""),
         };
         helper.finish()
@@ -84,7 +88,7 @@ impl<E: TaskEncoder + ?Sized> Clone for TaskEncoderError<E> {
         match self {
             Self::EncodingError(err) => Self::EncodingError(err.clone()),
             Self::EnqueueingError(err) => Self::EnqueueingError(err.clone()),
-            Self::DependencyError => Self::DependencyError,
+            Self::DependencyError(stack) => Self::DependencyError(stack.clone()),
             Self::CyclicError => Self::CyclicError,
         }
     }

--- a/vir/src/data.rs
+++ b/vir/src/data.rs
@@ -168,6 +168,7 @@ pub enum TypeKind<'vir> {
     Ref, // TODO: typed references ?
     Perm,
     Unsupported(UnsupportedType<'vir>),
+    Err,
 }
 
 #[derive(PartialEq, Eq, Clone, Ord, PartialOrd, Serialize, Deserialize, Hash)]

--- a/vir/src/debug.rs
+++ b/vir/src/debug.rs
@@ -522,6 +522,7 @@ impl<'vir> Debug for TypeKind<'vir> {
             Self::Ref => write!(f, "Ref"),
             Self::Perm => write!(f, "Perm"),
             Self::Unsupported(u) => u.fmt(f),
+            Self::Err => write!(f, "Err"),
         }
     }
 }

--- a/vir/src/gendata.rs
+++ b/vir/src/gendata.rs
@@ -169,7 +169,8 @@ impl<'vir, Curr: 'vir, Next: 'vir, T: CompType> ExprGenData<'vir, Curr, Next, T>
     }
 
     pub(crate) fn new_inner(kind: ExprKindGen<'vir, Curr, Next>, debug_info: DebugInfo<'vir>, span: Option<&'vir VirSpan<'vir>>, ty: Type<'vir, T>) -> Self {
-        if kind.ty() != ty.as_dyn() {
+        if kind.ty() != ty.as_dyn()
+            && !matches!(kind.ty().kind(), crate::TypeKind::Err) {
             typecheck_error!(
                 "ExprGenData new_inner: kind {:?} has type {:?}, but trying to create with type {:?}",
                 kind,
@@ -284,7 +285,7 @@ impl<'vir, Curr, Next> ExprKindGenData<'vir, Curr, Next> {
             ExprKindGenData::AdtDestructor(_, destr) => destr.ty,
             ExprKindGenData::AdtConstructor(a) => a.result_ty,
             ExprKindGenData::AdtDiscriminator(_, _) => crate::TYPE_BOOL.as_dyn(),
-            ExprKindGenData::Todo(msg) => panic!("{msg}"),
+            ExprKindGenData::Todo(_msg) => crate::TYPE_ERR.as_dyn(), // panic!("{msg}"),
         }
     }
 }

--- a/vir/src/spans.rs
+++ b/vir/src/spans.rs
@@ -65,6 +65,8 @@ pub struct VirSpanManager<'vir> {
     stack: Vec<&'vir crate::spans::VirSpan<'vir>>,
 
     handlers: HashMap<usize, VirSpanHandler<'vir>>,
+
+    early_errors: Vec<PrustiError>,
 }
 
 impl<'tcx> VirCtxt<'tcx> {
@@ -110,9 +112,22 @@ impl<'tcx> VirCtxt<'tcx> {
         );
     }
 
+    pub fn emit_early_error(
+        &'tcx self,
+        error: PrustiError,
+    ) {
+        let mut manager = self.spans.borrow_mut();
+        manager.early_errors.push(error);
+    }
+
     // TODO: eventually, this should not be an Option
     pub fn top_span(&'tcx self) -> Option<&'tcx VirSpan<'tcx>> {
         self.spans.borrow().stack.last().copied()
+    }
+
+    /// Return all early (pre-verification) emitted errors.
+    pub fn early_errors(&'tcx self) -> Vec<PrustiError> {
+        self.spans.borrow().early_errors.clone()
     }
 
     /// Attempt to backtranslate the given error at the given position.

--- a/vir/src/type.rs
+++ b/vir/src/type.rs
@@ -96,6 +96,8 @@ impl_exp_type!(Int[TYPE_INT = Int] => Prim | Dyn, "The Viper `Int` type");
 impl_exp_type!(Perm[TYPE_PERM = Perm] => Prim | Dyn, "The Viper `Perm` type (reals)");
 impl_exp_type!(Ref[TYPE_REF = Ref] => Prim | Dyn, "The Viper `Ref` type");
 
+impl_exp_type!(Err[TYPE_ERR = Err] => Prim | Dyn, "Type for encoding errors");
+
 impl_exp_type!(CSnap => Snap | Dyn, TypeKind::Domain(name, ..) if name.starts_with("s_") && name != "s_Param", "A concrete Prusti snapshot type");
 impl_exp_type!(PSnap[TYPE_PSNAP = Domain("s_Param", &[])] => Snap | Dyn, "The generic snapshot domain (`s_Param`)");
 impl_exp_type!(TyVal[TYPE_TYVAL = Domain("Type", &[])] => Dyn, "The type domain (`ExpType`) which gives values to types");

--- a/vir/src/viper_ident.rs
+++ b/vir/src/viper_ident.rs
@@ -34,11 +34,14 @@ fn sanitize_char(c: char) -> Option<String> {
     match c {
         '<' => Some("$lt$".to_string()),
         '>' => Some("$gt$".to_string()),
-        ' ' => Some("$space$".to_string()),
-        ',' => Some("$comma$".to_string()),
-        ':' => Some("$colon$".to_string()),
+        ' ' => Some("$sp$".to_string()),
+        ',' => Some("$com$".to_string()),
+        ':' => Some("$col$".to_string()),
         '\'' => Some("$sq$".to_string()),
         '&' => Some("$amp$".to_string()),
+        '-' => Some("$hyp$".to_string()),
+        '(' => Some("$lp$".to_string()),
+        ')' => Some("$rp$".to_string()),
         _ => None,
     }
 }


### PR DESCRIPTION
Changes:

- Unsupported rvalues are now encoded as `assert false` and will only trigger a *verification* error if control flow hits them.
- "Most generic type" is now a fallible encoder. We might want to eventually change this (if we ever support all type kinds) but for now this makes it possible for dependente encoders (MIR local defs encoder) to fail if the types cannot be encoded.
- Task encoders have been changed slightly to allow handling failing tasks. In particular, the impure encoder will emit a method stub with the correct arity but a `requires false` precondition on encoding errors.
  - A call terminator to such a method is also encoded as `assert false`. The error reporting (for now) says "precondition might not hold" with the "reason" being a span for the method signature. This is not great, but we might be able to resolve once we have a separate encoder for method calls.
  - A failed method will also trigger an "early" error (before we even get to verification) if it should have been verified, i.e., if it is local and not trusted.
- Error reporting for encoders failing due to failed (transitive) dependencies is improved to present the user with an error showing the failed chain of dependencies.