### PR TITLE
Cleanup and fix various issues

### DIFF
--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -1,6 +1,6 @@
 use prusti_rustc_interface::{
     middle::{mir, ty},
-    span::{Symbol, def_id::DefId},
+    span::def_id::DefId,
 };
 use prusti_utils::config;
 use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
@@ -11,7 +11,7 @@ use crate::encoders::{
     r#const::ConstEncTask,
     ty::{
         RustTyDecomposition, TySpecifics,
-        generics::{GArgs, GParams, GenericParamsEnc},
+        generics::{GParams, GenericParamsEnc},
         interpretation::float::FloatDomain,
         pure::{TyPurePrimData, TyPurePrimDataKind},
         use_pure::TyUsePureEnc,
@@ -170,19 +170,22 @@ impl MirBuiltinEnc {
         let params = GParams::from(def_id);
         let generics = deps.require_dep::<GenericParamsEnc>(params)?;
 
-        let ty_task = RustTyDecomposition::from_ty(src_ty.peel_refs(), vcx.tcx(), params);
-        let src_array_pure = deps.require_dep::<TyUsePureEnc>(ty_task)?.expect_array();
-        //let src_array_impure = deps.require_dep::<TyUseImpureEnc>(ty_task)?;
-        let ty_task = RustTyDecomposition::from_ty(src_ty, vcx.tcx(), params);
-        let src_ref_pure = deps.require_dep::<TyUsePureEnc>(ty_task)?;
-        let src_ref_impure = deps.require_dep::<TyUseImpureEnc>(ty_task)?;
+        let src_ty_inner = src_ty.peel_refs();
+        let dst_ty_inner = dst_ty.peel_refs();
 
-        let ty_task = RustTyDecomposition::from_ty(dst_ty.peel_refs(), vcx.tcx(), params);
+        let ty_task = RustTyDecomposition::from_ty(src_ty_inner, vcx.tcx(), params);
+        let src_array_pure = deps.require_dep::<TyUsePureEnc>(ty_task)?.expect_array();
+
+        let src_ty = RustTyDecomposition::from_ty(src_ty, vcx.tcx(), params);
+        let src_ref_pure = deps.require_dep::<TyUsePureEnc>(src_ty)?;
+        let src_ref_impure = deps.require_dep::<TyUseImpureEnc>(src_ty)?;
+
+        let ty_task = RustTyDecomposition::from_ty(dst_ty_inner, vcx.tcx(), params);
         let dst_array_pure = deps.require_dep::<TyUsePureEnc>(ty_task)?.expect_array();
-        //let dst_array_impure = deps.require_dep::<TyUseImpureEnc>(ty_task)?;
-        let ty_task = RustTyDecomposition::from_ty(dst_ty, vcx.tcx(), params);
-        let dst_ref_pure = deps.require_dep::<TyUsePureEnc>(ty_task)?;
-        let dst_ref_impure = deps.require_dep::<TyUseImpureEnc>(ty_task)?;
+
+        let dst_ty = RustTyDecomposition::from_ty(dst_ty, vcx.tcx(), params);
+        let dst_ref_pure = deps.require_dep::<TyUsePureEnc>(dst_ty)?;
+        let dst_ref_impure = deps.require_dep::<TyUseImpureEnc>(dst_ty)?;
 
         let ref_src_decl = vcx.mk_local_decl("src", vir::TYPE_REF);
         let ref_src_ex = vcx.mk_local_ex(ref_src_decl);
@@ -219,18 +222,18 @@ impl MirBuiltinEnc {
 
         let src_value = match &src_ref_pure.specifics {
             TySpecifics::ImmRef(data) => data.value_access(snap_src.downcast_ty()),
-            TySpecifics::MutRef(data) => data.deref_snap(snap_src.downcast_ty()),
+            TySpecifics::MutRef(data) => data.value_access(snap_src.downcast_ty()),
             _ => unreachable!(),
         }
         .downcast_ty();
         let dst_value = match &dst_ref_pure.specifics {
             TySpecifics::ImmRef(data) => data.value_access(snap_dst.downcast_ty()),
-            TySpecifics::MutRef(data) => data.deref_snap(snap_dst.downcast_ty()),
+            TySpecifics::MutRef(data) => data.value_access(snap_dst.downcast_ty()),
             _ => unreachable!(),
         }
         .downcast_ty();
 
-        let src_len = match src_ty.peel_refs().kind() {
+        let src_len = match src_ty_inner.kind() {
             ty::TyKind::Array(_, len) => {
                 let const_enc = deps.require_dep::<ConstEnc>(ConstEncTask::Ty {
                     const_: *len,
@@ -248,34 +251,16 @@ impl MirBuiltinEnc {
         let mut posts = vec![dst_ref_impure.ref_to_pred(vcx, ref_dst_ex, None)];
         let mut pres_undo = vec![dst_ref_impure.ref_to_pred(vcx, ref_dst_ex, None)];
         let mut posts_undo = vec![src_ref_impure.ref_to_pred(vcx, ref_src_ex, None)];
-        if matches!(src_ty.kind(), ty::TyKind::Ref(_, _, ty::Mutability::Mut))
-            && matches!(dst_ty.kind(), ty::TyKind::Ref(_, _, ty::Mutability::Mut))
-        {
-            // TODO: Move this v into a new method RustTyDecomposition::decompose_local_ctx(?)
-            //   The issue is that we want a `p_Param` predicate instance even
-            //   though we are not actually creating a generic method (which
-            //   would allow us to refer to a type variable like `T$0: Type`),
-            //   but we also don't want to fully monomorphise the predicate to
-            //   the array resp. slice. This might also be needed for the
-            //   indirect encoder, as it seems like a general need for mutref
-            //   targets if they are kept generic?
-            let dummy_param = vcx
-                .tcx()
-                .mk_ty_from_kind(ty::TyKind::Param(ty::ParamTy::new(0, Symbol::intern("T"))));
-            let mut ty_task_param = RustTyDecomposition::from_ty(
-                dummy_param,
-                vcx.tcx(),
-                GParams::new(
-                    vcx.tcx().mk_args(&[dummy_param.into()]),
-                    ty::ParamEnv::empty(),
-                    false,
-                ),
-            );
-            ty_task_param.args =
-                GArgs::new(params, vcx.tcx().mk_args(&[src_ty.peel_refs().into()]));
+        if src_ty.ty.specifics.is_mutref() && dst_ty.ty.specifics.is_mutref() {
+            let ty_task_param = src_ty
+                .ty
+                .expect_mutref()
+                .decompose_context(src_ty.ty.params, src_ty.args);
             let src_param_impure = deps.require_dep::<TyUseImpureEnc>(ty_task_param)?;
-            ty_task_param.args =
-                GArgs::new(params, vcx.tcx().mk_args(&[dst_ty.peel_refs().into()]));
+            let ty_task_param = dst_ty
+                .ty
+                .expect_mutref()
+                .decompose_context(src_ty.ty.params, dst_ty.args);
             let dst_param_impure = deps.require_dep::<TyUseImpureEnc>(ty_task_param)?;
 
             pres.push(src_param_impure.ref_to_pred(
@@ -462,7 +447,7 @@ impl MirBuiltinEnc {
                         let prim_res_ty = res_ty_enc.expect_primitive();
                         let operand_value = match &operand_ref_pure.specifics {
                             TySpecifics::ImmRef(data) => data.value_access(snap_arg),
-                            TySpecifics::MutRef(data) => data.deref_snap(snap_arg),
+                            TySpecifics::MutRef(data) => data.value_access(snap_arg),
                             _ => unreachable!(),
                         }
                         .downcast_ty();

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -418,14 +418,13 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                         .into()
                 }
                 TyKind::Ref(.., ty::Mutability::Mut) => {
-                    let e_rvalue_ty = self.ty_use_pure(rvalue_ty);
                     let p_rvalue_ty = self.ty_use_impure(rvalue_ty);
                     let (place_expr, _, _, _) = self.encode_place_with_snap(Place::from(*place));
 
-                    let inner = e_rvalue_ty.expect_mutref();
+                    let inner = p_rvalue_ty.expect_mutref();
                     let place_ref = place_expr.expr.expect_predicate();
                     EncodedRvalue {
-                        expr: inner.prim_to_snap(place_ref).upcast_ty(),
+                        expr: inner.prim_to_snap_assign(place_ref).upcast_ty(),
                         post_assign_folds: Some(Box::new(move |lhs_place| {
                             p_rvalue_ty.fold(None, lhs_place, None, None, None)
                         })),

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -1,6 +1,5 @@
 use crate::encoders::{
-    FunctionCallEnc, MirLocalDefEnc, MirLocalDefEncOutput, MirLocalDefEncTask, TyUseImpureEnc,
-    ViperTupleEnc,
+    FunctionCallEnc, MirLocalDefEnc, MirLocalDefEncOutput, MirLocalDefEncTask, ViperTupleEnc,
     mir_fn::{CallTaskDescription, RustSignature},
     mir_shared::PureRvalueEnc,
     ty::{
@@ -245,6 +244,7 @@ struct Enc<'vir: 'enc, 'enc> {
     rel1_mode: bool,
     before_expiry_mode: bool,
     local_defs: MirLocalDefEncOutput<'vir>,
+    impure_context: bool,
 }
 
 struct EncodedPlace<'vir> {
@@ -347,6 +347,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
             rel1_mode: false,
             before_expiry_mode: false,
             local_defs,
+            impure_context: matches!(kind, PureKind::Spec(_)),
         }
     }
 
@@ -834,7 +835,9 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
                     let place_ref = encoded_place
                         .place_ref
                         .unwrap_or_else(|| self.vcx.mk_null().lazy());
-                    Ok(e_rvalue_ty.prim_to_snap(place_ref).upcast_ty())
+                    Ok(e_rvalue_ty
+                        .prim_to_snap(place_ref, encoded_place.snap)
+                        .upcast_ty())
                 } else {
                     let e_rvalue_ty = rvalue_snapshot_encoding.expect_immref();
                     // For shared borrows we want to use just the snapshot
@@ -898,61 +901,61 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         elem: mir::PlaceElem<'vir>,
         encoded_place: EncodedPlace<'vir>,
     ) -> EncodedPlace<'vir> {
-        let ty_task =
-            vir::with_vcx(|vcx| RustTyDecomposition::from_ty(place_ty.ty, vcx.tcx(), self.context));
+        let e_ty = self.ty_use(place_ty.ty);
         match elem {
             mir::ProjectionElem::Deref => {
                 assert!(place_ty.variant_index.is_none());
                 match place_ty.ty.kind() {
                     TyKind::Adt(adt, _) if adt.is_box() => {
-                        let e_ty_impure = self.deps.require_dep::<TyUseImpureEnc>(ty_task).unwrap();
-                        let struct_like = e_ty_impure.expect_variant_opt(place_ty.variant_index);
-                        let e_ty_pure = self.deps.require_dep::<TyUsePureEnc>(ty_task).unwrap();
-                        let proj = e_ty_pure.expect_variant_opt(place_ty.variant_index)
-                            [abi::FieldIdx::ZERO];
+                        let proj =
+                            e_ty.expect_variant_opt(place_ty.variant_index)[abi::FieldIdx::ZERO];
                         let proj_app = proj.read(encoded_place.snap.downcast_ty());
-                        let place_ref = encoded_place
-                            .place_ref
-                            .map(|pr| struct_like[abi::FieldIdx::ZERO].field_ref(pr));
+                        let place_ref = encoded_place.place_ref.map(|pr| proj.field_ref(pr));
                         EncodedPlace::new(proj_app, place_ref)
                     }
                     TyKind::Ref(.., ty::Mutability::Not) => {
-                        let e_ty = self
-                            .deps
-                            .require_dep::<TyUsePureEnc>(ty_task)
-                            .unwrap()
-                            .expect_immref();
+                        let e_ty = e_ty.expect_immref();
                         let val_expr = e_ty.value_access(encoded_place.snap.downcast_ty());
                         EncodedPlace::new(val_expr, encoded_place.place_ref)
                     }
                     TyKind::Ref(.., ty::Mutability::Mut) => {
-                        let e_ty = self
+                        assert!(
+                            self.impure_context,
+                            "mutable deref is not allowed in a pure context (e.g. pure functions)"
+                        );
+                        let e_ty = e_ty.expect_mutref();
+                        let val_expr = e_ty.deref_access(encoded_place.snap.downcast_ty());
+                        // TODO: avoid all of this by using shallow and deep snapshots
+                        let ty_task =
+                            RustTyDecomposition::from_ty(place_ty.ty, self.vcx.tcx(), self.context);
+                        let inner = ty_task.ty.expect_mutref();
+                        let normalized =
+                            inner.decompose_compare_normalize(ty_task.ty.params, ty_task.args);
+                        let caster = self
                             .deps
-                            .require_dep::<TyUsePureEnc>(ty_task)
-                            .unwrap()
-                            .expect_mutref();
-                        let val_expr = e_ty.deref_snap(encoded_place.snap.downcast_ty());
+                            .require_dep::<crate::GArgsCastEnc<crate::Pure>>(normalized)
+                            .unwrap();
+                        let inner_ty_task =
+                            inner.decompose_context(ty_task.ty.params, ty_task.args);
+                        let inner_ty = self
+                            .deps
+                            .require_dep::<crate::encoders::TyUseImpureEnc>(inner_ty_task)
+                            .unwrap();
+                        let val_expr = inner_ty.ref_to_snap(val_expr);
+                        let val_expr = caster.cast_to_caller_ctx(val_expr);
                         EncodedPlace::new(val_expr, encoded_place.place_ref)
                     }
                     _ => unreachable!(),
                 }
             }
             mir::ProjectionElem::Field(field_idx, _ty) => {
-                let e_ty = self.deps.require_dep::<TyUseImpureEnc>(ty_task).unwrap();
-                let struct_like = e_ty.expect_variant_opt(place_ty.variant_index);
-                let e_ty_pure = self.deps.require_dep::<TyUsePureEnc>(ty_task).unwrap();
-                let proj = e_ty_pure.expect_variant_opt(place_ty.variant_index)[field_idx];
+                let proj = e_ty.expect_variant_opt(place_ty.variant_index)[field_idx];
                 let proj_app = proj.read(encoded_place.snap.downcast_ty());
-                let place_ref = encoded_place
-                    .place_ref
-                    .map(|pr| struct_like[field_idx].field_ref(pr));
+                let place_ref = encoded_place.place_ref.map(|pr| proj.field_ref(pr));
                 EncodedPlace::new(proj_app, place_ref)
             }
             mir::ProjectionElem::Index(idx) => {
-                let e_ty = self.deps.require_dep::<TyUseImpureEnc>(ty_task).unwrap();
-                let array_like = e_ty.expect_array();
-                let e_ty_pure = self.deps.require_dep::<TyUsePureEnc>(ty_task).unwrap();
-                let proj = e_ty_pure.expect_array();
+                let proj = e_ty.expect_array();
                 let idx = self
                     .encode_place_with_ref(curr_ver, mir::Place::from(idx).into())
                     .snap;
@@ -966,7 +969,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
                 let proj_app = proj.index(encoded_place.snap.downcast_ty(), idx);
                 let place_ref = encoded_place
                     .place_ref
-                    .map(|pr| array_like.ref_to_index_ref(pr, idx));
+                    .map(|pr| proj.ref_to_index_ref(pr, idx));
                 EncodedPlace::new(proj_app, place_ref)
             }
             mir::ProjectionElem::Downcast(..) => encoded_place,

--- a/prusti-encoder/src/encoders/ty/data.rs
+++ b/prusti-encoder/src/encoders/ty/data.rs
@@ -130,6 +130,10 @@ impl<'vir, D: TyDatas<'vir>> TySpecifics<'vir, D> {
     pub fn is_param(&self) -> bool {
         matches!(self, Self::Param(_))
     }
+
+    pub fn is_mutref(&self) -> bool {
+        matches!(self, Self::MutRef(_))
+    }
 }
 
 impl<'vir, D: TyDatas<'vir>> TyData<'vir, D> {

--- a/prusti-encoder/src/encoders/ty/generics/args.rs
+++ b/prusti-encoder/src/encoders/ty/generics/args.rs
@@ -48,6 +48,22 @@ impl<'tcx> GArgs<'tcx> {
         }
     }
 
+    /// Given the definitions:
+    /// ```
+    /// struct S0<'a, T0, U0>
+    /// struct S1<'a, T1, U1> {
+    ///     field: S0<'a, U1, T1>,
+    /// }
+    /// # { field: &'a mut T }
+    /// fn foo<'x>(x: S1<'x, u32, bool>)
+    /// # {}
+    /// ```
+    /// We will decompose `S1<'x, u32, bool>` into a `GArgs` of `['x, u32, bool]`.
+    /// When traversing into the definition of `S1`, the field `S0<'a, U1, T1>` is
+    /// decomposed into a `GArgs` of `['a, U1, T1]`. This function will substitute
+    /// the first into the second resulting in the `GArgs` of `['x, bool, u32]`.
+    /// This is useful when encoding the field of `S1` in the context of `foo`
+    /// (without any e.g. predicate that needs to be general for any use of `S1`).
     pub fn substitute(self, to_sub_in: GArgs<'tcx>) -> GArgs<'tcx> {
         assert_eq!(self.context.rust_params().len(), to_sub_in.args.len());
         let args = vir::with_vcx(|vcx| {

--- a/prusti-encoder/src/encoders/ty/generics/args.rs
+++ b/prusti-encoder/src/encoders/ty/generics/args.rs
@@ -47,4 +47,19 @@ impl<'tcx> GArgs<'tcx> {
             other => panic!("expected type parameter, {other:?}"),
         }
     }
+
+    pub fn substitute(self, to_sub_in: GArgs<'tcx>) -> GArgs<'tcx> {
+        assert_eq!(self.context.rust_params().len(), to_sub_in.args.len());
+        let args = vir::with_vcx(|vcx| {
+            let args = self
+                .args
+                .iter()
+                .map(|arg| ty::EarlyBinder::bind(*arg).instantiate(vcx.tcx(), to_sub_in.args));
+            vcx.tcx().mk_args_from_iter(args)
+        });
+        GArgs {
+            context: to_sub_in.context,
+            args,
+        }
+    }
 }

--- a/prusti-encoder/src/encoders/ty/impure.rs
+++ b/prusti-encoder/src/encoders/ty/impure.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
-use vir::{CallableIdn, CastType, FunctionIdn, HasType, MethodIdn, PredicateIdn};
+use vir::{CastType, FunctionIdn, HasType, MethodIdn, PredicateIdn};
 
 use crate::encoders::{Impure, ty::use_impure::TyUseImpure};
 
@@ -40,12 +40,16 @@ pub struct TyImpureImmRefData {}
 
 #[derive(Debug, Clone, Copy)]
 pub struct TyImpureMutRefData<'vir> {
-    pub deref_func: vir::FunctionIdn<'vir, (vir::Ref, vir::ManyTyVal, vir::ManyCSnap), vir::Ref>,
+    pub pure: <PureTyDatas as TyDatas<'vir>>::MutRefData,
+    /// For use in constructing a snapshot from just a `Ref`.
+    pub arbitrary_value: vir::FunctionIdn<'vir, vir::Ref, vir::CSnap>,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct TyImpureArrayData<'vir> {
-    pub index_access: vir::FunctionIdn<'vir, (vir::Ref, vir::Int), vir::Ref>,
+    /// Function to access the ref at the given index.
+    pub ref_to_index_ref:
+        vir::FunctionIdn<'vir, (vir::Ref, vir::Int, vir::ManyTyVal, vir::ManyCSnap), vir::Ref>,
     #[allow(dead_code)]
     pub index_frame:
         vir::FunctionIdn<'vir, (vir::Ref, vir::Int, vir::ManyTyVal, vir::ManyCSnap), vir::CSnap>,
@@ -102,7 +106,7 @@ pub struct TyImpureEncLocal<'vir> {
     pub fields: Vec<vir::FieldDyn<'vir>>,
     pub predicates: Vec<vir::Predicate<'vir>>,
     pub function_snap: vir::Function<'vir>,
-    pub ref_to_field_refs: Vec<vir::Function<'vir>>,
+    pub functions: Vec<vir::Function<'vir>>,
     pub method_assign: vir::Method<'vir>,
     pub methods: Vec<vir::Method<'vir>>,
 }
@@ -136,26 +140,6 @@ impl TaskEncoder for TyImpureEnc {
             let ref_self_decl = builder.ref_self_decl();
             let ref_self = vcx.mk_local_ex(ref_self_decl);
 
-            let self_pred_ident = builder.inner.predicate_ident(
-                "",
-                (
-                    ref_self_decl.ty(),
-                    builder.params.ty_args(),
-                    builder.params.const_args(),
-                ),
-            );
-            let snap_func_ident = builder
-                .inner
-                .function_ident::<(vir::Ref, vir::ManyTyVal, vir::ManyCSnap), vir::Snap>(
-                    "snap",
-                    (
-                        ref_self_decl.ty(),
-                        builder.params.ty_args(),
-                        builder.params.const_args(),
-                    ),
-                    snapshot,
-                );
-
             // assign method
             let value_decl = vcx.mk_local_decl("value", snapshot);
             let value = vcx.mk_local_ex(value_decl);
@@ -166,8 +150,8 @@ impl TaskEncoder for TyImpureEnc {
                 (ref_self_decl, builder.params.ty_decls(), builder.params.const_decls(), value_decl),
                 &[],
                 &[
-                    vir::expr! { [self_pred_ident](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]]) },
-                    vir::expr! { ([snap_func_ident](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])) == (value) },
+                    vir::expr! { [builder.ref_to_pred](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]]) },
+                    vir::expr! { ([builder.ref_to_snap](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])) == (value) },
                 ],
             );
 
@@ -178,15 +162,9 @@ impl TaskEncoder for TyImpureEnc {
                 TySpecifics::Opaque(opaque) => TySpecifics::Opaque(
                     super::kinds::opaque::ty_impure(opaque, deps, &mut builder)?,
                 ),
-                TySpecifics::ArrayLike(array) => {
-                    TySpecifics::ArrayLike(super::kinds::arraylike::ty_impure(
-                        &ty,
-                        array,
-                        deps,
-                        &mut builder,
-                        snap_func_ident,
-                    )?)
-                }
+                TySpecifics::ArrayLike(array) => TySpecifics::ArrayLike(
+                    super::kinds::arraylike::ty_impure(&ty, array, deps, &mut builder)?,
+                ),
                 TySpecifics::Primitive(prim) => TySpecifics::Primitive(
                     super::kinds::primitive::ty_impure(prim, deps, &mut builder)?,
                 ),
@@ -212,8 +190,8 @@ impl TaskEncoder for TyImpureEnc {
             };
             let data = TyImpureRef {
                 inhabited: ty.inhabited,
-                ref_to_pred: self_pred_ident,
-                ref_to_snap: snap_func_ident.cast_ty(snap_func_ident.arity()),
+                ref_to_pred: builder.ref_to_pred,
+                ref_to_snap: builder.ref_to_snap,
                 method_assign,
             };
             let output = TyData::new(data, ty.inhabited, specifics).alloc();
@@ -227,7 +205,7 @@ impl TaskEncoder for TyImpureEnc {
             for field in output.fields {
                 program.add_field(field);
             }
-            for field_projection in output.ref_to_field_refs {
+            for field_projection in output.functions {
                 program.add_function(field_projection);
             }
             program.add_function(output.function_snap);
@@ -245,6 +223,9 @@ impl TaskEncoder for TyImpureEnc {
 pub(crate) struct PredicateBuilder<'vir> {
     pub(super) params: GenericParams<'vir>,
     snapshot: vir::TypeSnap<'vir>,
+    pub(super) ref_to_pred: PredicateIdn<'vir, (vir::Ref, vir::ManyTyVal, vir::ManyCSnap)>,
+    pub(super) ref_to_snap:
+        FunctionIdn<'vir, (vir::Ref, vir::ManyTyVal, vir::ManyCSnap), vir::Snap>,
 
     pub(super) inner: PredicateBuilderInner<'vir>,
 }
@@ -272,27 +253,75 @@ impl<'vir> PredicateBuilder<'vir> {
     ) -> Self {
         let params = deps.require_dep::<GenericParamsEnc>(ty.params).unwrap();
         let name = vir::vir_format!(vcx, "p_{}", ty.name());
+        let inner = PredicateBuilderInner {
+            vcx,
+            name,
+            fields: Vec::new(),
+            functions: Vec::new(),
+            methods: Vec::new(),
+            predicates: Vec::new(),
+            function_snap: None,
+        };
+
+        let ref_self_decl = inner.ref_self_decl();
+        let args = (ref_self_decl.ty(), params.ty_args(), params.const_args());
+        let ref_to_pred = inner.predicate_ident("", args);
+        let ref_to_snap = inner.function_ident("snap", args, snapshot);
+
         PredicateBuilder {
             params,
             snapshot,
-            inner: PredicateBuilderInner {
-                vcx,
-                name,
-                fields: Vec::new(),
-                functions: Vec::new(),
-                methods: Vec::new(),
-                predicates: Vec::new(),
-                function_snap: None,
-            },
+            ref_to_pred,
+            ref_to_snap,
+            inner,
         }
-    }
-
-    pub(crate) fn snap_type(&self) -> vir::TypeSnap<'vir> {
-        self.snapshot
     }
 
     pub(crate) fn csnap_type(&self) -> vir::TypeCSnap<'vir> {
         self.snapshot.downcast_ty()
+    }
+
+    pub(crate) fn mk_predicate(
+        &mut self,
+        name: &str,
+        expr: Option<vir::ExprBool<'vir>>,
+    ) -> PredicateIdn<'vir, (vir::Ref, vir::ManyTyVal, vir::ManyCSnap)> {
+        let ref_self_decl = self.ref_self_decl();
+        let args = (
+            ref_self_decl.ty(),
+            self.params.ty_args(),
+            self.params.const_args(),
+        );
+        let params = (
+            ref_self_decl,
+            self.params.ty_decls(),
+            self.params.const_decls(),
+        );
+        self.inner.predicate(name, args, params, expr)
+    }
+
+    /// Creates the `snap` function, sets the precondition to
+    /// `acc(ref_to_pred(self, ...))`, and the body as
+    /// `unfolding acc(ref_to_pred(self, ...)) in inner`. Note that the `inner`
+    /// will be wrapped in an unfolding and should not include it.
+    pub(crate) fn mk_snap_function(&mut self, inner: Option<vir::ExprCSnap<'vir>>) {
+        let ref_self_decl = self.ref_self_decl();
+        let ref_self = self.vcx.mk_local_ex(ref_self_decl);
+        let params = (
+            ref_self_decl,
+            self.params.ty_decls(),
+            self.params.const_decls(),
+        );
+        let pred = vir::expr! {
+            acc([self.ref_to_pred](ref_self, [..[self.params.ty_exprs()]], [..[self.params.const_exprs()]]))
+        };
+        let expr = inner.map(|e| vir::expr! {
+            unfolding ([self.ref_to_pred](ref_self, [..[self.params.ty_exprs()]], [..[self.params.const_exprs()]])) in (e)
+        }.upcast_ty());
+        let function = self
+            .inner
+            .mk_function(self.ref_to_snap, params, &[pred], &[], expr);
+        self.inner.function_snap = Some(function);
     }
 }
 
@@ -335,12 +364,11 @@ impl<'vir> PredicateBuilderInner<'vir> {
     }
 
     pub(crate) fn predicate_ident<A: vir::Arity>(
-        &mut self,
+        &self,
         name: &str,
         args: A::Tys<'vir>,
     ) -> vir::PredicateIdn<'vir, A> {
         let name = self.ident_str(name);
-
         vir::PredicateIdn::new(vir::ViperIdent::new(name), args)
     }
 
@@ -358,7 +386,7 @@ impl<'vir> PredicateBuilderInner<'vir> {
     }
 
     pub(crate) fn function_ident<A: vir::Arity, T: vir::CompType>(
-        &mut self,
+        &self,
         name: &str,
         args: A::Tys<'vir>,
         ret: vir::Type<'vir, T>,
@@ -368,29 +396,21 @@ impl<'vir> PredicateBuilderInner<'vir> {
         vir::FunctionIdn::new(vir::ViperIdent::new(name), args, ret)
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn mk_function<A: vir::Arity, T: vir::CompType>(
+    fn mk_function<A: vir::Arity, T: vir::CompType>(
         &self,
-        name: &str,
-        args: A::Tys<'vir>,
-        ret: vir::Type<'vir, T>,
+        ident: FunctionIdn<'vir, A, T>,
         params: A::Locals<'_, 'vir>,
         pres: &[vir::ExprBool<'vir>],
         posts: &[vir::ExprBool<'vir>],
         expr: Option<vir::Expr<'vir, T>>,
-    ) -> (vir::FunctionIdn<'vir, A, T>, vir::Function<'vir>) {
-        let name = self.ident_str(name);
-        let ident = vir::FunctionIdn::new(vir::ViperIdent::new(name), args, ret);
-        (
+    ) -> vir::Function<'vir> {
+        self.vcx.mk_function(
             ident,
-            self.vcx.mk_function(
-                ident,
-                params,
-                self.vcx.alloc_slice(pres),
-                self.vcx.alloc_slice(posts),
-                None,
-                expr,
-            ),
+            params,
+            self.vcx.alloc_slice(pres),
+            self.vcx.alloc_slice(posts),
+            None,
+            expr,
         )
     }
 
@@ -405,8 +425,10 @@ impl<'vir> PredicateBuilderInner<'vir> {
         posts: &[vir::ExprBool<'vir>],
         expr: Option<vir::Expr<'vir, T>>,
     ) -> vir::FunctionIdn<'vir, A, T> {
-        let (ident, function) = self.mk_function(name, args, ret, params, pres, posts, expr);
-        self.functions.push(function);
+        let name = self.ident_str(name);
+        let ident = vir::FunctionIdn::new(vir::ViperIdent::new(name), args, ret);
+        self.functions
+            .push(self.mk_function(ident, params, pres, posts, expr));
         ident
     }
 
@@ -443,7 +465,7 @@ impl<'vir> PredicateBuilderInner<'vir> {
             fields: self.fields,
             predicates: self.predicates,
             function_snap: self.function_snap.unwrap(),
-            ref_to_field_refs: self.functions,
+            functions: self.functions,
             method_assign,
             methods: self.methods,
         }

--- a/prusti-encoder/src/encoders/ty/indirect.rs
+++ b/prusti-encoder/src/encoders/ty/indirect.rs
@@ -2,7 +2,7 @@ use pcg::borrow_pcg::region_projection::LifetimeProjection;
 use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 use vir::{CastType, Reify};
 
-use crate::encoders::ty::RustTyDecomposition;
+use crate::encoders::{TyUseImpureEnc, ty::RustTyDecomposition};
 
 use super::{data::TySpecifics, use_pure::TyUsePureEnc};
 
@@ -67,14 +67,14 @@ impl TaskEncoder for IndirectPredicatesEnc {
                 // This is why we should return `opaque_behind_a(x)` here.
                 TySpecifics::Param(_) | TySpecifics::Opaque(_) | TySpecifics::ArrayLike(_) => (),
                 TySpecifics::MutRef((data, ref_domain)) => {
-                    let inner_ty = data.decompose_normalize(ty.args);
+                    let inner_ty = data.decompose_context(ty.ty.params, ty.args);
+                    let inner_impure = deps.require_dep::<TyUseImpureEnc>(inner_ty)?;
                     predicate_applications.push(vcx.mk_lazy_expr(
                         "ref_indirect",
                         vir::TYPE_BOOL,
                         Box::new(move |vcx, self_expr: vir::ExprSnap<'vir>| {
-                            ref_domain
-                                .inner_predicate(vcx, self_expr.downcast_ty())
-                                .kind
+                            let addr = ref_domain.deref_access(self_expr.downcast_ty());
+                            inner_impure.ref_to_pred(vcx, addr, None).kind
                         }),
                     ));
                     if let Some(new_projection) =
@@ -94,7 +94,10 @@ impl TaskEncoder for IndirectPredicatesEnc {
                                             inner_expr
                                                 .reify(
                                                     vcx,
-                                                    ref_domain.deref_snap(self_expr.downcast_ty()),
+                                                    inner_impure.ref_to_snap(
+                                                        ref_domain
+                                                            .deref_access(self_expr.downcast_ty()),
+                                                    ),
                                                 )
                                                 .kind
                                         }),

--- a/prusti-encoder/src/encoders/ty/interpretation/real.rs
+++ b/prusti-encoder/src/encoders/ty/interpretation/real.rs
@@ -1,5 +1,5 @@
 use task_encoder::{EncodeFullError, TaskEncoderDependencies};
-use vir::{AdtDestructorData, CastType, FunctionIdn, HasType, TYPE_PERM};
+use vir::{AdtDestructorData, CastType, FunctionIdn, TYPE_PERM};
 
 use crate::encoders::ty::{
     impure::{PredicateBuilder, TyImpureBuiltin, TyImpureEnc},
@@ -36,29 +36,10 @@ pub(crate) fn ty_impure<'vir>(
     let prim_field = builder.field("val", snap_type);
 
     // main predicate
-    let self_pred = builder.predicate::<vir::Ref>(
-        "",
-        ref_self_decl.ty(),
-        (ref_self_decl,),
-        Some(vir::expr! { acc((ref_self).[prim_field]) }),
-    );
+    builder.mk_predicate("", Some(vir::expr! { acc((ref_self).[prim_field]) }));
 
     // Ref-to-snap
-    builder.function_snap = Some(
-        builder
-            .mk_function::<vir::Ref, _>(
-                "snap",
-                ref_self_decl.ty(),
-                snap_type,
-                (ref_self_decl,),
-                &[vir::expr! { acc([self_pred](ref_self)) }],
-                &[],
-                Some(vir::expr! {
-                    unfolding ([self_pred](ref_self)) in ([prim_field](ref_self))
-                }),
-            )
-            .1,
-    );
+    builder.mk_snap_function(Some(vir::expr! { [prim_field](ref_self) }));
 
     Ok(())
 }

--- a/prusti-encoder/src/encoders/ty/kinds/arraylike.rs
+++ b/prusti-encoder/src/encoders/ty/kinds/arraylike.rs
@@ -9,7 +9,7 @@ use crate::encoders::{
     },
 };
 use task_encoder::{EncodeFullError, TaskEncoderDependencies};
-use vir::{CastType, FunctionIdn, HasType};
+use vir::{CastType, HasType};
 
 pub(crate) fn ty_pure<'vir>(
     data: &ArrayData<'vir, RustTyDatas>,
@@ -22,8 +22,19 @@ pub(crate) fn ty_pure<'vir>(
         vir::TYPE_PSNAP,
     );
     let len = builder.function("len", builder.self_type(), vir::TYPE_INT);
+    let args = (
+        vir::TYPE_REF,
+        vir::TYPE_INT,
+        builder.params.ty_args(),
+        builder.params.const_args(),
+    );
+    let ref_to_index_ref = builder.function("index_ref", args, vir::TYPE_REF);
     Ok(ArrayData::new(
-        TyPureArrayData { index_access, len },
+        TyPureArrayData {
+            index_access,
+            len,
+            ref_to_index_ref,
+        },
         data.inhabited,
         data.slice,
     ))
@@ -34,7 +45,6 @@ pub(crate) fn ty_impure<'vir>(
     data: &ArrayData<'vir, (RustTyDatas, PureTyDatas)>,
     deps: &mut TaskEncoderDependencies<'vir, TyImpureEnc>,
     builder: &mut PredicateBuilder<'vir>,
-    snap_func_ident: FunctionIdn<'vir, (vir::Ref, vir::ManyTyVal, vir::ManyCSnap), vir::Snap>, // TODO: make this exposed through builder?
 ) -> Result<ArrayData<'vir, ImpureTyDatas>, EncodeFullError<'vir, TyImpureEnc>> {
     set_opaque(builder);
     let ref_self_decl = builder.ref_self_decl();
@@ -60,25 +70,12 @@ pub(crate) fn ty_impure<'vir>(
             None,
         );
 
-    let self_pred_ident = builder
-        .inner
-        .predicate_ident::<(vir::Ref, vir::ManyTyVal, vir::ManyCSnap)>(
-            "",
-            (
-                ref_self_decl.ty(),
-                builder.params.ty_args(),
-                builder.params.const_args(),
-            ),
-        );
-
-    let index_access = builder.function(
-        "index_ref",
-        (vir::TYPE_REF, vir::TYPE_INT),
-        vir::TYPE_REF,
-        (ref_self_decl, index_decl),
-        &[],
-        &[],
-        None,
+    let ref_to_index_ref = data.1.ref_to_index_ref;
+    let index_ref = ref_to_index_ref(
+        ref_self,
+        index,
+        builder.params.ty_exprs(),
+        builder.params.const_exprs(),
     );
 
     let index_frame = builder.inner.function(
@@ -105,9 +102,9 @@ pub(crate) fn ty_impure<'vir>(
 
     let element_ty = data.0.decompose(task_key.0.params);
     let element_ty_out = deps.require_dep::<TyUseImpureEnc>(element_ty)?;
-    let element_pred = element_ty_out.ref_to_pred(builder.vcx, index_access(ref_self, index), None);
+    let element_pred = element_ty_out.ref_to_pred(builder.vcx, index_ref, None);
 
-    let array_snap = vir::expr! { [snap_func_ident](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]]) }.downcast_ty();
+    let array_snap = vir::expr! { [builder.ref_to_snap](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]]) }.downcast_ty();
     let array_index = data.1.index_access.call()(array_snap, index);
     let method_fold = builder
         .inner
@@ -131,12 +128,12 @@ pub(crate) fn ty_impure<'vir>(
                 vir::expr! { [index_predicate](ref_self, index, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]]) },
             ],
             &[
-                vir::expr! { [self_pred_ident](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]]) },
+                vir::expr! { [builder.ref_to_pred](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]]) },
                 vir::expr! {
                     forall idx: Int :: {[data.1.index_access](array_snap, idx)}
                         ([data.1.index_access](array_snap, idx)) == (
                             ((idx) == (index))
-                            ? ([builder.vcx.mk_old_expr(element_ty_out.ref_to_snap(vir::expr! { [index_access](ref_self, index) }).downcast_ty())])
+                            ? ([builder.vcx.mk_old_expr(element_ty_out.ref_to_snap(index_ref).downcast_ty())])
                             : (old([data.1.index_access](([index_frame](ref_self, index, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])), idx)))
                         )
                 },
@@ -160,13 +157,13 @@ pub(crate) fn ty_impure<'vir>(
                 builder.params.const_decls(),
             ),
             &[
-                vir::expr! { [self_pred_ident](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]]) },
+                vir::expr! { [builder.ref_to_pred](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]]) },
             ],
             &[
                 element_pred,
                 vir::expr! { [index_predicate](ref_self, index, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]]) },
                 vir::expr! {
-                    ([element_ty_out.ref_to_snap(vir::expr! { [index_access](ref_self, index) })])
+                    ([element_ty_out.ref_to_snap(index_ref)])
                     == ([builder.vcx.mk_old_expr(array_index).upcast_ty()])
                 },
                 vir::expr! {
@@ -178,7 +175,7 @@ pub(crate) fn ty_impure<'vir>(
 
     Ok(ArrayData::new(
         TyImpureArrayData {
-            index_access,
+            ref_to_index_ref,
             index_frame,
             index_predicate,
             method_fold,

--- a/prusti-encoder/src/encoders/ty/kinds/enumlike.rs
+++ b/prusti-encoder/src/encoders/ty/kinds/enumlike.rs
@@ -111,6 +111,9 @@ pub(crate) fn ty_impure<'vir>(
                 (([snap_disc])
                     == ([variant.1.discr])) ==> ([variant_pred](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]]))
             };
+            let variant_snap_expr = vir::expr! {
+                unfolding ([variant_pred](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])) in (variant_snap_expr)
+            };
 
             Ok((
                 variant_snap_expr,
@@ -134,45 +137,27 @@ pub(crate) fn ty_impure<'vir>(
     let variant_predicates = builder
         .vcx
         .mk_conj(&variants.iter().map(|v| v.1).collect::<Vec<_>>());
-    let self_pred = builder
-        .inner
-        .predicate::<(vir::Ref, vir::ManyTyVal, vir::ManyCSnap)>(
-            "",
-            (
-                ref_self_decl.ty,
-                builder.params.ty_args(),
-                builder.params.const_args(),
-            ),
-            (
-                ref_self_decl,
-                builder.params.ty_decls(),
-                builder.params.const_decls(),
-            ),
-            Some(vir::expr! {
-                ([variant_predicate])
-                && (([variant_values])
-                && ([variant_predicates]))
-            }),
-        );
+    builder.mk_predicate(
+        "",
+        Some(vir::expr! {
+            ([variant_predicate])
+            && (([variant_values])
+            && ([variant_predicates]))
+        }),
+    );
 
     // Ref-to-snap
-    builder.function_snap = Some(builder.mk_function::<(vir::Ref, vir::ManyTyVal, vir::ManyCSnap), _>(
-        "snap",
-        (ref_self_decl.ty,
-            builder.params.ty_args(), builder.params.const_args()),
-        builder.csnap_type(),
-        (ref_self_decl, builder.params.ty_decls(), builder.params.const_decls()),
-        &[vir::expr! { acc([self_pred](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])) }],
-        &[],
-        Some(vir::expr! {
-            unfolding ([self_pred](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])) in ([variants.iter()
-                .fold((task_key.1.unreachable_to_snap)(builder.params.ty_exprs()).downcast_ty(), |else_, variant| builder.vcx.mk_ternary_expr(
-                    vir::expr! { ([snap_disc]) == ([variant.2]) },
-                    variant.0,
-                    else_,
-                ))])
-        }),
-    ).1);
+    let base =
+        (task_key.1.unreachable_to_snap)(builder.params.ty_exprs(), builder.params.const_exprs())
+            .downcast_ty();
+    let inner = variants.iter().fold(base, |else_, variant| {
+        builder.vcx.mk_ternary_expr(
+            vir::expr! { ([snap_disc]) == ([variant.2]) },
+            variant.0,
+            else_,
+        )
+    });
+    builder.mk_snap_function(Some(inner));
 
     Ok(EnumData::new(
         TyImpureEnumData {

--- a/prusti-encoder/src/encoders/ty/kinds/immref.rs
+++ b/prusti-encoder/src/encoders/ty/kinds/immref.rs
@@ -4,7 +4,7 @@ use crate::encoders::ty::{
     pure::{AdtBuilder, TyPureEnc, TyPureImmRef, TyPureImmRefData},
 };
 use task_encoder::{EncodeFullError, TaskEncoderDependencies};
-use vir::{CastType, HasType};
+use vir::CastType;
 
 pub(crate) fn ty_pure<'vir>(
     _data: &RustImmRef<'vir>,
@@ -35,39 +35,17 @@ pub(crate) fn ty_impure<'vir>(
     let ref_field = builder.field("val", snap_type);
 
     // main predicate
-    let self_pred = builder
-        .inner
-        .predicate::<(vir::Ref, vir::ManyTyVal, vir::ManyCSnap)>(
-            "",
-            (
-                ref_self_decl.ty(),
-                builder.params.ty_args(),
-                builder.params.const_args(),
-            ),
-            (
-                ref_self_decl,
-                builder.params.ty_decls(),
-                builder.params.const_decls(),
-            ),
-            Some(vir::expr! {
-                acc((ref_self).[ref_field])
-                // TODO: pure typeof assertions do not currently work
-                // && (([generic_typeof]([data.1.value_access]([ref_field](ref_self)))) == ([builder.params.ty_exprs()[0]]))
-            }), // TODO: use generic args?
-        );
+    builder.mk_predicate(
+        "",
+        Some(vir::expr! {
+            acc((ref_self).[ref_field])
+            // TODO: pure typeof assertions do not currently work
+            // && (([generic_typeof]([data.1.value_access]([ref_field](ref_self)))) == ([builder.params.ty_exprs()[0]]))
+        }), // TODO: use generic args?
+    );
 
     // Ref-to-snap
-    builder.function_snap = Some(builder.mk_function::<(vir::Ref, vir::ManyTyVal, vir::ManyCSnap), _>(
-        "snap",
-        (ref_self_decl.ty(), builder.params.ty_args(), builder.params.const_args()),
-        snap_type,
-        (ref_self_decl, builder.params.ty_decls(), builder.params.const_decls()),
-        &[vir::expr! { acc([self_pred](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])) }],
-        &[], // vir::expr! { ([generic_typeof]([data.1.value_access](result: [snap_type]))) == ([builder.params.ty_exprs()[0]]) }],
-        Some(vir::expr! {
-            unfolding ([self_pred](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])) in ([ref_field](ref_self))
-        }),
-    ).1);
+    builder.mk_snap_function(Some(vir::expr! { [ref_field](ref_self) }));
 
     Ok(TyImpureImmRefData {})
 }

