### PR TITLE
Fix a bug in encoding of from/to vars

### DIFF
--- a/prusti-encoder/src/encoders/mir_fn/method.rs
+++ b/prusti-encoder/src/encoders/mir_fn/method.rs
@@ -266,9 +266,8 @@ impl TaskEncoder for MethodEnc {
                 start_stmts.extend(
                     visitor
                         .from_to_vars
-                        .iter()
-                        .flat_map(|(_, v)| v.iter())
-                        .map(|(_, v)| vcx.mk_local_decl_stmt(v, Some(vcx.mk_bool::<false>()))),
+                        .decls()
+                        .map(|v| vcx.mk_local_decl_stmt(v, Some(vcx.mk_bool::<false>()))),
                 );
                 visitor.encoded_blocks[0] = vcx.mk_cfg_block(
                     &vir::CfgBlockLabelData::Start,

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -31,7 +31,7 @@ use prusti_rustc_interface::{
 };
 use prusti_utils::config;
 use task_encoder::{EncodeFullError, TaskEncoder, TaskEncoderDependencies};
-use vir::{CastType, CompType};
+use vir::{CastType, CompType, LocalDeclData};
 
 use crate::encoders::{
     self, FunctionCallEnc, TyUseImpureEnc, WandEnc, WandEncTask,
@@ -45,6 +45,54 @@ use crate::encoders::{
 };
 
 use super::WandEncOutput;
+
+#[derive(Clone, Copy)]
+struct FromToVar<'vir> {
+    decl: vir::LocalDeclBool<'vir>,
+    expr: vir::ExprBool<'vir>,
+}
+
+impl<'vir> FromToVar<'vir> {
+    fn new(vcx: &'vir vir::VirCtxt<'vir>, from: mir::BasicBlock, to: mir::BasicBlock) -> Self {
+        let decl = vcx.mk_local_decl(
+            vir::vir_format!(vcx, "_from_bb{}_to_bb{}", from.index(), to.index()),
+            vir::TYPE_BOOL,
+        );
+        let expr = vcx.mk_local_ex(decl);
+        Self { decl, expr }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct FromToVars<'vir>(FxHashMap<(mir::BasicBlock, mir::BasicBlock), FromToVar<'vir>>);
+
+impl<'vir> FromToVars<'vir> {
+    pub(crate) fn decls(&self) -> impl Iterator<Item = &'vir LocalDeclData<'vir, vir::Bool>> {
+        self.0.values().map(|v| v.decl)
+    }
+
+    fn set_from_to_flag_stmt(
+        &mut self,
+        vcx: &'vir vir::VirCtxt<'vir>,
+        from: mir::BasicBlock,
+        to: mir::BasicBlock,
+    ) -> vir::Stmt<'vir> {
+        let var = self.get_or_create(vcx, from, to);
+        vcx.mk_pure_assign_stmt(var.expr, vcx.mk_bool::<true>())
+    }
+
+    fn get_or_create(
+        &mut self,
+        vcx: &'vir vir::VirCtxt<'vir>,
+        from: mir::BasicBlock,
+        to: mir::BasicBlock,
+    ) -> FromToVar<'vir> {
+        *self
+            .0
+            .entry((from, to))
+            .or_insert_with(|| FromToVar::new(vcx, from, to))
+    }
+}
 
 pub struct ImpureEncVisitor<'vir, 'enc, E: TaskEncoder>
 where
@@ -63,7 +111,7 @@ where
     pub tmp_ctr: usize,
     pub label_ctr: usize,
     pub call_labels: FxHashMap<mir::BasicBlock, (&'vir str, &'vir str)>,
-    pub from_to_vars: FxHashMap<mir::BasicBlock, Vec<(mir::BasicBlock, vir::LocalDeclBool<'vir>)>>,
+    pub from_to_vars: FromToVars<'vir>,
 
     // for the current basic block
     pub current_fpcs: Option<PcgBasicBlock<'enc, 'vir>>,
@@ -395,23 +443,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 let from = choices.from();
                 let conj = successors
                     .iter()
-                    .map(|to| {
-                        let decl = self
-                            .from_to_vars
-                            .get(&from)
-                            .and_then(|tos| tos.iter().find(|(t, _)| t == to))
-                            .map(|(_, decl)| *decl);
-                        let decl = decl.unwrap_or_else(|| {
-                            let name = vir::vir_format!(
-                                self.vcx,
-                                "_from_bb{}_to_bb{}",
-                                from.index(),
-                                to.index()
-                            );
-                            self.vcx.mk_local_decl(name, vir::TYPE_BOOL)
-                        });
-                        self.vcx.mk_local_ex(decl)
-                    })
+                    .map(|to| self.from_to_vars.get_or_create(self.vcx, from, *to).expr)
                     .collect::<Vec<_>>();
                 // Control flow must continue from `choices.from()` to any one of the `successors`
                 self.vcx.mk_disj(self.vcx.alloc_slice(&conj))
@@ -865,14 +897,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
     }
 
     fn set_from_to_flag(&mut self, from: mir::BasicBlock, to: mir::BasicBlock) -> vir::Stmt<'vir> {
-        let name = vir::vir_format!(self.vcx, "_from_bb{}_to_bb{}", from.index(), to.index());
-        let decl = self.vcx.mk_local_decl(name, vir::TYPE_BOOL);
-        let tos = self.from_to_vars.entry(from).or_default();
-        debug_assert!(!tos.contains(&(to, decl)));
-        tos.push((to, decl));
-        let local = self.vcx.mk_local_ex(decl);
-        self.vcx
-            .mk_pure_assign_stmt(local, self.vcx.mk_bool::<true>())
+        self.from_to_vars.set_from_to_flag_stmt(self.vcx, from, to)
     }
 }
 


### PR DESCRIPTION
The crash in `verify/pass/no-annotations/shared-ref.rs` was caused because there can be switch cases like 

```
[case 42 => goto bb8
 case 53 => goto bb8
 otherwise => goto bb7]
 ```
 
 which were crashing because of an assertion that each call to set_from_to_flag is called with distinct pairs of basic blocks.
 
 I removed that assertion and refactored a bit (such that the same decl and expr can be re-used).

This allows `verify/pass/no-annotations/shared-ref.rs` to pass and did not cause any regressions for `verify/pass`.


@Aurel300 @JonasAlaif as far as I can tell there is no need to change to a postorder traversal (perhaps this is already being done?). But let me know if there are other related failing tests.