### PR TITLE
Correctly implement inhabitedness

### DIFF
--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -73,7 +73,7 @@ impl ConstEnc {
         span: Option<Span>,
     ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, Self>> {
         vir::with_vcx(|vcx| {
-            let ty_task = RustTyDecomposition::from_ty(ty, vcx.tcx(), context);
+            let ty_task = RustTyDecomposition::from_ty(ty, context);
             let kind = deps.require_dep::<TyUsePureEnc>(ty_task)?;
             Ok(match val {
                 ConstValue::Scalar(Scalar::Int(int)) => {
@@ -117,7 +117,7 @@ impl ConstEnc {
                 ConstValue::Slice { .. } if ty.peel_refs().is_str() => {
                     let ref_ty = kind.expect_immref();
                     let str_ty = ty.peel_refs();
-                    let str_ty_task = RustTyDecomposition::from_ty(str_ty, vcx.tcx(), context);
+                    let str_ty_task = RustTyDecomposition::from_ty(str_ty, context);
                     let str_snap = deps.require_dep::<TyUsePureEnc>(str_ty_task)?;
                     let str_snap = str_snap.expect_opaque();
                     // first, we create a string snapshot

--- a/prusti-encoder/src/encoders/impure/fn_wand.rs
+++ b/prusti-encoder/src/encoders/impure/fn_wand.rs
@@ -125,7 +125,7 @@ impl<'vir> WandEncOutput<'vir> {
         use vir::Reify;
         let g = g.into();
         let fn_sig = self.fn_sig(vcx);
-        let ty = RustTyDecomposition::from_ty(g.ty(fn_sig), vcx.tcx(), self.g_params(vcx));
+        let ty = RustTyDecomposition::from_ty(g.ty(fn_sig), self.g_params(vcx));
         let predicates = deps
             .require_dep::<IndirectPredicatesEnc>(g.with_base(ty))
             .unwrap()

--- a/prusti-encoder/src/encoders/impure/loop.rs
+++ b/prusti-encoder/src/encoders/impure/loop.rs
@@ -45,7 +45,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             }
             let (place_res, _snap, _, _) = self.encode_place_with_snap(*place);
             let ty = (*place).ty(self.pcg_ctxt());
-            let task = RustTyDecomposition::from_ty(ty.ty, self.vcx.tcx(), self.def_id);
+            let task = RustTyDecomposition::from_ty(ty.ty, self.def_id);
             let ty_out = self.deps.require_dep::<TyUseImpureEnc>(task).unwrap();
             let pred = ty_out.ref_to_pred(self.vcx, place_res.expr.expect_predicate(), None);
             inv.push(pred);
@@ -95,7 +95,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             PcgNode::Place(place) => {
                 let p = place.place();
                 let ty = (*p).ty(self.local_decls, self.vcx.tcx());
-                let task = RustTyDecomposition::from_ty(ty.ty, self.vcx.tcx(), self.def_id);
+                let task = RustTyDecomposition::from_ty(ty.ty, self.def_id);
                 let ty_out = self.deps.require_dep::<TyUseImpureEnc>(task).unwrap();
                 let p = self.encode_place(p);
                 let p = self.configure_old((*place).into(), p.expr.expect_predicate(), old_outer);
@@ -122,7 +122,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             }
             PcgLifetimeProjectionBase::Const(c) => todo!("{c:?}"),
         };
-        let ty = RustTyDecomposition::from_ty(ty.ty, self.vcx.tcx(), self.def_id);
+        let ty = RustTyDecomposition::from_ty(ty.ty, self.def_id);
         let indirect = self
             .deps
             .require_dep::<IndirectPredicatesEnc>(r.with_base(ty))

--- a/prusti-encoder/src/encoders/local_def.rs
+++ b/prusti-encoder/src/encoders/local_def.rs
@@ -189,8 +189,7 @@ impl TaskEncoder for MirLocalDefEnc {
                 let locals = IndexVec::from_fn_n(
                     |local: mir::Local| {
                         let rust_ty = body.local_decls[local].ty;
-                        let rust_ty_task =
-                            RustTyDecomposition::from_ty(rust_ty, vcx.tcx(), task_key.def_id());
+                        let rust_ty_task = RustTyDecomposition::from_ty(rust_ty, task_key.def_id());
                         let ty = deps.require_dep::<TyUseImpureEnc>(rust_ty_task).unwrap();
                         mk_local_def(vcx, local, ty)
                     },
@@ -228,8 +227,7 @@ impl TaskEncoder for MirLocalDefEnc {
                         } else {
                             sig.inputs()[local.index() - 1]
                         };
-                        let rust_ty_task =
-                            RustTyDecomposition::from_ty(rust_ty, vcx.tcx(), task_key.def_id());
+                        let rust_ty_task = RustTyDecomposition::from_ty(rust_ty, task_key.def_id());
                         let ty = deps.require_dep::<TyUseImpureEnc>(rust_ty_task)?;
                         Ok(mk_local_def(vcx, local, ty))
                     })

--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -172,17 +172,17 @@ impl MirBuiltinEnc {
         let src_ty_inner = src_ty.peel_refs();
         let dst_ty_inner = dst_ty.peel_refs();
 
-        let ty_task = RustTyDecomposition::from_ty(src_ty_inner, vcx.tcx(), params);
+        let ty_task = RustTyDecomposition::from_ty(src_ty_inner, params);
         let src_array_pure = deps.require_dep::<TyUsePureEnc>(ty_task)?.expect_array();
 
-        let src_ty = RustTyDecomposition::from_ty(src_ty, vcx.tcx(), params);
+        let src_ty = RustTyDecomposition::from_ty(src_ty, params);
         let src_ref_pure = deps.require_dep::<TyUsePureEnc>(src_ty)?;
         let src_ref_impure = deps.require_dep::<TyUseImpureEnc>(src_ty)?;
 
-        let ty_task = RustTyDecomposition::from_ty(dst_ty_inner, vcx.tcx(), params);
+        let ty_task = RustTyDecomposition::from_ty(dst_ty_inner, params);
         let dst_array_pure = deps.require_dep::<TyUsePureEnc>(ty_task)?.expect_array();
 
-        let dst_ty = RustTyDecomposition::from_ty(dst_ty, vcx.tcx(), params);
+        let dst_ty = RustTyDecomposition::from_ty(dst_ty, params);
         let dst_ref_pure = deps.require_dep::<TyUsePureEnc>(dst_ty)?;
         let dst_ref_impure = deps.require_dep::<TyUseImpureEnc>(dst_ty)?;
 
@@ -341,7 +341,7 @@ impl MirBuiltinEnc {
         key: <Self as TaskEncoder>::TaskKey<'vir>,
         arg_ty: ty::Ty<'vir>,
     ) -> Result<vir::Function<'vir>, EncodeFullError<'vir, Self>> {
-        let ty_task = RustTyDecomposition::from_ty(arg_ty, vcx.tcx(), GParams::empty()); // TODO: context ...
+        let ty_task = RustTyDecomposition::from_ty(arg_ty, GParams::empty()); // TODO: context ...
         let arg_ty_pure = deps.require_dep::<TyUsePureEnc>(ty_task)?;
 
         let ty_task = RustTyDecomposition::from_prim_ty(vcx.tcx().types.usize);
@@ -420,7 +420,7 @@ impl MirBuiltinEnc {
             mir::UnOp::PtrMetadata => {
                 // TODO: the task key for this should not store the region
                 //   (e.g. len for &[bool] is currently &'3 [bool] depending on the callsite region)
-                let ty_task = RustTyDecomposition::from_ty(operand_ty, vcx.tcx(), GParams::empty());
+                let ty_task = RustTyDecomposition::from_ty(operand_ty, GParams::empty());
                 let operand_ref_pure = deps.require_dep::<TyUsePureEnc>(ty_task)?;
                 let ty_task = RustTyDecomposition::from_prim_ty(res_ty);
                 let res_ty_enc = deps.require_dep::<TyUsePureEnc>(ty_task)?;
@@ -435,11 +435,8 @@ impl MirBuiltinEnc {
 
                 let body = match operand_ty.peel_refs().kind() {
                     ty::TyKind::Slice(..) | ty::TyKind::Array(..) => {
-                        let ty_task = RustTyDecomposition::from_ty(
-                            operand_ty.peel_refs(),
-                            vcx.tcx(),
-                            GParams::empty(),
-                        );
+                        let ty_task =
+                            RustTyDecomposition::from_ty(operand_ty.peel_refs(), GParams::empty());
                         let operand_array_pure =
                             deps.require_dep::<TyUsePureEnc>(ty_task)?.expect_array();
                         let snap_arg = vcx.mk_local_ex(snap_arg_decl);
@@ -794,7 +791,7 @@ impl MirBuiltinEnc {
             int_name(l_ty),
             int_name(r_ty)
         );
-        let res_ty_task = RustTyDecomposition::from_ty(res_ty, vcx.tcx(), GParams::empty());
+        let res_ty_task = RustTyDecomposition::from_ty(res_ty, GParams::empty());
         let e_res_ty = deps.require_dep::<TyUsePureEnc>(res_ty_task)?;
         let e_res_ty_snap = e_res_ty.snapshot.downcast_ty();
         let function = FunctionIdn::new(name, (e_l_ty_snap, e_r_ty_snap), e_res_ty_snap);

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -280,7 +280,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
     }
 
     fn ty_use_impure(&mut self, ty: ty::Ty<'vir>) -> TyUseImpure<'vir> {
-        let ty_task = RustTyDecomposition::from_ty(ty, self.vcx.tcx(), self.def_id);
+        let ty_task = RustTyDecomposition::from_ty(ty, self.def_id);
         self.deps.require_dep::<TyUseImpureEnc>(ty_task).unwrap()
     }
 
@@ -1205,7 +1205,7 @@ impl<'vir, 'enc, E: TaskEncoder> PureRvalueEnc<'vir> for ImpureEncVisitor<'vir, 
     }
 
     fn ty_use_pure(&mut self, ty: ty::Ty<'vir>) -> TyUsePure<'vir> {
-        let ty_task = RustTyDecomposition::from_ty(ty, self.vcx.tcx(), self.def_id);
+        let ty_task = RustTyDecomposition::from_ty(ty, self.def_id);
         self.deps.require_dep::<TyUsePureEnc>(ty_task).unwrap()
     }
 

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -142,7 +142,7 @@ impl TaskEncoder for MirPureEnc {
             // We wrap the expression with an additional lazy that will perform
             // some sanity checks. These requirements cannot be expressed using
             // only the type system.
-            let ret = RustTyDecomposition::from_ty(body.return_ty(), vcx.tcx(), def_id);
+            let ret = RustTyDecomposition::from_ty(body.return_ty(), def_id);
             let expr = vcx.mk_lazy_expr(
                 vir::vir_format!(vcx, "pure body {def_id:?}"),
                 deps.require_ref::<TyUsePureEnc>(ret)?.snapshot,
@@ -352,7 +352,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
     }
 
     fn ty_use(&mut self, ty: ty::Ty<'vir>) -> TyUsePure<'vir> {
-        let ty_task = RustTyDecomposition::from_ty(ty, self.vcx.tcx(), self.context);
+        let ty_task = RustTyDecomposition::from_ty(ty, self.context);
         self.deps.require_dep::<TyUsePureEnc>(ty_task).unwrap()
     }
 
@@ -367,7 +367,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
 
     fn get_ty_for_local(&mut self, local: mir::Local) -> vir::TypeSnap<'vir> {
         let ty = self.body.local_decls[local].ty;
-        let ty_task = RustTyDecomposition::from_ty(ty, self.vcx.tcx(), self.context);
+        let ty_task = RustTyDecomposition::from_ty(ty, self.context);
         self.deps
             .require_ref::<TyUsePureEnc>(ty_task)
             .unwrap()
@@ -931,8 +931,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
                         let e_ty = e_ty.expect_mutref();
                         let val_expr = e_ty.deref_access(encoded_place.snap.downcast_ty());
                         // TODO: avoid all of this by using shallow and deep snapshots
-                        let ty_task =
-                            RustTyDecomposition::from_ty(place_ty.ty, self.vcx.tcx(), self.context);
+                        let ty_task = RustTyDecomposition::from_ty(place_ty.ty, self.context);
                         let inner = ty_task.ty.expect_mutref();
                         let normalized =
                             inner.decompose_compare_normalize(ty_task.ty.params, ty_task.args);

--- a/prusti-encoder/src/encoders/ty/data.rs
+++ b/prusti-encoder/src/encoders/ty/data.rs
@@ -31,7 +31,6 @@ pub trait TyDatas<'vir>: Debug + Clone + Copy {
 pub type Ty<'vir, D> = &'vir TyData<'vir, D>;
 
 pub struct TyData<'vir, D: TyDatas<'vir>> {
-    pub inhabited: bool,
     pub data: D::TyData,
     pub specifics: TySpecifics<'vir, D>,
 }
@@ -51,24 +50,20 @@ pub enum TySpecifics<'vir, D: TyDatas<'vir>> {
 pub struct ArrayData<'vir, D: TyDatas<'vir>> {
     pub data: D::ArrayData,
     pub slice: bool,
-    pub inhabited: bool,
 }
 
 pub struct StructData<'vir, D: TyDatas<'vir>> {
     pub data: D::StructData,
-    pub inhabited: bool,
     pub fields: Vec<D::FieldData>,
 }
 
 pub struct EnumData<'vir, D: TyDatas<'vir>> {
     pub data: D::EnumData,
-    pub inhabited: bool,
     pub variants: Vec<VariantData<'vir, D>>,
 }
 
 pub struct VariantData<'vir, D: TyDatas<'vir>> {
     pub data: D::VariantData,
-    pub inhabited: bool,
     pub inner: StructData<'vir, D>,
 }
 
@@ -111,16 +106,12 @@ impl<'vir, D: TyDatas<'vir>> TySpecifics<'vir, D> {
         Self::MutRef(data)
     }
 
-    pub fn mk_structlike(data: D::StructData, inhabited: bool, fields: Vec<D::FieldData>) -> Self {
-        Self::StructLike(StructData::new(data, inhabited, fields))
+    pub fn mk_structlike(data: D::StructData, fields: Vec<D::FieldData>) -> Self {
+        Self::StructLike(StructData::new(data, fields))
     }
 
-    pub fn mk_enumlike(
-        data: D::EnumData,
-        inhabited: bool,
-        variants: Vec<VariantData<'vir, D>>,
-    ) -> Self {
-        Self::EnumLike(EnumData::new(data, inhabited, variants))
+    pub fn mk_enumlike(data: D::EnumData, variants: Vec<VariantData<'vir, D>>) -> Self {
+        Self::EnumLike(EnumData::new(data, variants))
     }
 
     pub fn mk_builtin(data: D::BuiltinData) -> Self {
@@ -288,12 +279,10 @@ impl<'vir, D: TyDatas<'vir>> ArrayData<'vir, D> {
         &'vir self,
         other: &'vir ArrayData<'vir, D2>,
     ) -> ArrayData<'vir, (D, D2)> {
-        assert_eq!(self.inhabited, other.inhabited);
         assert_eq!(self.slice, other.slice);
         ArrayData {
             slice: self.slice,
             data: (&self.data, &other.data),
-            inhabited: self.inhabited,
         }
     }
 }
@@ -304,11 +293,9 @@ impl<'vir, D: TyDatas<'vir>> StructData<'vir, D> {
         other: &'vir StructData<'vir, D2>,
     ) -> StructData<'vir, (D, D2)> {
         assert_eq!(self.fields.len(), other.fields.len());
-        assert_eq!(self.inhabited, other.inhabited);
         let fields = self.fields.iter().zip(other.fields.iter());
         StructData {
             data: (&self.data, &other.data),
-            inhabited: self.inhabited,
             fields: fields.collect(),
         }
     }
@@ -320,11 +307,9 @@ impl<'vir, D: TyDatas<'vir>> EnumData<'vir, D> {
         other: &'vir EnumData<'vir, D2>,
     ) -> EnumData<'vir, (D, D2)> {
         assert_eq!(self.variants.len(), other.variants.len());
-        assert_eq!(self.inhabited, other.inhabited);
         let variants = self.variants.iter().zip(other.variants.iter());
         EnumData {
             data: (&self.data, &other.data),
-            inhabited: self.inhabited,
             variants: variants.map(|(v1, v2)| v1.zip(v2)).collect(),
         }
     }
@@ -352,8 +337,8 @@ impl<'vir, D1: TyDatas<'vir>, D2: TyDatas<'vir>> TyDatas<'vir> for (D1, D2) {
 macro_rules! impls {
     ($container:ident$( { $field:ident: $ty:ty })?) => {
 impl<'vir, D: TyDatas<'vir>> $container<'vir, D> {
-    pub fn new(data: D::$container, inhabited: bool $(, $field: $ty)?) -> Self {
-        Self { data, inhabited, $($field,)? }
+    pub fn new(data: D::$container $(, $field: $ty)?) -> Self {
+        Self { data, $($field,)? }
     }
 }
 
@@ -365,7 +350,7 @@ impl<'vir, D: TyDatas<'vir>> Debug for $container<'vir, D> {
 
 impl<'vir, D: TyDatas<'vir>> Clone for $container<'vir, D> {
     fn clone(&self) -> Self {
-        Self { data: self.data.clone(), inhabited: self.inhabited, $($field: self.$field.clone())? }
+        Self { data: self.data.clone(), $($field: self.$field.clone())? }
     }
 }
 
@@ -440,10 +425,8 @@ macro_rules! impl_zip {
     ($container:ident$(.$field:ident)?) => {
 impl<'vir, D: TyDatas<'vir>> $container<'vir, D> {
     pub fn zip<D2: TyDatas<'vir>>(&'vir self, other: &'vir $container<'vir, D2>) -> $container<'vir, (D, D2)> {
-        assert_eq!(self.inhabited, other.inhabited);
         $container {
             data: (&self.data, &other.data),
-            inhabited: self.inhabited,
             $($field: self.$field.zip(&other.$field),)?
         }
     }

--- a/prusti-encoder/src/encoders/ty/generics/args_ty.rs
+++ b/prusti-encoder/src/encoders/ty/generics/args_ty.rs
@@ -49,9 +49,7 @@ impl TaskEncoder for GArgsTyEnc {
             .copied()
             .filter_map(ty::GenericArg::as_type)
             .map(|arg| {
-                let decomp = vir::with_vcx(|vcx| {
-                    RustTyDecomposition::from_ty(arg, vcx.tcx(), task_key.context)
-                });
+                let decomp = RustTyDecomposition::from_ty(arg, task_key.context);
                 params.ty_expr(deps, decomp)
             })
             .collect::<Vec<_>>();

--- a/prusti-encoder/src/encoders/ty/generics/params.rs
+++ b/prusti-encoder/src/encoders/ty/generics/params.rs
@@ -139,6 +139,12 @@ impl<'tcx> GParams<'tcx> {
         self.params
     }
 
+    pub fn typing_env(self) -> ty::TypingEnv<'tcx> {
+        let mut env = ty::TypingEnv::fully_monomorphized();
+        env.param_env = self.env;
+        env
+    }
+
     fn params<T>(
         self,
         f: impl Fn(ty::GenericArg<'tcx>) -> Option<T>,
@@ -267,7 +273,7 @@ impl<'vir> GenericParams<'vir> {
                             TyKind::Param(p) => self.ty_exprs[self.map_idx(p.index).unwrap()],
                             _ => self.ty_expr(
                                 deps,
-                                RustTyDecomposition::from_ty(arg.expect_ty(), tcx, ty.args.context),
+                                RustTyDecomposition::from_ty(arg.expect_ty(), ty.args.context),
                             ),
                         })
                         .collect::<Vec<_>>();

--- a/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
@@ -85,7 +85,6 @@ impl TaskEncoder for TraitImplEnc {
                         deps,
                         RustTyDecomposition::from_ty(
                             tcx.type_of(impl_item.def_id).instantiate_identity(),
-                            tcx,
                             GParams::from(impl_item.def_id),
                         ),
                     );

--- a/prusti-encoder/src/encoders/ty/impure.rs
+++ b/prusti-encoder/src/encoders/ty/impure.rs
@@ -86,7 +86,6 @@ pub enum TyImpureEncError {
 // TODO: should output refs actually be references to structs...?
 #[derive(Debug, Clone, Copy)]
 pub struct TyImpureRef<'vir> {
-    pub inhabited: bool,
     /// Constructs the Viper predicate application.
     pub ref_to_pred: PredicateIdn<'vir, (vir::Ref, vir::ManyTyVal, vir::ManyCSnap)>,
     /// Construct snapshot from Viper ref.
@@ -185,12 +184,11 @@ impl TaskEncoder for TyImpureEnc {
                 ),
             };
             let data = TyImpureRef {
-                inhabited: ty.inhabited,
                 ref_to_pred: builder.ref_to_pred,
                 ref_to_snap: builder.ref_to_snap,
                 method_assign,
             };
-            let output = TyData::new(data, ty.inhabited, specifics).alloc();
+            let output = TyData::new(data, specifics).alloc();
 
             Ok((builder.inner.build(), output))
         })

--- a/prusti-encoder/src/encoders/ty/kinds/arraylike.rs
+++ b/prusti-encoder/src/encoders/ty/kinds/arraylike.rs
@@ -35,7 +35,6 @@ pub(crate) fn ty_pure<'vir>(
             len,
             ref_to_index_ref,
         },
-        data.inhabited,
         data.slice,
     ))
 }
@@ -181,7 +180,6 @@ pub(crate) fn ty_impure<'vir>(
             method_fold,
             method_unfold,
         },
-        data.inhabited,
         data.slice,
     ))
 }

--- a/prusti-encoder/src/encoders/ty/kinds/enumlike.rs
+++ b/prusti-encoder/src/encoders/ty/kinds/enumlike.rs
@@ -41,11 +41,7 @@ pub(crate) fn ty_pure<'vir>(
                 builder,
             )?;
 
-            Ok(VariantData::new(
-                TyPureVariantData { discr },
-                variant.inhabited,
-                specifics,
-            ))
+            Ok(VariantData::new(TyPureVariantData { discr }, specifics))
         })
         .collect::<Result<Vec<_>, _>>()?;
 
@@ -58,7 +54,6 @@ pub(crate) fn ty_pure<'vir>(
             discr_prim: *discr_prim,
             snap_to_discr_snap,
         },
-        data.inhabited,
         variants,
     ))
 }