--- a/prusti-encoder/src/encoders/ty/kinds/mutref.rs
+++ b/prusti-encoder/src/encoders/ty/kinds/mutref.rs
@@ -4,16 +4,18 @@ use crate::encoders::ty::{
     pure::{AdtBuilder, TyPureEnc, TyPureMutRef, TyPureMutRefData},
 };
 use task_encoder::{EncodeFullError, TaskEncoderDependencies};
-use vir::{CastType, HasType};
+use vir::CastType;
 
 pub(crate) fn ty_pure<'vir>(
     builder: &mut AdtBuilder<'vir>,
 ) -> Result<TyPureMutRef<'vir>, EncodeFullError<'vir, TyPureEnc>> {
-    let (field_snaps_to_snap, field_access) = builder.constructor("", vir::TYPE_REF, None);
+    let (field_snaps_to_snap, field_access) =
+        builder.constructor("", (vir::TYPE_REF, vir::TYPE_PSNAP), None);
 
     Ok(TyPureMutRefData {
         prim_to_snap: field_snaps_to_snap,
         deref_access: field_access[0].downcast_ty(),
+        value_access: field_access[1].downcast_ty(),
     })
 }
 
@@ -22,7 +24,20 @@ pub(crate) fn ty_impure<'vir>(
     _deps: &mut TaskEncoderDependencies<'vir, TyImpureEnc>,
     builder: &mut PredicateBuilder<'vir>,
 ) -> Result<TyImpureMutRef<'vir>, EncodeFullError<'vir, TyImpureEnc>> {
-    let snap_type = builder.snap_type();
+    let snap_type = builder.csnap_type();
+    let ref_param = builder.vcx.mk_local_decl("r", vir::TYPE_REF);
+    let ref_param_ex = builder.vcx.mk_local_ex(ref_param);
+    let arbitrary_value = builder.inner.function(
+        "arbitrary_value",
+        vir::TYPE_REF,
+        snap_type,
+        (ref_param,),
+        &[],
+        &[vir::expr! {
+            ([data.1.deref_access](result: [snap_type])) == ([ref_param_ex])
+        }],
+        None,
+    );
 
     let ref_self_decl = builder.ref_self_decl();
     let ref_self = builder.vcx.mk_local_ex(ref_self_decl);
@@ -31,52 +46,13 @@ pub(crate) fn ty_impure<'vir>(
     let ref_field = builder.field("val", snap_type);
 
     // main predicate
-    let self_pred = builder
-        .inner
-        .predicate::<(vir::Ref, vir::ManyTyVal, vir::ManyCSnap)>(
-            "",
-            (
-                ref_self_decl.ty(),
-                builder.params.ty_args(),
-                builder.params.const_args(),
-            ),
-            (
-                ref_self_decl,
-                builder.params.ty_decls(),
-                builder.params.const_decls(),
-            ),
-            Some(vir::expr! { acc((ref_self).[ref_field]) }),
-        );
+    builder.mk_predicate("", Some(vir::expr! { acc((ref_self).[ref_field]) }));
 
     // Ref-to-snap
-    builder.function_snap = Some(
-        builder
-            .mk_function::<(vir::Ref, vir::ManyTyVal, vir::ManyCSnap), _>(
-                "snap",
-                (ref_self_decl.ty(), builder.params.ty_args(), builder.params.const_args()),
-                snap_type,
-                (ref_self_decl, builder.params.ty_decls(), builder.params.const_decls()),
-                &[vir::expr! { acc([self_pred](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])) }],
-                &[],
-                Some(vir::expr! {
-                    unfolding ([self_pred](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])) in ([ref_field](ref_self))
-                }),
-            )
-            .1,
-    );
+    builder.mk_snap_function(Some(vir::expr! { [ref_field](ref_self) }));
 
