### PR TITLE
Automatically load prusti contracts crate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,13 +8,5 @@
         "--workspace",
         "--message-format=json",
         "--all-targets",
-    ],
-    "rust-analyzer.checkOnSave.overrideCommand": [
-        "python3",
-        "x.py",
-        "check",
-        "--workspace",
-        "--message-format=json",
-        "--all-targets",
-    ],
+    ]
 }

--- a/prusti/src/callbacks.rs
+++ b/prusti/src/callbacks.rs
@@ -113,7 +113,9 @@ impl prusti_rustc_interface::driver::Callbacks for PrustiCompilerCalls {
             let prusti_contracts_symbol = Symbol::intern("prusti_contracts");
 
             if !krate.items.iter().any(|item| match item.kind {
-                ItemKind::ExternCrate(Some(original_ident), _) => original_ident == prusti_contracts_symbol,
+                ItemKind::ExternCrate(Some(original_ident), _) => {
+                    original_ident == prusti_contracts_symbol
+                }
                 ItemKind::ExternCrate(None, ident) => ident.name == prusti_contracts_symbol,
                 _ => false,
             }) {

--- a/prusti/src/callbacks.rs
+++ b/prusti/src/callbacks.rs
@@ -8,18 +8,20 @@ use prusti_interface::{
     PrustiError,
 };
 use prusti_rustc_interface::{
+    ast::{AttrVec, Crate, Item, ItemKind, Visibility, VisibilityKind, DUMMY_NODE_ID},
     borrowck::consumers,
     data_structures::steal::Steal,
     driver::Compilation,
     hir::{def::DefKind, def_id::LocalDefId},
     index::IndexVec,
     interface::{interface::Compiler, Config},
+    metadata::creader::CStore,
     middle::{
         mir, query::queries::mir_borrowck::ProvidedValue as MirBorrowck, ty::TyCtxt,
         util::Providers,
     },
     session::Session,
-    span::DUMMY_SP,
+    span::{Ident, Span, Symbol, DUMMY_SP},
 };
 use prusti_utils::config;
 
@@ -89,6 +91,42 @@ impl prusti_rustc_interface::driver::Callbacks for PrustiCompilerCalls {
             providers.mir_borrowck = mir_borrowck;
             providers.mir_promoted = mir_promoted;
         });
+    }
+
+    fn after_crate_root_parsing(&mut self, compiler: &Compiler, krate: &mut Crate) -> Compilation {
+        // `prusti-rustc` will pass a `--extern` option indicating where to find
+        // the `prusti-contracts` crate. This crate must be loaded in order to
+        // include the default extern specs (for e.g build-in `assert!`
+        // statements). However, if the user does not explicitly import the
+        // crate in the code or use an `extern crate` statement, then the
+        // compiler will not load the crate.
+        //
+        // To work around this, we add a dummy `extern crate` statement to the
+        // crate if one does not already exist.
+        //
+        // Ideally we could load the prusti-contracts crate directly in the
+        // TyCtxt rather than modifying the crate AST.  However, it does not
+        // seem possible to load the crate directly in the TyCtxt in the
+        // `after_expansion` or `after_analysis` callback as the `cstore` object
+        // appears to be frozen at that point.
+        if compiler.sess.opts.externs.get("prusti_contracts").is_some() {
+            krate.items.push(Box::new(Item {
+                attrs: AttrVec::new(),
+                id: DUMMY_NODE_ID,
+                span: DUMMY_SP,
+                vis: Visibility {
+                    kind: VisibilityKind::Public,
+                    span: DUMMY_SP,
+                    tokens: None,
+                },
+                kind: ItemKind::ExternCrate(
+                    None,
+                    Ident::new(Symbol::intern("prusti_contracts"), DUMMY_SP),
+                ),
+                tokens: None,
+            }));
+        }
+        Compilation::Continue
     }
 
     #[tracing::instrument(level = "debug", skip_all)]

--- a/prusti/src/callbacks.rs
+++ b/prusti/src/callbacks.rs
@@ -15,13 +15,12 @@ use prusti_rustc_interface::{
     hir::{def::DefKind, def_id::LocalDefId},
     index::IndexVec,
     interface::{interface::Compiler, Config},
-    metadata::creader::CStore,
     middle::{
         mir, query::queries::mir_borrowck::ProvidedValue as MirBorrowck, ty::TyCtxt,
         util::Providers,
     },
     session::Session,
-    span::{Ident, Span, Symbol, DUMMY_SP},
+    span::{Ident, Symbol, DUMMY_SP},
 };
 use prusti_utils::config;
 