@@ -121,7 +116,7 @@ pub(crate) fn ty_impure<'vir>(
                 variant.1.discr,
                 VariantData::new(TyImpureVariantData {
                     predicate: variant_pred,
-                }, variant.inhabited, inner)
+                }, inner)
             ))
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -164,7 +159,6 @@ pub(crate) fn ty_impure<'vir>(
             discr: fdisc_func,
             discr_ty: discr_ty_impure,
         },
-        data.inhabited,
         variants.into_iter().map(|v| v.3).collect::<Vec<_>>(),
     ))
 }

--- a/prusti-encoder/src/encoders/ty/kinds/structlike.rs
+++ b/prusti-encoder/src/encoders/ty/kinds/structlike.rs
@@ -70,7 +70,6 @@ pub(super) fn ty_pure_variant<'vir>(
         TyPureStructData {
             field_snaps_to_snap,
         },
-        data.inhabited,
         des,
     ))
 }
@@ -161,7 +160,7 @@ pub(crate) fn ty_impure_variant<'vir>(
     let variant_snap_expr = data.1.field_snaps_to_snap.call()(snap_args.as_slice());
 
     Ok((
-        StructData::new((), data.inhabited, field_accessors),
+        StructData::new((), field_accessors),
         pred_owned,
         variant_snap_expr,
     ))

