### PR TITLE
Support associated constants

### DIFF
--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -1,9 +1,8 @@
 use prusti_rustc_interface::{
     middle::{
         mir::{
-            self,
+            self, ConstValue,
             interpret::{GlobalAlloc, Scalar},
-            ConstValue,
         },
         ty,
     },
@@ -13,13 +12,13 @@ use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDe
 use vir::CastType;
 
 use crate::encoders::{
+    MirPureEnc, MirPureEncTask,
     mir_pure::PureKind,
     ty::{
+        RustTyDecomposition,
         generics::{GParams, GenericParamsEnc},
         use_pure::TyUsePureEnc,
-        RustTyDecomposition,
     },
-    MirPureEnc, MirPureEncTask,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -1,8 +1,9 @@
 use prusti_rustc_interface::{
     middle::{
         mir::{
-            self, ConstValue,
+            self,
             interpret::{GlobalAlloc, Scalar},
+            ConstValue,
         },
         ty,
     },
@@ -12,13 +13,13 @@ use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDe
 use vir::CastType;
 
 use crate::encoders::{
-    MirPureEnc, MirPureEncTask,
     mir_pure::PureKind,
     ty::{
-        RustTyDecomposition,
         generics::{GParams, GenericParamsEnc},
         use_pure::TyUsePureEnc,
+        RustTyDecomposition,
     },
+    MirPureEnc, MirPureEncTask,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -150,14 +151,11 @@ impl TaskEncoder for ConstEnc {
                 mir::Const::Unevaluated(uneval, ty) => vir::with_vcx(|vcx| {
                     let resolved = {
                         let typing_env = ty::TypingEnv::post_analysis(vcx.tcx(), def_id);
-                        vcx.tcx().const_eval_resolve(
-                            typing_env,
-                            uneval,
-                            vcx.tcx().def_span(def_id)
-                        )
+                        vcx.tcx()
+                            .const_eval_resolve(typing_env, uneval, vcx.tcx().def_span(def_id))
                     };
                     if let Ok(val) = resolved {
-                        return Self::encode_const_val(deps, val, ty, def_id.into())
+                        Self::encode_const_val(deps, val, ty, def_id.into())
                     } else if let Some(promoted) = uneval.promoted {
                         let task = MirPureEncTask {
                             encoding_depth: encoding_depth + 1,

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -147,18 +147,32 @@ impl TaskEncoder for ConstEnc {
                 def_id,
             } => match const_ {
                 mir::Const::Val(val, ty) => Self::encode_const_val(deps, val, ty, def_id.into())?,
-                mir::Const::Unevaluated(uneval, _) => vir::with_vcx(|vcx| {
-                    let task = MirPureEncTask {
-                        encoding_depth: encoding_depth + 1,
-                        parent_def_id: uneval.def,
-                        param_env: vcx.tcx().param_env(uneval.def),
-                        substs: ty::List::identity_for_item(vcx.tcx(), uneval.def),
-                        kind: PureKind::Constant(uneval.promoted.unwrap()),
-                        caller_def_id: Some(def_id),
+                mir::Const::Unevaluated(uneval, ty) => vir::with_vcx(|vcx| {
+                    let resolved = {
+                        let typing_env = ty::TypingEnv::post_analysis(vcx.tcx(), def_id);
+                        vcx.tcx().const_eval_resolve(
+                            typing_env,
+                            uneval,
+                            vcx.tcx().def_span(def_id)
+                        )
                     };
-                    let expr = deps.require_dep::<MirPureEnc>(task)?.expr;
-                    use vir::Reify;
-                    Ok(expr.reify(vcx, (uneval.def, &[])).downcast_ty())
+                    if let Ok(val) = resolved {
+                        return Self::encode_const_val(deps, val, ty, def_id.into())
+                    } else if let Some(promoted) = uneval.promoted {
+                        let task = MirPureEncTask {
+                            encoding_depth: encoding_depth + 1,
+                            parent_def_id: uneval.def,
+                            param_env: vcx.tcx().param_env(uneval.def),
+                            substs: ty::List::identity_for_item(vcx.tcx(), uneval.def),
+                            kind: PureKind::Constant(promoted),
+                            caller_def_id: Some(def_id),
+                        };
+                        let expr = deps.require_dep::<MirPureEnc>(task)?.expr;
+                        use vir::Reify;
+                        Ok(expr.reify(vcx, (uneval.def, &[])).downcast_ty())
+                    } else {
+                        todo!("const too generic")
+                    }
                 })?,
                 mir::Const::Ty(ty, const_) => {
                     Self::encode_ty_const(deps, const_, ty, def_id.into())?

--- a/prusti-tests/tests/verify/pass/associated-consts.rs
+++ b/prusti-tests/tests/verify/pass/associated-consts.rs
@@ -1,0 +1,11 @@
+use prusti_contracts::*;
+
+struct Bar();
+
+impl Bar {
+    const CONST: i32 = i32::MAX;
+}
+
+fn main() {
+    assert!(Bar::CONST == i32::MAX);
+}

--- a/prusti-tests/tests/verify/pass/associated-consts.rs
+++ b/prusti-tests/tests/verify/pass/associated-consts.rs
@@ -7,5 +7,5 @@ impl Bar {
 }
 
 fn main() {
-    assert!(Bar::CONST == i32::MAX);
+    prusti_assert!(Bar::CONST == i32::MAX);
 }


### PR DESCRIPTION
This PR adds support for promote-able associated constants. 

At the moment, prusti panics if an associated constant cannot be resolved (if the type is too generic, for example) - it seems like it would be nice to raise some nice error instead (on const.rs:173) but I'm not sure what would be appropriate here, help would be appreciated.