-    // Ref-to-Ref
-    let deref_func = builder.inner.function(
-        "deref",
-        (ref_self_decl.ty(), builder.params.ty_args(), builder.params.const_args()),
-        vir::TYPE_REF,
-        (ref_self_decl, builder.params.ty_decls(), builder.params.const_decls()),
-        &[vir::expr! { acc([self_pred](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])) }],
-        &[],
-        Some(vir::expr! {
-            unfolding ([self_pred](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])) in ([data.1.deref_access](([ref_field](ref_self)) as CSnap))
-        }),
-    );
-
-    Ok(TyImpureMutRefData { deref_func })
+    Ok(TyImpureMutRefData {
+        pure: *data.1,
+        arbitrary_value,
+    })
 }

--- a/prusti-encoder/src/encoders/ty/kinds/opaque.rs
+++ b/prusti-encoder/src/encoders/ty/kinds/opaque.rs
@@ -24,35 +24,6 @@ pub(crate) fn ty_impure<'vir>(
 }
 
 pub(super) fn set_opaque<'vir>(builder: &mut PredicateBuilder<'vir>) {
-    let ref_self_decl = builder.ref_self_decl();
-    let ref_self = builder.vcx.mk_local_ex(ref_self_decl);
-    let self_pred = builder
-        .inner
-        .predicate::<(vir::Ref, vir::ManyTyVal, vir::ManyCSnap)>(
-            "",
-            (
-                ref_self_decl.ty,
-                builder.params.ty_args(),
-                builder.params.const_args(),
-            ),
-            (
-                ref_self_decl,
-                builder.params.ty_decls(),
-                builder.params.const_decls(),
-            ),
-            None,
-        );
-    builder.function_snap = Some(
-        builder
-            .mk_function::<(vir::Ref, vir::ManyTyVal, vir::ManyCSnap), _>(
-                "snap",
-                (ref_self_decl.ty, builder.params.ty_args(), builder.params.const_args()),
-                builder.snap_type(),
-                (ref_self_decl, builder.params.ty_decls(), builder.params.const_decls()),
-                &[vir::expr! { acc([self_pred](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])) }],
-                &[],
-                None,
-            )
-            .1,
-    );
+    builder.mk_predicate("", None);
+    builder.mk_snap_function(None);
 }