--- a/prusti-encoder/src/encoders/ty/pure.rs
+++ b/prusti-encoder/src/encoders/ty/pure.rs
@@ -277,7 +277,7 @@ impl TaskEncoder for TyPureEnc {
                     TySpecifics::Builtin(super::kinds::builtin::ty_pure(builtin, builder)?)
                 }
             };
-            let output = TyData::new(output_ref, task_key.inhabited, specifics).alloc();
+            let output = TyData::new(output_ref, specifics).alloc();
             Ok((builder.build(), output))
         })
     }

--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -19,6 +19,7 @@ use super::{
 pub struct RustTyDecomposition<'tcx> {
     pub ty: RustTy<'tcx>,
     pub args: GArgs<'tcx>,
+    pub maybe_inhabited: bool,
 }
 
 impl<'tcx, Ctxt> HasRegions<'tcx, Ctxt> for RustTyDecomposition<'tcx> {
@@ -64,26 +65,20 @@ impl<'tcx> RustTyDecomposition<'tcx> {
     /// unfolding), one should walk the `decomp.ty.specifics` and call
     /// `RustFieldData::decompose_compare_normalize` with `decomp.ty.params`
     /// and `decomp.args`.
-    pub fn from_ty(
-        ty: ty::Ty<'tcx>,
-        tcx: ty::TyCtxt<'tcx>,
-        context: impl Into<GParams<'tcx>>,
-    ) -> Self {
-        let (ty, args) = TyData::<'tcx, RustTyDatas>::from_ty(ty, tcx, context.into());
-        Self { ty, args }
+    pub fn from_ty(ty: ty::Ty<'tcx>, context: impl Into<GParams<'tcx>>) -> Self {
+        TyData::<'tcx, RustTyDatas>::from_ty(ty, context.into())
     }
 
     pub fn from_real() -> Self {
-        let name = "Real";
-        let params = GParams::empty();
         let data = RustTyData {
-            name: symbol::Symbol::intern(name),
-            params,
+            name: symbol::Symbol::intern("Real"),
+            params: GParams::empty(),
         };
         let specifics = TySpecifics::Builtin(RustBuiltinData::BuiltinReal);
         Self {
-            ty: TyData::<'tcx, RustTyDatas>::new(data, true, specifics).alloc(),
-            args: GArgs::new(params, &[]),
+            ty: TyData::<'tcx, RustTyDatas>::new(data, specifics).alloc(),
+            args: GArgs::new(GParams::empty(), &[]),
+            maybe_inhabited: true,
         }
     }
 
@@ -91,8 +86,7 @@ impl<'tcx> RustTyDecomposition<'tcx> {
     /// but requires fewer arguments when the type is known to be primitive.
     pub fn from_prim_ty(ty: ty::Ty<'tcx>) -> Self {
         assert!(ty.is_primitive());
-        let (ty, args) = TyData::<'tcx, RustTyDatas>::from_prim_ty(ty);
-        Self { ty, args }
+        TyData::<'tcx, RustTyDatas>::from_prim_ty(ty)
     }
 }
 
@@ -133,7 +127,7 @@ impl<'tcx> LazyRustTy<'tcx> {
     /// decomposing the field of the struct would yield `TySpecifics::Param`
     /// with arguments `<T>` (i.e. the `i32` from the context is lost).
     pub fn decompose(&self, params: GParams<'tcx>) -> RustTyDecomposition<'tcx> {
-        vir::with_vcx(|vcx| RustTyDecomposition::from_ty(self.0, vcx.tcx(), params))
+        RustTyDecomposition::from_ty(self.0, params)
     }
 
     /// Decomposes the field's type into a `RustTyDecomposition` (to be used
@@ -159,10 +153,8 @@ impl<'tcx> LazyRustTy<'tcx> {
     /// removing definitional generics. For example a `Foo<i32>` with definition
     /// `struct Foo<T>(T);` would yield `i32` instead of `T` when called on the
     /// field of `Foo`.
-    fn decompose_normalize(&self, args: GArgs<'tcx>) -> RustTyDecomposition<'tcx> {
-        vir::with_vcx(|vcx| {
-            RustTyDecomposition::from_ty(args.normalize(self.0), vcx.tcx(), args.context())
-        })
+    pub(super) fn decompose_normalize(&self, args: GArgs<'tcx>) -> RustTyDecomposition<'tcx> {
+        RustTyDecomposition::from_ty(args.normalize(self.0), args.context())
     }
 
     /// Similarly to `Self::decompose`, this decomposes the fields type.
@@ -200,7 +192,7 @@ impl<'tcx> LazyRustTy<'tcx> {
         let TySpecifics::Param(..) = &param.specifics else {
             return None;
         };
-        let RustTyDecomposition { ty, args } = self.decompose_normalize(args);
+        let RustTyDecomposition { ty, args, .. } = self.decompose_normalize(args);
         if let TySpecifics::Param(..) = &ty.specifics {
             None
         } else {
@@ -294,11 +286,7 @@ impl<'tcx> Deref for RustFieldData<'tcx> {
 }
 
 impl<'tcx> TyData<'tcx, RustTyDatas> {
-    fn from_ty(
-        ty: ty::Ty<'tcx>,
-        tcx: ty::TyCtxt<'tcx>,
-        context: GParams<'tcx>,
-    ) -> (RustTy<'tcx>, GArgs<'tcx>) {
+    fn from_ty(ty: ty::Ty<'tcx>, context: GParams<'tcx>) -> RustTyDecomposition<'tcx> {
         // We normalize since we may be translating a type such as the field of
         // `struct MyStruct<T: Iterator<Item = i32>>(T::Item);` where `ty` is
         // `T::Item` and `context` is `<T: Iterator<Item = i32>>`. In this case
@@ -314,11 +302,16 @@ impl<'tcx> TyData<'tcx, RustTyDatas> {
             params,
         };
         let specifics = TySpecifics::from_ty(ty);
-        let inhabited = !ty.is_privately_uninhabited(tcx, ty::TypingEnv::fully_monomorphized());
-        (Self::new(data, inhabited, specifics).alloc(), args)
+        let maybe_inhabited =
+            vir::with_vcx(|vcx| !ty.is_privately_uninhabited(vcx.tcx(), context.typing_env()));
+        RustTyDecomposition {
+            ty: Self::new(data, specifics).alloc(),
+            args,
+            maybe_inhabited,
+        }
     }
 
-    fn from_prim_ty(ty: ty::Ty<'tcx>) -> (RustTy<'tcx>, GArgs<'tcx>) {
+    fn from_prim_ty(ty: ty::Ty<'tcx>) -> RustTyDecomposition<'tcx> {
         let name = Self::prim_ty_name(ty);
         let (params, args) = Self::identity_for_prim_ty(ty);
         let args = GArgs::new(params, args);
@@ -327,7 +320,11 @@ impl<'tcx> TyData<'tcx, RustTyDatas> {
             params,
         };
         let specifics = TySpecifics::from_prim_ty(ty);
-        (Self::new(data, true, specifics).alloc(), args)
+        RustTyDecomposition {
+            ty: Self::new(data, specifics).alloc(),
+            args,
+            maybe_inhabited: true,
+        }
     }
 
     fn ty_name(ty: ty::Ty<'tcx>) -> String {
@@ -488,16 +485,14 @@ impl<'tcx> TySpecifics<'tcx, RustTyDatas> {
                         ty: LazyRustTy(Self::new_param_ty(i as u32)),
                     })
                     .collect::<Vec<_>>();
-                TySpecifics::mk_structlike((), true, fields)
+                TySpecifics::mk_structlike((), fields)
             }
             ty::TyKind::Array(_, _) => TySpecifics::ArrayLike(ArrayData {
                 slice: false,
-                inhabited: true,
                 data: LazyRustTy(Self::new_param_ty(1)),
             }),
             ty::TyKind::Slice(_) => TySpecifics::ArrayLike(ArrayData {
                 slice: true,
-                inhabited: true,
                 data: LazyRustTy(Self::new_param_ty(0)),
             }),
             ty::TyKind::Ref(_, _, mutability) => match mutability {
@@ -522,13 +517,13 @@ impl<'tcx> TySpecifics<'tcx, RustTyDatas> {
                         ty: LazyRustTy(ty),
                     })
                     .collect::<Vec<_>>();
-                TySpecifics::mk_structlike((), true, fields)
+                TySpecifics::mk_structlike((), fields)
             }
             ty::TyKind::Never => {
                 let data = vir::with_vcx(|vcx| RustEnumData {
                     discr: vcx.tcx().types.isize,
                 });
-                TySpecifics::mk_enumlike(data, false, Vec::new())
+                TySpecifics::mk_enumlike(data, Vec::new())
             }
             // TODO: add str support
             ty::TyKind::Str => TySpecifics::mk_opaque(()),
@@ -548,7 +543,7 @@ impl<'tcx> TySpecifics<'tcx, RustTyDatas> {
                 fid: abi::FieldIdx::from_usize(0),
                 ty: LazyRustTy(Self::new_param_ty(0)),
             }];
-            TySpecifics::mk_structlike((), true, fields)
+            TySpecifics::mk_structlike((), fields)
         } else if vir::with_vcx(|vcx| {
             EnvQuery::new(vcx.tcx()).is_adt_in_crate(adt, "prusti_contracts")
         }) {
@@ -577,7 +572,7 @@ impl<'tcx> TySpecifics<'tcx, RustTyDatas> {
 
     fn from_struct(variant: &ty::VariantDef) -> StructData<'tcx, RustTyDatas> {
         let fields = Self::from_fields(&variant.fields);
-        StructData::new((), true, fields)
+        StructData::new((), fields)
     }
 
     fn from_enum(adt: ty::AdtDef<'tcx>) -> EnumData<'tcx, RustTyDatas> {
@@ -596,12 +591,11 @@ impl<'tcx> TySpecifics<'tcx, RustTyDatas> {
                             vid,
                             discr_val: discr.val,
                         },
-                        true,
-                        StructData::new((), true, fields),
+                        StructData::new((), fields),
                     )
                 })
                 .collect::<Vec<_>>();
-            EnumData::new(data, true, variants)
+            EnumData::new(data, variants)
         })
     }
 

--- a/prusti-encoder/src/encoders/ty/use_impure.rs
+++ b/prusti-encoder/src/encoders/ty/use_impure.rs
@@ -43,6 +43,7 @@ pub type TyUseImpureEnum<'vir> = EnumData<'vir, UseImpureTyDatas>;
 pub struct TyUseImpureData<'vir> {
     args: GArgsTy<'vir>,
     impure: <ImpureTyDatas as TyDatas<'vir>>::TyData,
+    maybe_inhabited: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -119,7 +120,7 @@ impl TaskEncoder for TyUseImpureEnc {
 
         let ty_impure = deps.require_dep::<TyImpureEnc>(task_key.ty)?;
         let mut walker = TyUseImpureWalker::new(deps, task_key.args);
-        let ty_use_impure = walker.encode_ty(task_key.ty.zip(ty_impure));
+        let ty_use_impure = walker.encode_ty(task_key.ty.zip(ty_impure), task_key.maybe_inhabited);
         Ok(((), ty_use_impure.alloc()))
     }
 
@@ -143,6 +144,7 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
     fn encode_ty(
         &mut self,
         ty: TyData<'vir, (RustTyDatas, ImpureTyDatas)>,
+        maybe_inhabited: bool,
     ) -> TyData<'vir, UseImpureTyDatas> {
         let specifics = match &ty.specifics {
             TySpecifics::Param(..) => TySpecifics::mk_param(()),
@@ -179,8 +181,9 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
         let data = TyUseImpureData {
             args: self.args_t,
             impure: *ty.1,
+            maybe_inhabited,
         };
-        TyData::new(data, ty.inhabited, specifics)
+        TyData::new(data, specifics)
     }
 
     fn encode_normalized(
@@ -202,13 +205,12 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
     ) -> ArrayData<'vir, UseImpureTyDatas> {
         let caster = self.encode_normalized(*data.0, params);
         let slice = data.slice;
-        let inhabited = data.inhabited;
         let data = TyUseImpureArrayData {
             args: self.args_t,
             impure: *data.data.1,
             element_caster: caster,
         };
-        ArrayData::new(data, inhabited, slice)
+        ArrayData::new(data, slice)
     }
 
     fn encode_structlike(
@@ -229,13 +231,12 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
                 }
             })
             .collect::<Vec<_>>();
-        let inhabited = data.inhabited;
         let data = TyUseImpureStructData {
             args: self.args_t,
             ref_to_pred,
             impure: *data.1,
         };
-        StructData::new(data, inhabited, fields)
+        StructData::new(data, fields)
     }
 
     fn encode_enumlike(
@@ -249,15 +250,14 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
             .map(|variant| {
                 let structlike =
                     self.encode_structlike(&variant.inner, variant.1.predicate, params);
-                VariantData::new((), variant.inhabited, structlike)
+                VariantData::new((), structlike)
             })
             .collect::<Vec<_>>();
-        let inhabited = data.inhabited;
         let data = TyUseImpureEnumData {
             args: self.args_t,
             impure: *data.1,
         };
-        EnumData::new(data, inhabited, variants)
+        EnumData::new(data, variants)
     }
 }
 
@@ -285,7 +285,7 @@ impl<'vir> TyUseImpureData<'vir> {
         self_ref: vir::ExprRef<'vir>,
         perm: Option<vir::ExprPerm<'vir>>,
     ) -> vir::ExprBool<'vir> {
-        if self.impure.inhabited {
+        if self.maybe_inhabited {
             vcx.mk_predicate_app_expr(self.ref_to_pred_app(self_ref, perm))
         } else {
             vcx.mk_bool::<false>()

--- a/prusti-encoder/src/encoders/ty/use_pure.rs
+++ b/prusti-encoder/src/encoders/ty/use_pure.rs
@@ -123,10 +123,9 @@ impl TaskEncoder for TyUsePureEnc {
 
         let ty_pure = deps.require_dep::<TyPureEnc>(task_key.ty)?;
         let ty = task_key.ty.zip(ty_pure);
-        let inhabited = ty.inhabited;
         let mut walker = TyUsePureWalker::new(deps, task_key.args);
         let specifics = walker.encode_ty(ty);
-        let ty_use_pure = TyData::new(inner, inhabited, specifics);
+        let ty_use_pure = TyData::new(inner, specifics);
         Ok(((), ty_use_pure.alloc()))
     }
 
@@ -206,13 +205,12 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
     ) -> ArrayData<'vir, UsePureTyDatas> {
         let caster = self.encode_normalized(*data.0, params);
         let slice = data.slice;
-        let inhabited = data.inhabited;
         let data = TyUsePureArrayData {
             caster,
             args: self.args_t,
             pure: *data.data.1,
         };
-        ArrayData::new(data, inhabited, slice)
+        ArrayData::new(data, slice)
     }
 
     fn encode_structlike(
@@ -232,12 +230,11 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
                 }
             })
             .collect::<Vec<_>>();
