### PR TITLE
Update PCG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +832,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
 name = "ctrlc"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +942,21 @@ name = "dot"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74b6c4d4a1cff5f454164363c16b72fa12463ca6b31f4b5f2035a65fa3d5906"
+
+[[package]]
+name = "dtor"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "either"
@@ -2074,6 +2111,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smallvec",
+ "specta",
+ "strum",
+ "strum_macros",
  "toml 0.7.8",
  "tracing 0.1.41",
  "tracing-subscriber",
@@ -2981,6 +3021,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "specta"
+version = "2.0.0-rc.22"
+source = "git+https://github.com/zgrannan/specta.git?rev=19d77b5d26bc1251fb3630a007290e299e825bf9#19d77b5d26bc1251fb3630a007290e299e825bf9"
+dependencies = [
+ "ctor",
+ "specta-macros",
+]
+
+[[package]]
+name = "specta-macros"
+version = "2.0.0-rc.18"
+source = "git+https://github.com/zgrannan/specta.git?rev=19d77b5d26bc1251fb3630a007290e299e825bf9#19d77b5d26bc1251fb3630a007290e299e825bf9"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2997,6 +3057,25 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "subtle"

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -630,6 +630,17 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
 
     fn pcg_repack(&mut self, repack_op: &RepackOp<'vir>) {
         comment!(self, "[PCG] {repack_op:?}");
+
+        fn should_ignore(repack_op: &RepackOp<'_>) -> bool {
+            match repack_op {
+                RepackOp::RegainLoanedCapability(..) => true,
+                RepackOp::Weaken(weaken) => {
+                    weaken.from_cap().is_exclusive() && weaken.to_cap().is_read()
+                }
+                _ => false,
+            }
+        }
+
         match repack_op {
             RepackOp::Expand(_) | RepackOp::Collapse(_) => {
                 let (place, capability_kind) = match repack_op {
@@ -665,18 +676,19 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             {
                 self.pcg_weaken(weaken.place())
             }
-            ignored_op @ (RepackOp::RegainLoanedCapability(..) | RepackOp::Weaken(..)) => {
-                self.stmt(self.vcx.mk_comment_stmt(vir::vir_format!(
-                    self.vcx,
-                    "ignored repack op: {ignored_op:?}"
-                )));
-            }
-            unsupported_op => {
-                self.stmt(self.vcx.mk_comment_stmt(vir::vir_format!(
-                    self.vcx,
-                    "unsupported repack op: {unsupported_op:?}"
-                )));
-                self.stmt(self.vcx.mk_exhale_stmt(self.vcx.mk_bool::<false>()));
+            other => {
+                if should_ignore(other) {
+                    self.stmt(self.vcx.mk_comment_stmt(vir::vir_format!(
+                        self.vcx,
+                        "ignored repack op: {other:?}"
+                    )));
+                } else {
+                    self.stmt(self.vcx.mk_comment_stmt(vir::vir_format!(
+                        self.vcx,
+                        "unsupported repack op: {other:?}"
+                    )));
+                    self.stmt(self.vcx.mk_exhale_stmt(self.vcx.mk_bool::<false>()));
+                }
             }
         }
     }

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -660,8 +660,12 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                     }
                 }
             }
-            RepackOp::Weaken(weaken) => self.pcg_weaken(weaken.place()),
-            ignored_op @ RepackOp::RegainLoanedCapability(..) => {
+            RepackOp::Weaken(weaken)
+                if weaken.from_cap().is_exclusive() && weaken.to_cap().is_write() =>
+            {
+                self.pcg_weaken(weaken.place())
+            }
+            ignored_op @ (RepackOp::RegainLoanedCapability(..) | RepackOp::Weaken(..)) => {
                 self.stmt(self.vcx.mk_comment_stmt(vir::vir_format!(
                     self.vcx,
                     "ignored repack op: {ignored_op:?}"

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -660,11 +660,8 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                     }
                 }
             }
-            RepackOp::Weaken(place, CapabilityKind::Exclusive, CapabilityKind::Write) => {
-                self.pcg_weaken(*place)
-            }
-            ignored_op @ (RepackOp::RegainLoanedCapability(..)
-            | RepackOp::Weaken(_, CapabilityKind::Exclusive, CapabilityKind::Read)) => {
+            RepackOp::Weaken(weaken) => self.pcg_weaken(weaken.place()),
+            ignored_op @ RepackOp::RegainLoanedCapability(..) => {
                 self.stmt(self.vcx.mk_comment_stmt(vir::vir_format!(
                     self.vcx,
                     "ignored repack op: {ignored_op:?}"


### PR DESCRIPTION
Merges some updates. There is now a `guide` field for BorrowPcgExpansion (to be consistent with owned pcg expansions)

This does not cause any new tests to pass or fail