@@ -113,15 +112,10 @@ impl prusti_rustc_interface::driver::Callbacks for PrustiCompilerCalls {
         if compiler.sess.opts.externs.get("prusti_contracts").is_some() {
             let prusti_contracts_symbol = Symbol::intern("prusti_contracts");
 
-            let is_prusti_contracts_extern_crate = |item: &Item| {
-                if let ItemKind::ExternCrate(_, ident) = item.kind {
-                    ident.name == prusti_contracts_symbol
-                } else {
-                    false
-                }
-            };
-
-            if !krate.items.iter().any(is_prusti_contracts_extern_crate) {
+            if !krate.items.iter().any(|item| match item.kind {
+                ItemKind::ExternCrate(_, ident) => ident.name == prusti_contracts_symbol,
+                _ => false,
+            }) {
                 krate.items.push(Box::new(Item {
                     attrs: AttrVec::new(),
                     id: DUMMY_NODE_ID,

--- a/prusti/src/callbacks.rs
+++ b/prusti/src/callbacks.rs
@@ -110,24 +110,34 @@ impl prusti_rustc_interface::driver::Callbacks for PrustiCompilerCalls {
         // `after_expansion` or `after_analysis` callback as the `cstore` object
         // appears to be frozen at that point.
 
-        let prusti_contracts_symbol = Symbol::intern("prusti_contracts");
+        if compiler.sess.opts.externs.get("prusti_contracts").is_some() {
+            let prusti_contracts_symbol = Symbol::intern("prusti_contracts");
 
-        if compiler.sess.opts.externs.get("prusti_contracts").is_some() && !krate.items.iter().any(|item| matches!(item.kind, ItemKind::ExternCrate(_, ident) if ident.name == prusti_contracts_symbol)) {
-            krate.items.push(Box::new(Item {
-                attrs: AttrVec::new(),
-                id: DUMMY_NODE_ID,
-                span: DUMMY_SP,
-                vis: Visibility {
-                    kind: VisibilityKind::Public,
+            let is_prusti_contracts_extern_crate = |item: &Item| {
+                if let ItemKind::ExternCrate(_, ident) = item.kind {
+                    ident.name == prusti_contracts_symbol
+                } else {
+                    false
+                }
+            };
+
+            if !krate.items.iter().any(is_prusti_contracts_extern_crate) {
+                krate.items.push(Box::new(Item {
+                    attrs: AttrVec::new(),
+                    id: DUMMY_NODE_ID,
                     span: DUMMY_SP,
+                    vis: Visibility {
+                        kind: VisibilityKind::Public,
+                        span: DUMMY_SP,
+                        tokens: None,
+                    },
+                    kind: ItemKind::ExternCrate(
+                        None,
+                        Ident::new(prusti_contracts_symbol, DUMMY_SP),
+                    ),
                     tokens: None,
-                },
-                kind: ItemKind::ExternCrate(
-                    None,
-                    Ident::new(prusti_contracts_symbol, DUMMY_SP),
-                ),
-                tokens: None,
-            }));
+                }));
+            }
         }
         Compilation::Continue
     }

--- a/prusti/src/callbacks.rs
+++ b/prusti/src/callbacks.rs
@@ -109,7 +109,10 @@ impl prusti_rustc_interface::driver::Callbacks for PrustiCompilerCalls {
         // seem possible to load the crate directly in the TyCtxt in the
         // `after_expansion` or `after_analysis` callback as the `cstore` object
         // appears to be frozen at that point.
-        if compiler.sess.opts.externs.get("prusti_contracts").is_some() {
+
+        let prusti_contracts_symbol = Symbol::intern("prusti_contracts");
+
+        if compiler.sess.opts.externs.get("prusti_contracts").is_some() && !krate.items.iter().any(|item| matches!(item.kind, ItemKind::ExternCrate(_, ident) if ident.name == prusti_contracts_symbol)) {
             krate.items.push(Box::new(Item {
                 attrs: AttrVec::new(),
                 id: DUMMY_NODE_ID,
@@ -121,7 +124,7 @@ impl prusti_rustc_interface::driver::Callbacks for PrustiCompilerCalls {
                 },
                 kind: ItemKind::ExternCrate(
                     None,
-                    Ident::new(Symbol::intern("prusti_contracts"), DUMMY_SP),
+                    Ident::new(prusti_contracts_symbol, DUMMY_SP),
                 ),
                 tokens: None,
             }));

--- a/prusti/src/callbacks.rs
+++ b/prusti/src/callbacks.rs
@@ -113,7 +113,8 @@ impl prusti_rustc_interface::driver::Callbacks for PrustiCompilerCalls {
             let prusti_contracts_symbol = Symbol::intern("prusti_contracts");
 
             if !krate.items.iter().any(|item| match item.kind {
-                ItemKind::ExternCrate(_, ident) => ident.name == prusti_contracts_symbol,
+                ItemKind::ExternCrate(Some(original_ident), _) => original_ident == prusti_contracts_symbol,
+                ItemKind::ExternCrate(None, ident) => ident.name == prusti_contracts_symbol,
                 _ => false,
             }) {
                 krate.items.push(Box::new(Item {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-09-01"
+channel = "nightly-2025-09-04"
 components = [ "rustc-dev", "llvm-tools-preview", "rust-std", "rustfmt", "clippy" ]
 profile = "minimal"

--- a/x.py
+++ b/x.py
@@ -226,7 +226,7 @@ def check_smir():
             continue
         if os.path.exists(os.path.join(folder, 'Cargo.toml')):
             completed = subprocess.run(
-                ['grep', 'extern crate', '-nr', folder],
+                ['grep', '^extern crate', '-nr', folder],
                 capture_output=True
             )
             lines = [


### PR DESCRIPTION
Ensures the `prusti-contracts` crate is always loaded so that built-in extern specs (for e.g. `assert!`) are in scope.

This is implemented by adding an `ExternCrate` item to the `Crate` AST after it's been parsed. Ideally, we would leave the AST untouched and instead load the crate manually. However, AFAICT the compiler callbacks interface does not allow us to access the `TyCtxt` during a time when crates can be loaded: in `after_expansion` and `after_analysis` the crate loader is in a "frozen" state. 

Also makes two small changes:

- Removes an invalid option value for the rust-analyzer config (for more info see [here](https://users.rust-lang.org/t/rust-analyzer-checkonsave-command-works-but-shows-invalid-config-warning/128652))
- Updates rust-toolchain to 2025-09-04. For some reason 2025-09-01 was breaking my rust-analyzer IDE support.

One final note: this PR causes three tests to fail:
```
tests/verify/pass/equality/empty-tuple.rs
tests/verify/pass/equality/simple-struct-inequality.rs
tests/verify/pass/no-annotations/modulo.rs
```

They previously passed because the extern specs for `assert!` statements were not loaded. Now they are picking up the spec, they fail due to some incompleteness in the current encoding. 