-        let inhabited = data.inhabited;
         let data = TyUsePureStructData {
             args: self.args_t,
             pure: *data.1,
         };
-        StructData::new(data, inhabited, fields)
+        StructData::new(data, fields)
     }
 
     fn encode_enumlike(
@@ -250,10 +247,10 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
             .iter()
             .map(|variant| {
                 let structlike = self.encode_structlike(&variant.inner, params);
-                VariantData::new(*variant.1, variant.inhabited, structlike)
+                VariantData::new(*variant.1, structlike)
             })
             .collect::<Vec<_>>();
-        EnumData::new(*data.1, data.inhabited, variants)
+        EnumData::new(*data.1, variants)
     }
 }
 

--- a/prusti-encoder/src/encoders/ty/viper_tuple.rs
+++ b/prusti-encoder/src/encoders/ty/viper_tuple.rs
@@ -62,7 +62,7 @@ impl TaskEncoder for ViperTupleEnc {
         vir::with_vcx(|vcx| {
             let tys = vcx.tcx().mk_type_list(tys);
             let ty = vcx.tcx().mk_ty_from_kind(ty::TyKind::Tuple(tys));
-            RustTyDecomposition::from_ty(ty, vcx.tcx(), *def_id)
+            RustTyDecomposition::from_ty(ty, *def_id)
         })
     }
 


### PR DESCRIPTION
Cleans up the mess associated with inhabitedness. What still isn't handled is when an enum has an uninhabited variant and is then matched, e.g. the following will fail to verify:

```rust
fn foo(x: Result<i32, std::convert::Infallible>) -> i32 {
	let Ok(x) = x;
	x
}
```