--- a/prusti-encoder/src/encoders/ty/kinds/primitive.rs
+++ b/prusti-encoder/src/encoders/ty/kinds/primitive.rs
@@ -9,7 +9,7 @@ use crate::encoders::ty::{
 };
 use prusti_rustc_interface::middle::ty;
 use task_encoder::{EncodeFullError, TaskEncoderDependencies};
-use vir::{CastType, HasType, VirCtxt};
+use vir::{CastType, VirCtxt};
 
 pub(crate) fn ty_pure<'vir>(
     vcx: &'vir VirCtxt<'vir>,
@@ -92,29 +92,10 @@ pub(crate) fn ty_impure<'vir>(
     let prim_field = builder.field("val", snap_type);
 
     // main predicate
-    let self_pred = builder.predicate::<vir::Ref>(
-        "",
-        ref_self_decl.ty(),
-        (ref_self_decl,),
-        Some(vir::expr! { acc((ref_self).[prim_field]) }),
-    );
+    builder.mk_predicate("", Some(vir::expr! { acc((ref_self).[prim_field]) }));
 
     // Ref-to-snap
-    builder.function_snap = Some(
-        builder
-            .mk_function::<vir::Ref, _>(
-                "snap",
-                ref_self_decl.ty(),
-                snap_type,
-                (ref_self_decl,),
-                &[vir::expr! { acc([self_pred](ref_self)) }],
-                &[],
-                Some(vir::expr! {
-                    unfolding ([self_pred](ref_self)) in ([prim_field](ref_self))
-                }),
-            )
-            .1,
-    );
+    builder.mk_snap_function(Some(vir::expr! { [prim_field](ref_self) }));
 
     Ok(())
 }

