### PR TITLE
Various tiny bugfixes

### DIFF
--- a/analysis/tests/test_cases/gen_accessibility/create-box.rs
+++ b/analysis/tests/test_cases/gen_accessibility/create-box.rs
@@ -1,5 +1,4 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 fn use_box(v: i32) -> Box<i32> {
     let x = Box::new(v);

--- a/analysis/tests/test_cases/gen_accessibility/deref.rs
+++ b/analysis/tests/test_cases/gen_accessibility/deref.rs
@@ -1,5 +1,4 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 struct InfiniteList1 {
     next: Box<InfiniteList1>

--- a/analysis/tests/test_cases/gen_accessibility/loops/tmp-in-guard.rs
+++ b/analysis/tests/test_cases/gen_accessibility/loops/tmp-in-guard.rs
@@ -1,4 +1,3 @@
-#![feature(box_syntax)]
 
 fn random() -> u32 {
     unimplemented!()

--- a/analysis/tests/test_cases/gen_accessibility/predicate-old-expr.rs
+++ b/analysis/tests/test_cases/gen_accessibility/predicate-old-expr.rs
@@ -1,5 +1,4 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use std::borrow::BorrowMut;
 

--- a/analysis/tests/test_cases/gen_accessibility/reassignment.rs
+++ b/analysis/tests/test_cases/gen_accessibility/reassignment.rs
@@ -1,7 +1,6 @@
 //! Example of reassignment
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 struct InfiniteList {
     val: i32,

--- a/prusti-encoder/src/encoder_traits/pure_function_enc.rs
+++ b/prusti-encoder/src/encoder_traits/pure_function_enc.rs
@@ -154,6 +154,7 @@ where
                 .map(|i| i.skip_binder())
                 .copied()
                 .collect::<Vec<_>>();
+            // TODO: type preconditions do not currently work
             let type_preconditions = input_tys.iter().enumerate().filter_map(|(idx, ty)| {
                 let vir_arg = local_defs[mir::Local::from(idx + 1)];
                 let vir_arg = vcx.mk_local_ex(vir_arg.local.name, vir_arg.ty.snapshot());
@@ -163,13 +164,14 @@ where
             tracing::debug!("finished {def_id:?}");
 
             let mut type_preconditions: Vec<_> = type_preconditions.collect();
-            let pres = if type_preconditions.is_empty() {
+            let pres = if true || type_preconditions.is_empty() {
                 spec.pres
             } else {
                 type_preconditions.extend(spec.pres);
                 type_preconditions
             };
 
+            // TODO: type postcondition do not currently work
             let type_postcondition = Self::mk_type_assertion(
                 vcx,
                 deps,
@@ -178,7 +180,9 @@ where
             );
             let mut posts = spec.posts;
             if let Some(pc) = type_postcondition {
-                posts.insert(0, pc);
+                if false {
+                    posts.insert(0, pc);
+                }
             }
 
             Ok(MirFunctionEncOutput {

--- a/prusti-encoder/src/encoders/impure/fn_wand.rs
+++ b/prusti-encoder/src/encoders/impure/fn_wand.rs
@@ -466,7 +466,8 @@ impl TaskEncoder for WandEnc {
                     todo!("region bound pair: {pred:?}");
                 };
                 let Some(a) = IndirectKey::from_region(pred.1) else {
-                    todo!("region bound pair: {pred:?}");
+                    // TODO: handle unexpected todo!("region bound pair: {pred:?}");
+                    continue;
                 };
                 // This edge may be skipped, see TODO in `WandEncEdges::edge`.
                 insert_edge(a, IndirectKey::Param(b));

--- a/prusti-encoder/src/encoders/type/indirect.rs
+++ b/prusti-encoder/src/encoders/type/indirect.rs
@@ -31,7 +31,7 @@ impl IndirectKey {
         match region.kind() {
             RegionKind::ReEarlyParam(e) => Some(IndirectKey::Early(e)),
             RegionKind::ReBound(_, g) => Some(IndirectKey::Late(g.kind)),
-            RegionKind::ReLateParam(r) => todo!("{r:?}"),//Some(IndirectKey::Late(r.bound_region)),
+            RegionKind::ReLateParam(_r) => None, // TODO: Some(IndirectKey::Late(r.bound_region)),
             RegionKind::ReVar(r) => Some(IndirectKey::Var(r)),
             RegionKind::RePlaceholder(..) | RegionKind::ReError(..) | RegionKind::ReErased => {
                 unreachable!("{region:?}")

--- a/prusti-encoder/src/encoders/type/lifted/casters.rs
+++ b/prusti-encoder/src/encoders/type/lifted/casters.rs
@@ -339,7 +339,9 @@ impl TaskEncoder for CastersEnc<CastTypePure> {
             let make_concrete = vcx.mk_function(
                 make_concrete_ident,
                 (make_concrete_snap_arg_decl, &ty_params_vec),
-                vcx.alloc_slice(&[make_concrete_pre]),
+                // TODO: type preconditions do not currently work
+                // vcx.alloc_slice(&[make_concrete_pre]),
+                &[],
                 vcx.alloc_slice(&[make_concrete_post]),
                 None,
                 None,

--- a/prusti-tests/tests/verify/fail/assert-false/list-sound.rs
+++ b/prusti-tests/tests/verify/fail/assert-false/list-sound.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 
@@ -59,7 +58,7 @@ fn empty_list(val: i32) -> List {
 fn singleton_list(val: i32) -> List {
     let ret = List::Const {
         val,
-        next: box List::Nil
+        next: Box::new(List::Nil)
     };
     assert!(false);  //~ERROR: the asserted expression might not hold
     ret
@@ -68,7 +67,7 @@ fn singleton_list(val: i32) -> List {
 fn prepend(val: i32, list: List) -> List {
     let ret = List::Const {
         val,
-        next: box list
+        next: Box::new(list)
     };
     assert!(false);  //~ERROR: the asserted expression might not hold
     ret
@@ -78,11 +77,11 @@ fn append(new_val: i32, list: List) -> List {
     let ret = match list {
         List::Nil => List::Const {
             val: new_val,
-            next: box List::Nil
+            next: Box::new(List::Nil)
         },
         List::Const { val, box next } => List::Const {
             val: val,
-            next: box append(new_val, next)
+            next: Box::new(append(new_val, next))
         },
     };
     assert!(false);  //~ERROR: the asserted expression might not hold

--- a/prusti-tests/tests/verify/fail/demos/append-error.rs
+++ b/prusti-tests/tests/verify/fail/demos/append-error.rs
@@ -1,4 +1,4 @@
-#![feature(box_patterns, box_syntax)]
+#![feature(box_patterns)]
 use prusti_contracts::*;
 
 struct List {
@@ -20,10 +20,10 @@ fn append(a: &mut List, v: i32) {
     if let Some(box ref mut tail) = a.next {
         append(tail, v);
     } else {
-        a.next = Some(box List {
+        a.next = Some(Box::new(List {
             val: v,
             next: None
-        });
+        }));
     }
 }
 

--- a/prusti-tests/tests/verify/fail/demos/append-sorted-error-3.rs
+++ b/prusti-tests/tests/verify/fail/demos/append-sorted-error-3.rs
@@ -1,4 +1,4 @@
-#![feature(box_patterns, box_syntax)]
+#![feature(box_patterns)]
 use prusti_contracts::*;
 
 struct List {
@@ -48,10 +48,10 @@ fn append(a: &mut List, v: i32) {
     if let Some(box ref mut tail) = a.next {
         append(tail, v);
     } else {
-        a.next = Some(box List {
+        a.next = Some(Box::new(List {
             val: v,
             next: None
-        });
+        }));
     }
 }
 

--- a/prusti-tests/tests/verify/fail/loops/havock_loop_vars.rs
+++ b/prusti-tests/tests/verify/fail/loops/havock_loop_vars.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 use prusti_contracts::*;
 
 #[trusted]
@@ -12,7 +10,7 @@ fn test() {
     let mut z = None;
 
     loop {
-        let x = box 5;
+        let x = Box::new(5);
         if random() {
             y = Some(x);
         } else {

--- a/prusti-tests/tests/verify/fail/loops/tmp_in_loop_condition.rs
+++ b/prusti-tests/tests/verify/fail/loops/tmp_in_loop_condition.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 use prusti_contracts::*;
 
 #[trusted]
@@ -8,51 +6,51 @@ fn random() -> u32 {
 }
 
 fn test1() {
-    let mut tmp = box box random();
+    let mut tmp = Box::new(Box::new(random()));
     let tmp_ref = &tmp;
     let tmp_ref_mut = &mut tmp;
 
     while {
         let guard = random() < 55;
 
-        let mut tmp = box box random();
+        let mut tmp = Box::new(Box::new(random()));
         let tmp_ref = &tmp;
         let tmp_ref_mut = &mut tmp;
 
         guard
     } {
-        let mut tmp = box box random();
+        let mut tmp = Box::new(Box::new(random()));
         let tmp_ref = &tmp;
         let tmp_ref_mut = &mut tmp;
     }
 
-    let mut tmp = box box random();
+    let mut tmp = Box::new(Box::new(random()));
     let tmp_ref = &tmp;
     let tmp_ref_mut = &mut tmp;
     assert!(false); //~ ERROR
 }
 
 fn test2() {
-    let mut tmp = box box random();
+    let mut tmp = Box::new(Box::new(random()));
     let tmp_ref = &tmp;
     let tmp_ref_mut = &mut tmp;
 
     while {
         let guard = random() < 55;
 
-        let mut tmp = box box random();
+        let mut tmp = Box::new(Box::new(random()));
         let tmp_ref = &tmp;
         let tmp_ref_mut = &mut tmp;
 
         guard
     } {
-        let mut tmp = box box random();
+        let mut tmp = Box::new(Box::new(random()));
         let tmp_ref = &tmp;
         let tmp_ref_mut = &mut tmp;
         assert!(false); //~ ERROR
     }
 
-    let mut tmp = box box random();
+    let mut tmp = Box::new(Box::new(random()));
     let tmp_ref = &tmp;
     let tmp_ref_mut = &mut tmp;
 }

--- a/prusti-tests/tests/verify/fail/no-annotations/predicate-old-expr.rs
+++ b/prusti-tests/tests/verify/fail/no-annotations/predicate-old-expr.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use std::borrow::BorrowMut;
 

--- a/prusti-tests/tests/verify/fail/pure-fn/panic-in-fn.rs
+++ b/prusti-tests/tests/verify/fail/pure-fn/panic-in-fn.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/fail/pure-fn/wrong-quantifiers.rs
+++ b/prusti-tests/tests/verify/fail/pure-fn/wrong-quantifiers.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/fail/pure-fn/wrong-ref-mut-arg.rs
+++ b/prusti-tests/tests/verify/fail/pure-fn/wrong-ref-mut-arg.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 #![feature(never_type)]
 #![allow(unconditional_recursion)]
 

--- a/prusti-tests/tests/verify/pass/demos/append.rs
+++ b/prusti-tests/tests/verify/pass/demos/append.rs
@@ -1,4 +1,4 @@
-#![feature(box_patterns, box_syntax)]
+#![feature(box_patterns)]
 use prusti_contracts::*;
 
 struct List {
@@ -20,10 +20,10 @@ fn append(a: &mut List, v: i32) {
     if let Some(box ref mut tail) = a.next {
         append(tail, v);
     } else {
-        a.next = Some(box List {
+        a.next = Some(Box::new(List {
             val: v,
             next: None
-        });
+        }));
     }
 }
 

--- a/prusti-tests/tests/verify/pass/expiring-loans/pure-fn-loan-2.rs
+++ b/prusti-tests/tests/verify/pass/expiring-loans/pure-fn-loan-2.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/pass/expiring-loans/pure-fn-loan.rs
+++ b/prusti-tests/tests/verify/pass/expiring-loans/pure-fn-loan.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/pass/gitlab-issues/issue-118-1.rs
+++ b/prusti-tests/tests/verify/pass/gitlab-issues/issue-118-1.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/pass/gitlab-issues/issue-118.rs
+++ b/prusti-tests/tests/verify/pass/gitlab-issues/issue-118.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/pass/gitlab-issues/issue-39.rs
+++ b/prusti-tests/tests/verify/pass/gitlab-issues/issue-39.rs
@@ -2,7 +2,6 @@
 
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/pass/loop-invs/framing_after_break.rs
+++ b/prusti-tests/tests/verify/pass/loop-invs/framing_after_break.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 use prusti_contracts::*;
 
 #[trusted]
@@ -21,7 +19,7 @@ fn test() {
             break;
         }
 
-        let y = box x;
+        let y = Box::new(x);
     }
 
     assert!(x == 123);
@@ -44,7 +42,7 @@ fn test2() {
             break;
         }
 
-        let y = box x;
+        let y = Box::new(x);
     }
 
     assert!(x == 123);
@@ -69,7 +67,7 @@ fn test3() {
 
         x = 567;
 
-        let y = box x;
+        let y = Box::new(x);
     }
 
     assert!(x == 123);

--- a/prusti-tests/tests/verify/pass/loop-invs/initialize_in_loop_condition.rs
+++ b/prusti-tests/tests/verify/pass/loop-invs/initialize_in_loop_condition.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 use prusti_contracts::*;
 
 #[trusted]
@@ -11,7 +9,7 @@ fn test() {
     let mut x: Box<u32>;
 
     'myloop: while {
-        x = box random();
+        x = Box::new(random());
         if *x == 0 {
             break 'myloop;
         }

--- a/prusti-tests/tests/verify/pass/loop-invs/tmp_in_loop_condition.rs
+++ b/prusti-tests/tests/verify/pass/loop-invs/tmp_in_loop_condition.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 use prusti_contracts::*;
 
 #[trusted]
@@ -8,25 +6,25 @@ fn random() -> u32 {
 }
 
 fn test() {
-    let mut tmp = box box random();
+    let mut tmp = Box::new(Box::new(random()));
     let tmp_ref = &tmp;
     let tmp_ref_mut = &mut tmp;
 
     while {
         let guard = random() < 55;
 
-        let mut tmp = box box random();
+        let mut tmp = Box::new(Box::new(random()))();
         let tmp_ref = &tmp;
         let tmp_ref_mut = &mut tmp;
 
         guard
     } {
-        let mut tmp = box box random();
+        let mut tmp = Box::new(Box::new(random()))();
         let tmp_ref = &tmp;
         let tmp_ref_mut = &mut tmp;
     }
 
-    let mut tmp = box box random();
+    let mut tmp = Box::new(Box::new(random()))();
     let tmp_ref = &tmp;
     let tmp_ref_mut = &mut tmp;
 

--- a/prusti-tests/tests/verify/pass/no-annotations/create-box.rs
+++ b/prusti-tests/tests/verify/pass/no-annotations/create-box.rs
@@ -1,7 +1,6 @@
 //! Currently unsupported because `Box` and `Option` use a type parameter
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 fn use_box(v: i32) -> Box<i32> {
     let x = Box::new(v);
@@ -9,7 +8,7 @@ fn use_box(v: i32) -> Box<i32> {
     assert!(v == y);
     let z = Box::new(y);
     assert!(v == *z);
-    box *z
+    Box::new(*z)
 }
 
 fn main() {}

--- a/prusti-tests/tests/verify/pass/no-annotations/either.rs
+++ b/prusti-tests/tests/verify/pass/no-annotations/either.rs
@@ -1,7 +1,6 @@
 //! Currently unsupported because `Box` and `Option` use a type parameter
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 enum Either {
     Left(i32),

--- a/prusti-tests/tests/verify/pass/no-annotations/list.rs
+++ b/prusti-tests/tests/verify/pass/no-annotations/list.rs
@@ -1,7 +1,6 @@
 //! Example of linked list
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 enum List {
     Nil,
@@ -49,14 +48,14 @@ fn empty_list(val: i32) -> List {
 fn singleton_list(val: i32) -> List {
     List::Const {
         val,
-        next: box List::Nil
+        next: Box::new(List::Nil)
     }
 }
 
 fn prepend(val: i32, list: List) -> List {
     List::Const {
         val,
-        next: box list
+        next: Box::new(list)
     }
 }
 
@@ -64,11 +63,11 @@ fn append(new_val: i32, list: List) -> List {
     match list {
         List::Nil => List::Const {
             val: new_val,
-            next: box List::Nil
+            next: Box::new(List::Nil)
         },
         List::Const { val, box next } => List::Const {
             val: val,
-            next: box append(new_val, next)
+            next: Box::new(append(new_val, next))
         },
     }
 }

--- a/prusti-tests/tests/verify/pass/no-annotations/option.rs
+++ b/prusti-tests/tests/verify/pass/no-annotations/option.rs
@@ -1,7 +1,6 @@
 //! Currently unsupported because `Box` and `Option` use a type parameter
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 fn main() {
     let x = 123;

--- a/prusti-tests/tests/verify/pass/no-annotations/reassignment.rs
+++ b/prusti-tests/tests/verify/pass/no-annotations/reassignment.rs
@@ -1,7 +1,6 @@
 //! Example of reassignment
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 struct InfiniteList {
     val: i32,

--- a/prusti-tests/tests/verify/pass/no-annotations/shared-ref.rs
+++ b/prusti-tests/tests/verify/pass/no-annotations/shared-ref.rs
@@ -19,7 +19,7 @@ macro_rules! matches {
 }
 
 fn byte_serialized_unchanged(byte: u8) -> bool {
-    matches!(byte, b'*' | b'-' | b'.' | b'0' ... b'9' | b'A' ... b'Z' | b'_' | b'a' ... b'z')
+    matches!(byte, b'*' | b'-' | b'.' | b'0' ..= b'9' | b'A' ..= b'Z' | b'_' | b'a' ..= b'z')
 }
 
 fn main(){}

--- a/prusti-tests/tests/verify/pass/no-annotations/use-box.rs
+++ b/prusti-tests/tests/verify/pass/no-annotations/use-box.rs
@@ -1,7 +1,6 @@
 //! Currently unsupported because `Box` and `Option` use a type parameter
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 fn use_box(x: Box<i32>) -> i32 {
     *x

--- a/prusti-tests/tests/verify/pass/paper-examples/ownership_align.rs
+++ b/prusti-tests/tests/verify/pass/paper-examples/ownership_align.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 use prusti_contracts::*;
 
 struct Point {
@@ -9,9 +7,10 @@ struct Point {
 #[ensures(old((*p).x + s) == (*result).x)]
 #[ensures(old((*p).y) == (*result).y)]
 fn shift_x(p: Box<Point>, s:i32) -> Box<Point> {
-  box Point { x: (*p).x + s, y: (*p).y }
+  Box::new(Point { x: (*p).x + s, y: (*p).y })
 }
 
+#[requires((*segm.0).x < 0x7FFFFFFF)]
 fn compress(mut segm: (Box<Point>, Box<Point>))
                     -> (Box<Point>, Box<Point>) {
   let mut end = segm.1; // move assignment

--- a/prusti-tests/tests/verify/pass/paper-examples/points.rs
+++ b/prusti-tests/tests/verify/pass/paper-examples/points.rs
@@ -10,6 +10,7 @@ fn shift_x(p: &mut Point, s: i32) {
   p.x = p.x + s
 }
 
+#[requires((*segm.0).x < 0x7FFFFFFF)]
 fn compress(mut segm: (Box<Point>, Box<Point>))
                     -> (Box<Point>, Box<Point>) {
   let diff = (*segm.0).x - (*segm.1).x + 1;

--- a/prusti-tests/tests/verify/pass/paper-examples/routes.rs
+++ b/prusti-tests/tests/verify/pass/paper-examples/routes.rs
@@ -1,4 +1,4 @@
-#![feature(box_syntax, box_patterns)]
+#![feature(box_patterns)]
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/pass/pure-fn/issue-27.rs
+++ b/prusti-tests/tests/verify/pass/pure-fn/issue-27.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 /// See issue #27
 

--- a/prusti-tests/tests/verify/pass/pure-fn/len-lookup.rs
+++ b/prusti-tests/tests/verify/pass/pure-fn/len-lookup.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/pass/pure-fn/quantifiers.rs
+++ b/prusti-tests/tests/verify/pass/pure-fn/quantifiers.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/pass/pure-fn/recursive-pure-fn.rs
+++ b/prusti-tests/tests/verify/pass/pure-fn/recursive-pure-fn.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/pass/pure-fn/ref-mut-arg.rs
+++ b/prusti-tests/tests/verify/pass/pure-fn/ref-mut-arg.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 #![feature(never_type)]
 #![allow(unconditional_recursion)]
 

--- a/prusti-tests/tests/verify/pass/quick/routes.rs
+++ b/prusti-tests/tests/verify/pass/quick/routes.rs
@@ -1,4 +1,4 @@
-#![feature(box_syntax, box_patterns)]
+#![feature(box_patterns)]
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify/pass/rosetta/Ackermann_function.rs
+++ b/prusti-tests/tests/verify/pass/rosetta/Ackermann_function.rs
@@ -16,51 +16,71 @@
 use prusti_contracts::*;
 
 #[pure]
+#[ensures({
+    let overflow = (a > 0 && b > 0 && 0 < (a - 0x7FFFFFFF) + b) || (a < 0 && b < 0 && (a + 0x7FFFFFFF) + (b + 1) < 0);
+    match result {
+        Some(r) => !overflow && a + b == r,
+        None => overflow,
+    }
+})]
+#[trusted]
+fn checked_add(a: i32, b: i32) -> Option<i32> {
+    a.checked_add(b)
+}
+
+#[pure]
 #[requires(0 <= m && 0 <= n)]
-#[ensures(result >= 0)]
-fn ack_pure(m: isize, n: isize) -> isize {
+#[ensures(if let Some(r) = result { r >= 0 } else { true })]
+fn ack_pure(m: i32, n: i32) -> Option<i32> {
     if m == 0 {
-        n + 1
+        checked_add(n, 1)
     } else if n == 0 {
         ack_pure(m - 1, 1)
+    } else if let Some(nn) = ack_pure(m, n - 1) {
+        ack_pure(m - 1, nn)
     } else {
-        ack_pure(m - 1, ack_pure(m, n - 1))
+        None
     }
 }
 
 
 #[requires(0 <= m && 0 <= n)]
-#[ensures(result == ack_pure(m, n))]
-#[ensures(result >= 0)]
-fn ack1(m: isize, n: isize) -> isize {
+#[ensures(result === ack_pure(m, n))]
+#[ensures(if let Some(r) = result { r >= 0 } else { true })]
+fn ack1(m: i32, n: i32) -> Option<i32> {
     if m == 0 {
-        n + 1
+        checked_add(n, 1)
     } else if n == 0 {
         ack1(m - 1, 1)
+    } else if let Some(nn) = ack1(m, n - 1) {
+        ack1(m - 1, nn)
     } else {
-        ack1(m - 1, ack1(m, n - 1))
+        None
     }
 }
 
 #[requires(0 <= m && 0 <= n)]
-#[ensures(result == ack_pure(m, n))]
-#[ensures(result >= 0)]
-fn ack2(m: isize, n: isize) -> isize {
-	match (m, n) {
-		(0, n) => n + 1,
-		(m, 0) => ack2(m - 1, 1),
-		(m, n) => ack2(m - 1, ack2(m, n - 1)),
-	}
+#[ensures(result === ack_pure(m, n))]
+#[ensures(if let Some(r) = result { r >= 0 } else { true })]
+fn ack2(m: i32, n: i32) -> Option<i32> {
+    match (m, n) {
+        (0, n) => checked_add(n, 1),
+        (m, 0) => ack2(m - 1, 1),
+        (m, n) => match ack2(m, n - 1) {
+            Some(nn) => ack2(m - 1, nn),
+            None => None,
+        },
+    }
 }
 
 #[trusted]
-fn print_isize(a: isize) {
-    println!("{}", a); // 125
+fn print_i32(a: Option<i32>) {
+    println!("{:?}", a); // Some(125)
 }
 
 fn main() {
     let a1 = ack1(3, 4);
     let a2 = ack2(3, 4);
     assert!(a1 == a2);
-    print_isize(a1);
+    print_i32(a1);
 }

--- a/prusti-tests/tests/verify_overflow/pass/initialization/deref.rs
+++ b/prusti-tests/tests/verify_overflow/pass/initialization/deref.rs
@@ -2,7 +2,6 @@
 
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify_overflow/pass/simple-specs/ownership1.rs
+++ b/prusti-tests/tests/verify_overflow/pass/simple-specs/ownership1.rs
@@ -1,5 +1,5 @@
 #![feature(nll)]
-#![feature(box_patterns, box_syntax)]
+#![feature(box_patterns)]
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests/verify_overflow/pass/simple-specs/ownership2.rs
+++ b/prusti-tests/tests/verify_overflow/pass/simple-specs/ownership2.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 
@@ -11,7 +10,7 @@ struct Point {
 
 #[requires(u32::MAX - *a >= b)]
 #[ensures(*result == old(*a) + old(b))]
-fn add(a: Box<u32>, b: u32) -> Box<u32> { box (*a + b) }
+fn add(a: Box<u32>, b: u32) -> Box<u32> { Box::new((*a + b)) }
 
 #[requires(u32::MAX - *p.x >= s)]
 #[ensures(*result.x == old(*p.x) + old(s))]

--- a/prusti-tests/tests_old/verify/fail/demos/append-sorted-error-1.rs
+++ b/prusti-tests/tests_old/verify/fail/demos/append-sorted-error-1.rs
@@ -1,4 +1,4 @@
-#![feature(box_patterns, box_syntax)]
+#![feature(box_patterns)]
 use prusti_contracts::*;
 
 struct List {
@@ -48,10 +48,10 @@ fn append(a: &mut List, v: i32) {
     if let Some(box ref mut tail) = a.next {
         append(tail, v);
     } else {
-        a.next = Some(box List {
+        a.next = Some(Box::new(List {
             val: v,
             next: None
-        });
+        }));
     }
 }
 

--- a/prusti-tests/tests_old/verify/fail/demos/append-sorted-error-2.rs
+++ b/prusti-tests/tests_old/verify/fail/demos/append-sorted-error-2.rs
@@ -1,4 +1,4 @@
-#![feature(box_patterns, box_syntax)]
+#![feature(box_patterns)]
 use prusti_contracts::*;
 
 struct List {
@@ -48,10 +48,10 @@ fn append(a: &mut List, v: i32) {
     if let Some(box ref mut tail) = a.next {
         append(tail, v);
     } else {
-        a.next = Some(box List {
+        a.next = Some(Box::new(List {
             val: v,
             next: None
-        });
+        }));
     }
 }
 

--- a/prusti-tests/tests_old/verify/fail/demos/append-sorted-error-4.rs
+++ b/prusti-tests/tests_old/verify/fail/demos/append-sorted-error-4.rs
@@ -1,4 +1,4 @@
-#![feature(box_patterns, box_syntax)]
+#![feature(box_patterns)]
 use prusti_contracts::*;
 
 struct List {
@@ -48,10 +48,10 @@ fn append(a: &mut List, v: i32) {
     if let Some(box ref mut tail) = a.next {
         append(tail, v);
     } else {
-        a.next = Some(box List {
+        a.next = Some(Box::new(List {
             val: v,
             next: None
-        });
+        }));
     }
 }
 

--- a/prusti-tests/tests_old/verify/pass/competitive_programming/dp-on-trees/LuckyTree_Slice.rs
+++ b/prusti-tests/tests_old/verify/pass/competitive_programming/dp-on-trees/LuckyTree_Slice.rs
@@ -4,7 +4,6 @@
 // Original PR: https://github.com/viperproject/prusti-dev/pull/405
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 

--- a/prusti-tests/tests_old/verify/pass/competitive_programming/dp-on-trees/LuckyTree_TreeDP.rs
+++ b/prusti-tests/tests_old/verify/pass/competitive_programming/dp-on-trees/LuckyTree_TreeDP.rs
@@ -4,7 +4,6 @@
 // Original PR: https://github.com/viperproject/prusti-dev/pull/405
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 use std::ptr;

--- a/prusti-tests/tests_old/verify/pass/demos/append-sorted.rs
+++ b/prusti-tests/tests_old/verify/pass/demos/append-sorted.rs
@@ -1,4 +1,4 @@
-#![feature(box_patterns, box_syntax)]
+#![feature(box_patterns)]
 use prusti_contracts::*;
 
 struct List {
@@ -48,10 +48,10 @@ fn append(a: &mut List, v: i32) {
     if let Some(box ref mut tail) = a.next {
         append(tail, v);
     } else {
-        a.next = Some(box List {
+        a.next = Some(Box::new(List {
             val: v,
             next: None
-        });
+        }));
     }
 }
 

--- a/prusti-tests/tests_old/verify/pass/gitlab-issues/issue-187-1.rs
+++ b/prusti-tests/tests_old/verify/pass/gitlab-issues/issue-187-1.rs
@@ -1,4 +1,4 @@
-#![feature(box_patterns, box_syntax)]
+#![feature(box_patterns)]
 
 use prusti_contracts::*;
 
@@ -30,10 +30,10 @@ fn append(list: &mut List, elem: Triple) {
         Some(box ref mut tail) => append(tail, elem),
         None => {
             list.next = Some(
-                box List {
+                Box::new(List {
                     next: None,
                     elem: elem
-                }
+                })
             )
         }
     }

--- a/prusti-tests/tests_old/verify/pass/quick/with-spec-list.rs
+++ b/prusti-tests/tests_old/verify/pass/quick/with-spec-list.rs
@@ -1,6 +1,5 @@
 #![feature(nll)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 
@@ -76,10 +75,10 @@ impl List {
             Some(_) => unreachable!(),
             None => {},
         }
-        last.next = Some(box List {
+        last.next = Some(Box::new(List {
             next: None,
             value: value,
-        });
+        }));
         let old_last_value = last.value;
         assert!(last.lookup(1) == value);
         assert!(last.lookup(0) == old_last_value);

--- a/prusti-tests/tests_old/verify_overflow/pass/competitive_programming/dp-on-trees/MaxCoinsInBinaryTree.rs
+++ b/prusti-tests/tests_old/verify_overflow/pass/competitive_programming/dp-on-trees/MaxCoinsInBinaryTree.rs
@@ -4,7 +4,6 @@
 // Original PR: https://github.com/viperproject/prusti-dev/pull/342
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use prusti_contracts::*;
 use std::ptr;

--- a/prusti-viper/src/lib.rs
+++ b/prusti-viper/src/lib.rs
@@ -860,7 +860,9 @@ impl<'vir, 'v> ToViperVec<'vir, 'v> for vir::TerminatorStmt<'vir> {
     ) {
         match self {
             vir::TerminatorStmtGenData::AssumeFalse => {
-                vec.push(ctx.ast.inhale(ctx.ast.false_lit_with_pos(pos), pos))
+                vec.push(ctx.ast.inhale(ctx.ast.false_lit_with_pos(pos), pos));
+                let goto_end = &vir::TerminatorStmtGenData::Goto(&vir::CfgBlockLabelData::End);
+                goto_end.to_viper_extend(vec, ctx, pos);
             }
             vir::TerminatorStmtGenData::Goto(label) => vec.push(ctx.ast.goto(&label.name())),
             vir::TerminatorStmtGenData::GotoIf(v) => v.to_viper_extend_no_pos(vec, ctx),

--- a/prusti/src/driver.rs
+++ b/prusti/src/driver.rs
@@ -160,6 +160,8 @@ fn main() {
             // Some crates might have a `overflow-checks = false` in their `Cargo.toml` to
             // disable integer overflow checks, but we want to override that.
             rustc_args.push("-Coverflow-checks=on".to_owned());
+        } else {
+            rustc_args.push("-Coverflow-checks=off".to_owned());
         }
 
         if config::dump_debug_info() {

--- a/vir/src/debug.rs
+++ b/vir/src/debug.rs
@@ -432,7 +432,11 @@ impl<'vir, Curr, Next> Debug for TerminatorStmtGenData<'vir, Curr, Next> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         let indent = f.width().unwrap_or_default();
         match self {
-            Self::AssumeFalse => write!(f, "assume false"),
+            Self::AssumeFalse => {
+                writeln!(f, "assume false")?;
+                f.pad("")?;
+                write!(f, "{:?}", Self::Goto(&CfgBlockLabelData::End))
+            }
             Self::Goto(target) => write!(f, "goto {:?}", target),
             Self::GotoIf(data) => {
                 if data.targets.is_empty() {


### PR DESCRIPTION
Fixes now-invalid syntax in many of the tests in the test suite (e.g. `box` syntax and `...` range), avoids panic in some cases for wands/indirect encoders (with a `TODO` to handle properly later), disables `type` assertions for pure functions (they were completely broken anyway), fixes compile error, adds a `goto end` for `AssumeFalse` to avoid Viper invalid CFGs, adds `-Coverflow-checks=off` when overflow checking is disabled to actually disable overflow checking in that case, fixes some examples which could overflow.

The last point is needed as the current semantics of disabling overflow checks is different to old Prusti (and imo better): with overflow checks disabled both versions do not raise a verification error if overflow could occur, but new Prusti does still handle the semantics correctly while only Prusti would just `assume no_overflow` which is super risky imo.