--- a/prusti-encoder/src/encoders/ty/kinds/structlike.rs
+++ b/prusti-encoder/src/encoders/ty/kinds/structlike.rs
@@ -38,11 +38,32 @@ pub(super) fn ty_pure_variant<'vir>(
         .collect::<Result<Vec<_>, _>>()?;
     let field_tys = builder.vcx.alloc_slice(&field_tys);
     let (field_snaps_to_snap, des) = builder.constructor(prefix, field_tys, discr);
+
+    let ref_self_decl = builder.vcx.mk_local_decl("self", vir::TYPE_REF);
+    let ref_self = builder.vcx.mk_local_ex(ref_self_decl);
+    let params = builder.params.clone();
+
     assert_eq!(des.len(), data.fields.len());
     let des = des
         .iter()
-        .map(|read| TyPureFieldData {
-            read: read.downcast_ty(),
+        .enumerate()
+        .map(|(idx, read)| {
+            let args = (ref_self_decl.ty(), params.ty_args(), params.const_args());
+            let params = (ref_self_decl, params.ty_decls(), params.const_decls());
+            let ref_to_field_ref = builder
+                .function::<(vir::Ref, vir::ManyTyVal, vir::ManyCSnap), vir::Ref>(
+                    &format!("{prefix}field_{idx}"),
+                    args,
+                    vir::TYPE_REF,
+                    params,
+                    &[],
+                    &[vir::expr! { ((ref_self) == (null)) == ((result: Ref) == (null)) }],
+                    None,
+                );
+            TyPureFieldData {
+                read: read.downcast_ty(),
+                ref_to_field_ref,
+            }
         })
         .collect::<Vec<_>>();
     Ok(StructData::new(
@@ -60,25 +81,10 @@ pub(crate) fn ty_impure<'vir>(
     deps: &mut TaskEncoderDependencies<'vir, TyImpureEnc>,
     builder: &mut PredicateBuilder<'vir>,
 ) -> Result<StructData<'vir, ImpureTyDatas>, EncodeFullError<'vir, TyImpureEnc>> {
-    let (data, self_pred, snap_expr) = ty_impure_variant("", task_key, data, deps, builder)?;
-
-    let ref_self_decl = builder.ref_self_decl();
-    let ref_self = builder.vcx.mk_local_ex(ref_self_decl);
+    let (data, _, snap_expr) = ty_impure_variant("", task_key, data, deps, builder)?;
 
     // Ref-to-snap
-    builder.function_snap = Some(
-        builder
-            .mk_function::<(vir::Ref, vir::ManyTyVal, vir::ManyCSnap), _>(
-                "snap",
-                (ref_self_decl.ty(), builder.params.ty_args(), builder.params.const_args()),
-                builder.csnap_type(),
-                (ref_self_decl, builder.params.ty_decls(), builder.params.const_decls()),
-                &[vir::expr! { acc([self_pred](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])) }],
-                &[],
-                Some(snap_expr),
-            )
-            .1,
-    );
+    builder.mk_snap_function(Some(snap_expr));
     Ok(data)
 }
 
@@ -108,30 +114,11 @@ pub(crate) fn ty_impure_variant<'vir>(
     let ref_self = builder.vcx.mk_local_ex(ref_self_decl);
 
     // Ref-to-Ref function for every field
-    let field_accessors = fields
+    let field_accessors = data
+        .fields
         .iter()
-        .enumerate()
-        .map(|(idx, _field)| {
-            let ref_to_field_ref = builder
-                .inner
-                .function::<(vir::Ref, vir::ManyTyVal, vir::ManyCSnap), vir::Ref>(
-                    &format!("{prefix}field_{idx}"),
-                    (
-                        ref_self_decl.ty(),
-                        builder.params.ty_args(),
-                        builder.params.const_args(),
-                    ),
-                    vir::TYPE_REF,
-                    (
-                        ref_self_decl,
-                        builder.params.ty_decls(),
-                        builder.params.const_decls(),
-                    ),
-                    &[], // TODO: should have a read permission here!
-                    &[vir::expr! { ((ref_self) == (null)) == ((result: Ref) == (null)) }],
-                    None,
-                );
-            TyImpureFieldData { ref_to_field_ref }
+        .map(|field| TyImpureFieldData {
+            ref_to_field_ref: field.1.ref_to_field_ref,
         })
         .collect::<Vec<_>>();
 
@@ -140,48 +127,30 @@ pub(crate) fn ty_impure_variant<'vir>(
     if !prefix.is_empty() {
         pred_name = format!("{prefix}owned");
     }
-    let pred_owned = builder
-        .inner
-        .predicate::<(vir::Ref, vir::ManyTyVal, vir::ManyCSnap)>(
-            &pred_name,
-            (
-                ref_self_decl.ty(),
-                builder.params.ty_args(),
-                builder.params.const_args(),
-            ),
-            (
-                ref_self_decl,
-                builder.params.ty_decls(),
-                builder.params.const_decls(),
-            ),
-            Some(
-                builder.vcx.mk_conj(
-                    &fields
-                        .iter()
-                        .zip(&field_accessors)
-                        .map(|(field, accessor)| {
-                            let TyImpureFieldData { ref_to_field_ref } = accessor;
-                            field.ref_to_pred(
-                                builder.vcx,
-                                ref_to_field_ref(
-                                    ref_self,
-                                    builder.params.ty_exprs(),
-                                    builder.params.const_exprs(),
-                                ),
-                                None,
-                            )
-                        })
-                        .collect::<Vec<_>>(),
-                ),
-            ),
-        );
+    let pred_expr = builder.vcx.mk_conj(
+        &fields
+            .iter()
+            .zip(&field_accessors)
+            .map(|(field, TyImpureFieldData { ref_to_field_ref })| {
+                field.ref_to_pred(
+                    builder.vcx,
+                    ref_to_field_ref(
+                        ref_self,
+                        builder.params.ty_exprs(),
+                        builder.params.const_exprs(),
+                    ),
+                    None,
+                )
+            })
+            .collect::<Vec<_>>(),
+    );
+    let pred_owned = builder.mk_predicate(&pred_name, Some(pred_expr));
 
     // Ref-to-snap
     let snap_args: Vec<&'vir vir::ExprGenData<'vir, (), !, vir::Snap>> = fields
         .iter()
         .zip(&field_accessors)
-        .map(|(field, accessor)| {
-            let TyImpureFieldData { ref_to_field_ref } = accessor;
+        .map(|(field, TyImpureFieldData { ref_to_field_ref })| {
             field.ref_to_snap(ref_to_field_ref(
                 ref_self,
                 builder.params.ty_exprs(),
@@ -189,9 +158,7 @@ pub(crate) fn ty_impure_variant<'vir>(
             ))
         })
         .collect::<Vec<_>>();
-    let variant_snap_expr = vir::expr! {
-        unfolding ([pred_owned](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])) in ([data.1.field_snaps_to_snap](..[snap_args.as_slice()]))
-    };
+    let variant_snap_expr = data.1.field_snaps_to_snap.call()(snap_args.as_slice());
 
     Ok((
         StructData::new((), data.inhabited, field_accessors),

--- a/prusti-encoder/src/encoders/ty/pure.rs
+++ b/prusti-encoder/src/encoders/ty/pure.rs
@@ -73,6 +73,9 @@ pub struct TyPureOpaqueData<'vir> {
 pub struct TyPureArrayData<'vir> {
     /// Function to access the value at the given index.
     pub(super) index_access: FunctionIdn<'vir, (vir::CSnap, vir::Int), vir::PSnap>,
+    /// Function to access the ref at the given index.
+    pub ref_to_index_ref:
+        vir::FunctionIdn<'vir, (vir::Ref, vir::Int, vir::ManyTyVal, vir::ManyCSnap), vir::Ref>,
     /// Function to read the length of the array.
     pub(super) len: FunctionIdn<'vir, vir::CSnap, vir::Int>,
 }
@@ -132,9 +135,11 @@ pub struct TyPureImmRefData<'vir> {
 #[derive(Debug, Clone, Copy)]
 pub struct TyPureMutRefData<'vir> {
     /// Construct domain from a `Ref` value.
-    pub(super) prim_to_snap: FunctionIdn<'vir, vir::Ref, vir::CSnap>,
+    pub(super) prim_to_snap: FunctionIdn<'vir, (vir::Ref, vir::PSnap), vir::CSnap>,
     /// Function to access the referee.
     pub(super) deref_access: AdtDestructor<'vir, vir::CSnap, vir::Ref>,
+    /// Function to access the value (beware that this may not be set).
+    pub(super) value_access: AdtDestructor<'vir, vir::CSnap, vir::PSnap>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -147,6 +152,8 @@ pub struct TyPureStructData<'vir> {
 #[derive(Debug, Clone, Copy)]
 pub struct TyPureFieldData<'vir> {
     pub(super) read: AdtDestructor<'vir, vir::CSnap, vir::Snap>,
+    pub(super) ref_to_field_ref:
+        FunctionIdn<'vir, (vir::Ref, vir::ManyTyVal, vir::ManyCSnap), vir::Ref>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -171,7 +178,7 @@ pub(super) type TyPureEnc = super::TyEnc<Pure>;
 #[derive(Debug, Clone, Copy)]
 pub struct TyPureRef<'vir> {
     pub domain: vir::DomainIdnSnap<'vir>,
-    pub unreachable_to_snap: FunctionIdn<'vir, vir::ManyTyVal, vir::Snap>,
+    pub unreachable_to_snap: FunctionIdn<'vir, (vir::ManyTyVal, vir::ManyCSnap), vir::Snap>,
 }
 
 impl<'vir> task_encoder::OutputRefAny for TyPureRef<'vir> {}
@@ -179,6 +186,8 @@ impl<'vir> task_encoder::OutputRefAny for TyPureRef<'vir> {}
 #[derive(Debug, Clone, Copy)]
 pub struct TyPureEncLocal<'vir> {
     pub unreachable_to_snap: vir::Function<'vir>,
+    /// Other functions related to this type.
+    pub functions: &'vir [vir::Function<'vir>],
     pub kind: TyPureEncLocalKind<'vir>,
 }
 
@@ -186,7 +195,6 @@ pub struct TyPureEncLocal<'vir> {
 pub enum TyPureEncLocalKind<'vir> {
     Domain {
         domain: vir::Domain<'vir>,
-        // functions: Vec<vir::Function<'vir>>,
     },
     Adt {
         adt: vir::Adt<'vir>,
@@ -277,6 +285,9 @@ impl TaskEncoder for TyPureEnc {
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
         for output in TyPureEnc::all_outputs_local_no_errors() {
             program.add_function(output.unreachable_to_snap);
+            for function in output.functions {
+                program.add_function(function);
+            }
             match output.kind {
                 TyPureEncLocalKind::Domain { domain } => program.add_domain(domain),
                 TyPureEncLocalKind::Adt { adt, discr_fn } => {
@@ -333,7 +344,7 @@ pub(crate) struct TyPureBuilder<'vir> {
     name: &'vir str,
     domain_ident: vir::DomainIdnSnap<'vir>,
     self_type: vir::TypeSnap<'vir>,
-    unreachable_to_snap: FunctionIdn<'vir, vir::ManyTyVal, vir::Snap>,
+    unreachable_to_snap: FunctionIdn<'vir, (vir::ManyTyVal, vir::ManyCSnap), vir::Snap>,
     pub(super) params: GenericParams<'vir>,
     data: BuilderData<'vir>,
 }
@@ -348,6 +359,8 @@ pub enum BuilderData<'vir> {
 pub(crate) struct AdtBuilderData<'vir> {
     constructors: Vec<vir::AdtConstructor<'vir>>,
     discr_fn: Option<DiscrFnBuilder<'vir>>,
+    /// Other related functions (for example Ref field accessors).
+    functions: Vec<vir::Function<'vir>>,
 }
 
 #[derive(Default)]
@@ -379,7 +392,7 @@ impl<'vir> TyPureBuilder<'vir> {
         let self_type = domain_ident();
         let unreachable_to_snap = FunctionIdn::new(
             vir::ViperIdent::new(vir::vir_format!(vcx, "{name}_unreachable")),
-            params.ty_args(),
+            (params.ty_args(), params.const_args()),
             self_type,
         );
         TyPureBuilder {
@@ -435,17 +448,23 @@ impl<'vir> TyPureBuilder<'vir> {
             let false_ = vcx.alloc_array(&[vcx.mk_bool::<false>()]);
             vcx.mk_function(
                 self.unreachable_to_snap,
-                (self.params.ty_decls(),),
+                (self.params.ty_decls(), self.params.const_decls()),
                 false_,
                 false_,
                 None,
                 None,
             )
         });
+        let functions = match &self.data {
+            BuilderData::Adt(data) => data.functions.as_slice(),
+            _ => &[],
+        };
+        let functions = vir::with_vcx(|vcx| vcx.alloc_slice(functions));
         let kind = self.build_kind();
         TyPureEncLocal {
             unreachable_to_snap,
             kind,
+            functions,
         }
     }
 
@@ -576,6 +595,31 @@ impl<'vir> AdtBuilder<'vir> {
             .vcx
             .mk_function(ident, (param,), &[], posts, None, expr);
         self.data().discr_fn = Some(DiscrFnBuilder::Built(built_fn));
+        ident
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn function<A: Arity, T: CompType>(
+        &mut self,
+        name: &str,
+        args: A::Tys<'vir>,
+        ret: vir::Type<'vir, T>,
+        params: A::Locals<'_, 'vir>,
+        pres: &[vir::ExprBool<'vir>],
+        posts: &[vir::ExprBool<'vir>],
+        expr: Option<vir::Expr<'vir, T>>,
+    ) -> FunctionIdn<'vir, A, T> {
+        let name = vir::vir_format!(self.vcx, "{}_{name}", self.name);
+        let ident = FunctionIdn::new(vir::ViperIdent::new(name), args, ret);
+        let function = self.vcx.mk_function(
+            ident,
+            params,
+            self.vcx.alloc_slice(pres),
+            self.vcx.alloc_slice(posts),
+            None,
+            expr,
+        );
+        self.data().functions.push(function);
         ident
     }
 }

--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -124,10 +124,31 @@ impl<'tcx> LazyRustTy<'tcx> {
 
 impl<'tcx> LazyRustTy<'tcx> {
     /// Decomposes the field's type into a `RustTyDecomposition` (to be used
-    /// when recursing over the fields of a containing `RustTy`).
+    /// when recursing over the fields of a containing `RustTy` to construct
+    /// e.g. a predicate - i.e. when the definition of the predicate is
+    /// independent of the context/generic args).
     /// The passed `params` should be those of the containing `RustTy::params`.
+    ///
+    /// For example a `Foo<i32>` with definition `struct Foo<T>(T);`, then
+    /// decomposing the field of the struct would yield `TySpecifics::Param`
+    /// with arguments `<T>` (i.e. the `i32` from the context is lost).
     pub fn decompose(&self, params: GParams<'tcx>) -> RustTyDecomposition<'tcx> {
         vir::with_vcx(|vcx| RustTyDecomposition::from_ty(self.0, vcx.tcx(), params))
+    }
+
+    /// Decomposes the field's type into a `RustTyDecomposition` (to be used
+    /// when recursing over the fields of a containing `RustTy`
+    /// non-transparently, e.g. when predicates of fields should be added
+    /// directly to a method itself).
+    /// The passed `args` should be those of the containing `RustTyDecomposition::args`.
+    pub fn decompose_context(
+        &self,
+        params: GParams<'tcx>,
+        args: GArgs<'tcx>,
+    ) -> RustTyDecomposition<'tcx> {
+        let mut decomp = self.decompose(params);
+        decomp.args = decomp.args.substitute(args);
+        decomp
     }
 
     /// Decomposes the field's type into a `RustTyDecomposition` (to be used
@@ -138,19 +159,11 @@ impl<'tcx> LazyRustTy<'tcx> {
     /// removing definitional generics. For example a `Foo<i32>` with definition
     /// `struct Foo<T>(T);` would yield `i32` instead of `T` when called on the
     /// field of `Foo`.
-    pub fn decompose_normalize(&self, args: GArgs<'tcx>) -> RustTyDecomposition<'tcx> {
+    fn decompose_normalize(&self, args: GArgs<'tcx>) -> RustTyDecomposition<'tcx> {
         vir::with_vcx(|vcx| {
             RustTyDecomposition::from_ty(args.normalize(self.0), vcx.tcx(), args.context())
         })
     }
-
-    // TODO: see comment in the `unsize` handler of `mir_builtin.rs`
-    //pub fn decompose_local_ctx(&self, _args: GArgs<'tcx>) -> RustTyDecomposition<'tcx> {
-    //    todo!()
-    //    // let dummy_param = vcx.tcx().mk_ty_from_kind(ty::TyKind::Param(ty::ParamTy::new(0, Symbol::intern("T"))));
-    //    // let mut ty_task = RustTyDecomposition::from_ty(dummy_param, vcx.tcx(), GParams::new(vcx.tcx().mk_args(&[dummy_param.into()]), ty::ParamEnv::empty(), false));
-    //    // ty_task.args = GArgs::new(params, vcx.tcx().mk_args(&[src_ty.peel_refs().into()]));
-    //}
 
     /// Similarly to `Self::decompose`, this decomposes the fields type.
     /// However, it tries to normalize the type first and only returns a

--- a/prusti-encoder/src/encoders/ty/use_impure.rs
+++ b/prusti-encoder/src/encoders/ty/use_impure.rs
@@ -1,6 +1,6 @@
 use prusti_rustc_interface::abi;
 use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
-use vir::PredicateIdn;
+use vir::{CastType, PredicateIdn};
 
 use crate::encoders::{
     Impure,
@@ -61,6 +61,7 @@ pub struct TyUseImpureMutRef<'vir> {
     caster: FieldCaster<'vir>,
     args: GArgsTy<'vir>,
     impure: <ImpureTyDatas as TyDatas<'vir>>::MutRefData,
+    ref_to_snap: vir::FunctionIdn<'vir, (vir::Ref, vir::ManyTyVal, vir::ManyCSnap), vir::Snap>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -161,6 +162,7 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
                     caster,
                     args: self.args_t,
                     impure: *data.1,
+                    ref_to_snap: ty.1.ref_to_snap,
                 })
             }
             TySpecifics::ArrayLike(data) => {
@@ -338,7 +340,7 @@ impl<'vir> TyData<'vir, UseImpureTyDatas> {
                 let index = index.expect("cannot fold array type without index");
                 array
                     .element_caster
-                    .cast_to_callee_ctx((array.impure.index_access)(self_ref, index))
+                    .cast_to_callee_ctx(array.ref_to_index_ref(self_ref, index))
                     .into_iter()
                     .chain([vir::with_vcx(|vcx| {
                         vcx.alloc(vir::StmtData::new(vcx.alloc(
@@ -399,7 +401,7 @@ impl<'vir> TyData<'vir, UseImpureTyDatas> {
                 .chain(
                     array
                         .element_caster
-                        .cast_to_caller_ctx((array.impure.index_access)(self_ref, index)),
+                        .cast_to_caller_ctx(array.ref_to_index_ref(self_ref, index)),
                 )
                 .collect()
             }
@@ -415,12 +417,19 @@ impl<'vir> TyData<'vir, UseImpureTyDatas> {
 }
 
 impl<'vir> TyUseImpureArray<'vir> {
+    /// Get the (Ref) address of an index. Identical to the function one would
+    /// call in `use_pure`.
     pub fn ref_to_index_ref<Curr, Next>(
         &self,
         self_ref: vir::ExprGenRef<'vir, Curr, Next>,
         index: vir::ExprGenInt<'vir, Curr, Next>,
     ) -> vir::ExprGenRef<'vir, Curr, Next> {
-        self.data.impure.index_access.call()(self_ref, index)
+        self.data.impure.ref_to_index_ref.call()(
+            self_ref,
+            index,
+            self.args.get_ty(),
+            self.args.get_const(),
+        )
     }
 }
 
@@ -477,7 +486,8 @@ impl<'vir> TyUseImpureStruct<'vir> {
 }
 
 impl<'vir> TyUseImpureField<'vir> {
-    /// Get the (Ref) address of a field.
+    /// Get the (Ref) address of a field. Identical to the function one would
+    /// call in `use_pure`.
     pub fn field_ref<Curr, Next>(
         &self,
         self_ref: vir::ExprGenRef<'vir, Curr, Next>,
@@ -512,8 +522,14 @@ impl<'vir> TyUseImpureMutRef<'vir> {
         self_ref: vir::ExprRef<'vir>,
         label: Option<vir::OldLabel<'vir>>,
     ) -> vir::ExprRef<'vir> {
-        let base = (self.impure.deref_func)(self_ref, self.args.get_ty(), self.args.get_const());
-        vir::with_vcx(|vcx| vcx.maybe_apply_label(base, label))
+        let snap = self.ref_to_snap.call()(self_ref, self.args.get_ty(), self.args.get_const())
+            .downcast_ty();
+        let deref = self.impure.pure.deref_access.call()(snap);
+        vir::with_vcx(|vcx| vcx.maybe_apply_label(deref, label))
+    }
+
+    pub fn prim_to_snap_assign(&self, self_ref: vir::ExprRef<'vir>) -> vir::ExprCSnap<'vir> {
+        (self.impure.arbitrary_value)(self_ref)
     }
 
     fn fold(

--- a/prusti-encoder/src/encoders/ty/use_pure.rs
+++ b/prusti-encoder/src/encoders/ty/use_pure.rs
@@ -6,7 +6,6 @@ use crate::encoders::{
     ty::{
         LazyRustTy, RustTyDatas,
         generics::{GArgs, GArgsCastEnc, GArgsTyEnc, GParams},
-        impure::{TyImpure, TyImpureEnc},
     },
 };
 
@@ -49,10 +48,8 @@ pub struct TyUsePureImmRef<'vir> {
 
 #[derive(Debug, Clone)]
 pub struct TyUsePureMutRef<'vir> {
-    snap_ty: vir::ExprTyVal<'vir>,
     caster: FieldCaster<'vir>,
     pure: <PureTyDatas as TyDatas<'vir>>::MutRefData,
-    inner: TyImpure<'vir>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -66,6 +63,8 @@ pub struct TyUsePureArrayData<'vir> {
 #[derive(Debug, Clone, Copy)]
 pub struct TyUsePureField<'vir> {
     caster: FieldCaster<'vir>,
+    #[allow(dead_code)]
+    args: GArgsTy<'vir>,
     pure: <PureTyDatas as TyDatas<'vir>>::FieldData,
 }
 
@@ -171,12 +170,9 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
             }
             TySpecifics::MutRef((data, ref_domain)) => {
                 let caster = self.encode_normalized(**data, ty.0.params);
-                let inner_ty = data.decompose(ty.0.params);
                 TySpecifics::mk_mutref(TyUsePureMutRef {
-                    snap_ty: self.args_t.get_ty()[0],
                     caster,
                     pure: **ref_domain,
-                    inner: self.deps.require_dep::<TyImpureEnc>(inner_ty.ty).unwrap(),
                 })
             }
             TySpecifics::ArrayLike(data) => {
@@ -231,6 +227,7 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
                 let caster = self.encode_normalized(field.0.ty(), params);
                 TyUsePureField {
                     caster,
+                    args: self.args_t,
                     pure: *field.1,
                 }
             })
@@ -262,7 +259,7 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
 
 impl<'vir> TyUsePureRef<'vir> {
     pub fn unreachable_to_snap<Curr, Next>(&self) -> vir::ExprGenSnap<'vir, Curr, Next> {
-        self.ty_pure_ref.unreachable_to_snap.call()(self.args.get_ty())
+        self.ty_pure_ref.unreachable_to_snap.call()(self.args.get_ty(), self.args.get_const())
     }
 }
 
@@ -296,44 +293,38 @@ impl<'vir> TyUsePureMutRef<'vir> {
     pub fn prim_to_snap<Curr, Next>(
         &self,
         ref_: vir::ExprGenRef<'vir, Curr, Next>,
+        val: vir::ExprGenSnap<'vir, Curr, Next>,
     ) -> vir::ExprGenCSnap<'vir, Curr, Next> {
-        self.pure.prim_to_snap.call()(ref_)
+        self.pure.prim_to_snap.call()(ref_, self.cast_to_callee_ctx(val))
     }
 
-    pub fn deref_snap_of<Curr, Next>(
+    pub fn deref_access<Curr, Next>(
         &self,
-        ref_: vir::ExprGenRef<'vir, Curr, Next>,
-    ) -> vir::ExprGenSnap<'vir, Curr, Next> {
-        self.caster
-            .cast_to_caller_ctx(self.inner.ref_to_snap.call()(
-                ref_,
-                &[self.snap_ty.lazy()],
-                &[],
-            ))
+        snap: vir::ExprGenCSnap<'vir, Curr, Next>,
+    ) -> vir::ExprGenRef<'vir, Curr, Next> {
+        self.pure.deref_access.call()(snap)
     }
 
-    pub fn deref_snap<Curr, Next>(
+    /// Function to access the value (beware that this may not be set).
+    pub fn value_access<Curr, Next>(
         &self,
         snap: vir::ExprGenCSnap<'vir, Curr, Next>,
     ) -> vir::ExprGenSnap<'vir, Curr, Next> {
-        self.deref_snap_of(self.pure.deref_access.call()(snap))
+        self.cast_to_caller_ctx(self.pure.value_access.call()(snap))
     }
 
-    pub fn inner_predicate<Curr, Next>(
+    pub fn cast_to_caller_ctx<Curr, Next>(
         &self,
-        vcx: &'vir vir::VirCtxt<'_>,
-        snap: vir::ExprGenCSnap<'vir, Curr, Next>,
-    ) -> vir::ExprGenBool<'vir, Curr, Next> {
-        if self.inner.inhabited {
-            let call: vir::PredicateAppGen<'vir, Curr, Next> = self.inner.ref_to_pred.call()(
-                self.pure.deref_access.call()(snap),
-                &[self.snap_ty.lazy()],
-                &[],
-            )(None);
-            vcx.mk_predicate_app_expr(call)
-        } else {
-            vcx.mk_bool::<false>().lazy()
-        }
+        inner_snap: vir::ExprGenPSnap<'vir, Curr, Next>,
+    ) -> vir::ExprGenSnap<'vir, Curr, Next> {
+        self.caster.cast_to_caller_ctx(inner_snap.upcast_ty())
+    }
+
+    pub fn cast_to_callee_ctx<Curr, Next>(
+        &self,
+        inner_snap: vir::ExprGenSnap<'vir, Curr, Next>,
+    ) -> vir::ExprGenPSnap<'vir, Curr, Next> {
+        self.caster.cast_to_callee_ctx(inner_snap).downcast_ty()
     }
 }
 
@@ -352,6 +343,21 @@ impl<'vir> TyUsePureArray<'vir> {
     ) -> vir::ExprGenSnap<'vir, Curr, Next> {
         let res = self.pure.index_access.call()(snap, index);
         self.caster.cast_to_caller_ctx(res.upcast_ty())
+    }
+
+    /// Get the (Ref) address of an index. Identical to the function one would
+    /// call in `use_pure`.
+    pub fn ref_to_index_ref<Curr, Next>(
+        &self,
+        self_ref: vir::ExprGenRef<'vir, Curr, Next>,
+        index: vir::ExprGenInt<'vir, Curr, Next>,
+    ) -> vir::ExprGenRef<'vir, Curr, Next> {
+        self.data.pure.ref_to_index_ref.call()(
+            self_ref,
+            index,
+            self.args.get_ty(),
+            self.args.get_const(),
+        )
     }
 }
 
@@ -375,6 +381,15 @@ impl<'vir> TyUsePureField<'vir> {
     ) -> vir::ExprGenSnap<'vir, Curr, Next> {
         let res = self.pure.read.call()(snap);
         self.caster.cast_to_caller_ctx(res)
+    }
+
+    /// Get the (Ref) address of a field. Identical to the function one would
+    /// call in `use_impure`.
+    pub fn field_ref<Curr, Next>(
+        &self,
+        self_ref: vir::ExprGenRef<'vir, Curr, Next>,
+    ) -> vir::ExprGenRef<'vir, Curr, Next> {
+        self.pure.ref_to_field_ref.call()(self_ref, self.args.get_ty(), self.args.get_const())
     }
 }
 


### PR DESCRIPTION
- Adds a `decompose_context` used by both the indirect encoder and array builtin stuff.
- Moves the creation of `function field_f(Ref): Ref` functions to the pure type encoder: these are required in the `mir_pure` encoder and it doesn't make sense for that encoder to call the impure type encoder.
- Reverts a previous change to the snapshot of a mutref. It now contains both the `Ref` and value `Snap`, instead the unsoundness is fixed by the field in the mutref predicate having a well-defined `Ref` only. We use an `arbitrary_value` function to go from `Ref` to mutref-`Snap` which uses an undefined value for the `Snap` field of it.
Ultimately, we will need two kinds of snapshots: a deep one which contains both `Ref` and `Snap` (used e.g. in pure functions) and a shallow one which contains `Ref` only (used e.g. when assigning a mutref). The implementation here reuses the same adt definition for both which is easier to implement, but risks mixing the two up (i.e. the deep one has a well-defined inner `Snap` value, while the shallow one sets it to a fixed undefined value - imagine something like null).