### PR TITLE
Minor fixes

### DIFF
--- a/prusti-encoder/src/encoders/impure/fn_wand.rs
+++ b/prusti-encoder/src/encoders/impure/fn_wand.rs
@@ -1,6 +1,6 @@
 use crate::encoders::{
     ImpureEncVisitor, MirLocalDefEncOutput, MirSpecEnc,
-    pure::spec::EncodedPledge,
+    pure::spec::{EncodedPledge, PledgeArgs, PledgeExpr},
     ty::{RustTyDecomposition, generics::GParams, indirect::IndirectPredicatesEnc},
 };
 use pcg::borrow_pcg::{
@@ -9,7 +9,7 @@ use pcg::borrow_pcg::{
 };
 use prusti_interface::PrustiError;
 use prusti_rustc_interface::{
-    data_structures::fx::{FxHashMap, FxHashSet},
+    data_structures::fx::FxHashSet,
     middle::{mir, ty},
     span::def_id::DefId,
 };
@@ -30,25 +30,17 @@ impl<'vir, E: TaskEncoder> ImpureEncVisitor<'vir, '_, E> {
         final_borrow_state: &BorrowsState<'_, 'vir>,
     ) -> Result<Vec<vir::Stmt<'vir>>, EncodeFullError<'vir, E>> {
         let mut wand_packages = Vec::new();
-        let vcx = self.vcx;
         let label = self.new_label("package_post");
-        let snap_lhs = |l| {
-            let ld: crate::encoders::LocalDef<'vir> = self.local_defs.locals[l];
-            if l == mir::RETURN_PLACE {
-                vcx.mk_local_labelled_old_expr(ld.impure_snap, label)
-            } else {
-                vcx.mk_old_expr(ld.impure_snap)
-            }
-        };
-        let snap_rhs = |l| {
-            let ld: crate::encoders::LocalDef<'vir> = self.local_defs.locals[l];
-            vcx.mk_old_expr(ld.impure_snap)
-        };
+        let result = self.local_defs.locals[mir::RETURN_PLACE].impure_snap;
+        let result = self.vcx.mk_local_labelled_old_expr(result, label);
+        let args = self
+            .local_defs
+            .args()
+            .map(|a| self.vcx.mk_old_expr(a.impure_snap));
+        let args = PledgeExpr::pledge_args(result, args);
 
         for wand_data in self.wands.viper_wands() {
-            let wand = self
-                .wands
-                .mk_wand(&wand_data, snap_lhs, snap_rhs, vcx, self.deps);
+            let wand = self.wands.mk_wand(&wand_data, args, self.vcx, self.deps);
             let mut package_script = Vec::new();
             for rhs in wand_data.rhs.iter() {
                 let ug = UnblockGraph::for_node(
@@ -63,7 +55,12 @@ impl<'vir, E: TaskEncoder> ImpureEncVisitor<'vir, '_, E> {
                 package_script.extend(unblock);
             }
 
-            for EncodedPledge { spec, span, .. } in wand_data.pledges.iter().copied() {
+            for EncodedPledge {
+                expiry_postcondition,
+                ..
+            } in wand_data.pledges.iter().copied()
+            {
+                let span = expiry_postcondition.span();
                 self.vcx.with_span(span, |vcx| {
                     vcx.handle_error("exhale.failed:assertion.false", move |_| {
                         Some(vec![PrustiError::verification(
@@ -71,7 +68,7 @@ impl<'vir, E: TaskEncoder> ImpureEncVisitor<'vir, '_, E> {
                             span.into(),
                         )])
                     });
-                    package_script.push(vcx.mk_exhale_stmt(spec));
+                    package_script.push(vcx.mk_exhale_stmt(expiry_postcondition.expr(args)));
                 });
             }
             wand_packages.push(
@@ -192,26 +189,22 @@ impl<'vir> WandEncOutput<'vir> {
         local_defs: &'a MirLocalDefEncOutput<'vir>,
         deps: &'a mut TaskEncoderDependencies<'vir, E>,
     ) -> impl Iterator<Item = vir::ExprBool<'vir>> + 'a {
+        let wand_result =
+            vcx.mk_local_decl("wand_result", local_defs[mir::RETURN_PLACE].local_snap.ty());
+        let wand_result_expr = vcx.mk_local_ex(wand_result);
+        let args = local_defs
+            .args()
+            .map(|arg| vcx.mk_old_expr(arg.impure_snap));
+        let args = PledgeExpr::pledge_args(wand_result_expr, args);
+
         // TODO: wands for late-bound regions
-        self.viper_wands().into_iter().map(|wand_data| {
-            let mut snaps = FxHashMap::default();
-            let snap_lhs = |i| {
-                snaps
-                    .entry(i)
-                    .or_insert_with(|| {
-                        let name = vir::vir_format!(vcx, "wand{:?}", i);
-                        let decl = vcx.mk_local_decl(name, local_defs[i].local_snap.ty());
-                        (decl, vcx.mk_local_ex(decl))
-                    })
-                    .1
-            };
-            let snap_rhs = |i| vcx.mk_old_expr(local_defs[i].impure_snap);
-            let wand = self.mk_wand(&wand_data, snap_lhs, snap_rhs, vcx, deps);
-            snaps
-                .into_iter()
-                .fold(vcx.mk_wand_expr(wand), |acc, (local, (name, _))| {
-                    vcx.mk_let_expr(name, local_defs[local].impure_snap, acc)
-                })
+        self.viper_wands().into_iter().map(move |wand_data| {
+            let wand = self.mk_wand(&wand_data, args, vcx, deps);
+            vcx.mk_let_expr(
+                wand_result,
+                local_defs[mir::RETURN_PLACE].impure_snap,
+                vcx.mk_wand_expr(wand),
+            )
         })
     }
 
@@ -222,18 +215,17 @@ impl<'vir> WandEncOutput<'vir> {
         label_post: &'vir str,
         visitor: &mut ImpureEncVisitor<'vir, '_, E>,
     ) {
-        let vcx = visitor.vcx;
-        let snap_lhs = |l: mir::Local| {
-            if l == mir::RETURN_PLACE {
-                vcx.mk_local_labelled_old_expr(arguments[l.as_usize()], label_post)
-            } else {
-                vcx.mk_local_labelled_old_expr(arguments[l.as_usize()], label_pre)
-            }
-        };
-        let snap_rhs =
-            |l: mir::Local| vcx.mk_local_labelled_old_expr(arguments[l.as_usize()], label_pre);
+        let result = visitor
+            .vcx
+            .mk_local_labelled_old_expr(arguments[mir::RETURN_PLACE.as_usize()], label_post);
+        let args = (1..arguments.len()).map(|l| {
+            visitor
+                .vcx
+                .mk_local_labelled_old_expr(arguments[l], label_pre)
+        });
+        let args = PledgeExpr::pledge_args(result, args);
         for wand_data in self.viper_wands() {
-            let wand = self.mk_wand(&wand_data, snap_lhs, snap_rhs, vcx, visitor.deps);
+            let wand = self.mk_wand(&wand_data, args, visitor.vcx, visitor.deps);
             visitor.stmt(visitor.vcx.mk_apply_stmt(wand));
         }
     }
@@ -241,27 +233,30 @@ impl<'vir> WandEncOutput<'vir> {
     fn mk_wand<'a, E: TaskEncoder>(
         &'a self,
         wand_data: &WandData<'vir>,
-        mut snap_lhs: impl FnMut(mir::Local) -> vir::ExprSnap<'vir>,
-        mut snap_rhs: impl FnMut(mir::Local) -> vir::ExprSnap<'vir>,
+        pledge_args: PledgeArgs<'vir>,
         vcx: &'vir vir::VirCtxt<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, E>,
     ) -> vir::Wand<'vir> {
         debug_assert!(!wand_data.lhs.is_empty());
-        let rhs = wand_data
-            .rhs
-            .iter()
-            .map(|g| self.encode_predicates_for_function_shape_node(vcx, deps, *g, &mut snap_rhs));
-        let rhs = rhs.chain(wand_data.pledges.iter().map(|pledge| pledge.spec));
+        let rhs = wand_data.rhs.iter().map(|g| {
+            self.encode_predicates_for_function_shape_node(vcx, deps, *g, |i| pledge_args[i])
+        });
+        let rhs = rhs.chain(
+            wand_data
+                .pledges
+                .iter()
+                .map(|pledge| pledge.expiry_postcondition.expr(pledge_args)),
+        );
         let rhs = vcx.mk_conj(vcx.alloc_slice(&rhs.collect::<Vec<_>>()));
-        let lhs = wand_data
-            .lhs
-            .iter()
-            .map(|g| self.encode_predicates_for_function_shape_node(vcx, deps, *g, &mut snap_lhs));
+        let lhs = wand_data.lhs.iter().map(|g| {
+            self.encode_predicates_for_function_shape_node(vcx, deps, *g, |i| pledge_args[i])
+        });
         let lhs = lhs.chain(
             wand_data
                 .pledges
                 .iter()
-                .filter_map(|pledge| pledge.expiry_obligation_expr()),
+                .filter_map(|pledge| pledge.expiry_obligation)
+                .map(|expr| expr.expr(pledge_args)),
         );
         let lhs = vcx.mk_conj(vcx.alloc_slice(&lhs.collect::<Vec<_>>()));
         vcx.mk_wand(lhs, rhs)

--- a/prusti-encoder/src/encoders/impure/fn_wand.rs
+++ b/prusti-encoder/src/encoders/impure/fn_wand.rs
@@ -58,7 +58,7 @@ impl<'vir, E: TaskEncoder> ImpureEncVisitor<'vir, '_, E> {
             for EncodedPledge {
                 expiry_postcondition,
                 ..
-            } in wand_data.pledges.iter().copied()
+            } in &wand_data.pledges
             {
                 let span = expiry_postcondition.span();
                 self.vcx.with_span(span, |vcx| {

--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -622,69 +622,24 @@ impl MirBuiltinEnc {
                             .mk_bin_op_expr(vir::BinOpKind::Or, arg1_cond, arg2_cond)
                             .downcast_ty::<vir::Bool>();
                         pres.push(pre);
-                        // The Rust and Viper (SMT) semantics for `\` and `%` do not
-                        // match up when `arg1 < 0`, encode this difference.
-                        if matches!(op, Div) {
-                            // `arg1 >= 0 ? arg1 \ arg2 : arg2 >= 0 ? (arg1 - 1) \ arg2 + 1 : (arg1 - 1) \ arg2 - 1`
-                            let lhs_sub = vcx.mk_bin_op_expr(
-                                vir::BinOpKind::Sub,
-                                lhs.downcast_ty(),
-                                vcx.mk_int::<1>(),
-                            );
-                            let common_div = vcx
-                                .mk_bin_op_expr_inner(op_kind, lhs_sub.as_dyn(), rhs.as_dyn())
-                                .downcast_ty();
-                            let neg_pos = vcx.mk_bin_op_expr(
-                                vir::BinOpKind::Add,
-                                common_div,
-                                vcx.mk_int::<1>(),
-                            );
-                            let neg_neg = vcx.mk_bin_op_expr(
-                                vir::BinOpKind::Sub,
-                                common_div,
-                                vcx.mk_int::<1>(),
-                            );
-                            let rhs_pos = vcx
-                                .mk_bin_op_expr(
-                                    vir::BinOpKind::CmpGe,
-                                    rhs.downcast_ty(),
-                                    vcx.mk_int::<0>(),
-                                )
-                                .downcast_ty();
-                            let negative = vcx.mk_ternary_expr(rhs_pos, neg_pos, neg_neg);
-                            let lhs_pos = vcx
-                                .mk_bin_op_expr(
-                                    vir::BinOpKind::CmpGe,
-                                    lhs.downcast_ty(),
-                                    vcx.mk_int::<0>(),
-                                )
-                                .downcast_ty();
-                            val = vcx.mk_ternary_expr(lhs_pos, val, negative);
-                        } else {
-                            // `arg1 >= 0 ? arg1 % arg2 : (arg1 % arg2) - (arg2 >= 0 ? arg2 : -arg2)`
-                            let rhs_pos = vcx
-                                .mk_bin_op_expr(
-                                    vir::BinOpKind::CmpGe,
-                                    rhs.downcast_ty(),
-                                    vcx.mk_int::<0>(),
-                                )
-                                .downcast_ty();
-                            let rhs_abs = vcx.mk_ternary_expr(
-                                rhs_pos,
-                                rhs,
-                                vcx.mk_unary_op_expr(vir::UnOpKind::Neg, rhs),
-                            );
-                            let negative =
-                                vcx.mk_bin_op_expr(vir::BinOpKind::Sub, viper_val, rhs_abs);
-                            let lhs_pos = vcx
-                                .mk_bin_op_expr(
-                                    vir::BinOpKind::CmpGe,
-                                    lhs.downcast_ty(),
-                                    vcx.mk_int::<0>(),
-                                )
-                                .downcast_ty();
-                            val = vcx.mk_ternary_expr(lhs_pos, val, negative);
-                        }
+
+                        // In SMTLib/Viper `\` and `%` round towards negative
+                        // infinity, whereas Rust rounds to zero. Therefore, in
+                        // the negative case where this matters, we flip the
+                        // sign to get the opposite rounding.
+                        let lhs_neg = vcx.mk_unary_op_expr(vir::UnOpKind::Neg, lhs);
+                        let val_inv_neg = vcx
+                            .mk_bin_op_expr_inner(op_kind, lhs_neg.as_dyn(), rhs.as_dyn())
+                            .downcast_ty();
+                        // -(-arg1 `op` arg2)
+                        let val_neg = vcx.mk_unary_op_expr(vir::UnOpKind::Neg, val_inv_neg);
+                        let lhs_pos = vcx.mk_bin_op_expr(
+                            vir::BinOpKind::CmpGe,
+                            lhs.downcast_ty(),
+                            vcx.mk_int::<0>(),
+                        );
+                        // arg1 >= 0 ? arg1 `op` arg2 : -(-arg1 `op` arg2)
+                        val = vcx.mk_ternary_expr(lhs_pos.downcast_ty(), val, val_neg);
                     }
                     (pres, val)
                 }

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -858,6 +858,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 RepackOp::Weaken(weaken) => {
                     weaken.from_cap().is_exclusive() && weaken.to_cap().is_read()
                 }
+                RepackOp::StorageDead(..) => true,
                 _ => false,
             }
         }
@@ -1612,77 +1613,91 @@ impl<'vir, 'enc, E: TaskEncoder> mir::visit::Visitor<'vir> for ImpureEncVisitor<
                     .encode_place(Place::from(*destination))
                     .expr
                     .expect_predicate();
-                if is_pure {
-                    let pure_func = self
-                        .deps
-                        .require_dep::<FunctionCallEnc>(CallTaskDescription::new(
-                            self.def_id,
-                            caller_substs,
-                            func_def_id,
-                        ))
-                        .unwrap();
-                    let snap_args = args
-                        .iter()
-                        .map(|arg| {
-                            self.vcx.with_span(arg.span, |_| {
-                                self.encode_operand_snap(&arg.node, &()).unwrap()
+                self.vcx.with_span(terminator.source_info.span, |vcx| {
+                    if is_pure {
+                        let pure_func = self
+                            .deps
+                            .require_dep::<FunctionCallEnc>(CallTaskDescription::new(
+                                self.def_id,
+                                caller_substs,
+                                func_def_id,
+                            ))
+                            .unwrap();
+                        let snap_args = args
+                            .iter()
+                            .map(|arg| {
+                                self.vcx.with_span(arg.span, |_| {
+                                    self.encode_operand_snap(&arg.node, &()).unwrap()
+                                })
                             })
-                        })
-                        .collect::<Vec<_>>();
-                    let pure_func_app = pure_func.call(snap_args);
+                            .collect::<Vec<_>>();
+                        let pure_func_app = pure_func.call(snap_args);
 
-                    let return_ty = destination.ty(self.local_decls, self.vcx.tcx()).ty;
-                    let assign_stmt = self.ty_use_impure(return_ty).apply_method_assign(
-                        self.vcx,
-                        dest,
-                        pure_func_app,
-                    );
+                        let return_ty = destination.ty(self.local_decls, self.vcx.tcx()).ty;
+                        let assign_stmt = self.ty_use_impure(return_ty).apply_method_assign(
+                            self.vcx,
+                            dest,
+                            pure_func_app,
+                        );
 
-                    self.stmt(assign_stmt);
-                } else {
-                    vir::with_vcx(|vcx| {
-                        vcx.with_span(terminator.source_info.span, |vcx| {
-                            let Ok(func_out) = self.deps.require_dep::<encoders::MethodCallEnc>(
-                                CallTaskDescription::new(self.def_id, caller_substs, func_def_id),
-                            ) else {
-                                self.current_terminator = Some(
-                                    self.vcx
-                                        .mk_dummy_stmt(vir::vir_format!(self.vcx, "recursion",)),
+                        vcx.handle_error(
+                            "application.precondition:assertion.false",
+                            move |reason_span_opt| {
+                                let mut error = PrustiError::verification(
+                                    "precondition might not hold",
+                                    span.into(),
                                 );
-                                return;
-                            };
-
-                            let method_in = args
-                                .iter()
-                                .map(|arg| self.encode_operand(&arg.node).unwrap())
-                                .collect::<Vec<_>>();
-
-                            let call = func_out.call(method_in, dest);
-
-                            let label_pre = self.new_label("pre");
-                            vcx.handle_error(
-                                "call.precondition:assertion.false",
-                                move |reason_span_opt| {
-                                    let mut error = PrustiError::verification(
-                                        "precondition might not hold",
-                                        span.into(),
+                                if let Some(reason_span) = reason_span_opt {
+                                    error.add_note_mut(
+                                        "the failing precondition is here",
+                                        Some(reason_span.into()),
                                     );
-                                    if let Some(reason_span) = reason_span_opt {
-                                        error.add_note_mut(
-                                            "the failing precondition is here",
-                                            Some(reason_span.into()),
-                                        );
-                                    }
-                                    Some(vec![error])
-                                },
+                                }
+                                Some(vec![error])
+                            },
+                        );
+                        self.stmt(assign_stmt);
+                    } else {
+                        let Ok(func_out) = self.deps.require_dep::<encoders::MethodCallEnc>(
+                            CallTaskDescription::new(self.def_id, caller_substs, func_def_id),
+                        ) else {
+                            self.current_terminator = Some(
+                                self.vcx
+                                    .mk_dummy_stmt(vir::vir_format!(self.vcx, "recursion",)),
                             );
-                            self.stmts(call);
-                            let label_post = self.new_label("post");
-                            self.call_labels
-                                .insert(location.block, (label_pre, label_post));
-                        })
-                    });
-                }
+                            return;
+                        };
+
+                        let method_in = args
+                            .iter()
+                            .map(|arg| self.encode_operand(&arg.node).unwrap())
+                            .collect::<Vec<_>>();
+
+                        let call = func_out.call(method_in, dest);
+
+                        let label_pre = self.new_label("pre");
+                        vcx.handle_error(
+                            "call.precondition:assertion.false",
+                            move |reason_span_opt| {
+                                let mut error = PrustiError::verification(
+                                    "precondition might not hold",
+                                    span.into(),
+                                );
+                                if let Some(reason_span) = reason_span_opt {
+                                    error.add_note_mut(
+                                        "the failing precondition is here",
+                                        Some(reason_span.into()),
+                                    );
+                                }
+                                Some(vec![error])
+                            },
+                        );
+                        self.stmts(call);
+                        let label_post = self.new_label("post");
+                        self.call_labels
+                            .insert(location.block, (label_pre, label_post));
+                    }
+                });
 
                 target
                     .map(|target| {

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -45,7 +45,7 @@ pub enum Mode {
 }
 
 // TODO: does this need to be `&'vir [..]`?
-type ExprInput<'vir> = (DefId, &'vir [vir::ExprSnap<'vir>]);
+pub type ExprInput<'vir> = (DefId, &'vir [vir::ExprSnap<'vir>]);
 type ExprRet<'vir> = vir::ExprGenSnap<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>;
 type ExprRetRef<'vir> = vir::ExprGenRef<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>;
 type ExprRetAny<'vir, T> = vir::ExprGen<'vir, ExprInput<'vir>, vir::ExprKind<'vir>, T>;

--- a/prusti-encoder/src/encoders/pure/spec.rs
+++ b/prusti-encoder/src/encoders/pure/spec.rs
@@ -1,3 +1,5 @@
+use std::borrow::Borrow;
+
 use prusti_interface::{
     PrustiError,
     specs::{specifications::find_trait_method_substs, typed::Pledge},
@@ -12,24 +14,61 @@ use vir::{CastType, HasType, Reify};
 
 use crate::encoders::{
     MirLocalDefEncTask, MirPureEnc,
-    mir_pure::PureKind,
+    mir_pure::{ExprInput, PureKind},
     ty::{RustTyDecomposition, use_pure::TyUsePureEnc},
 };
 pub struct MirSpecEnc;
 
-/// The VIR expression and span corresponding to an `assert_on_expiry`
-/// predicate. It will be conjoined to the left-hand side of the wand for the
-/// encoded pledge.
-#[derive(Clone, Copy, Debug)]
-pub struct PledgeExpiryObligation<'vir> {
-    pub expr: vir::ExprBool<'vir>,
-    #[allow(unused)]
-    pub span: Span,
+/// The VIR expression and span corresponding to either the lhs or rhs of a
+/// pledge. It will be conjoined to the permission expression of the
+/// corresponding side of the wand for the encoded pledge.
+#[derive(Debug, Clone, Copy)]
+pub struct PledgeExpr<'vir> {
+    did: DefId,
+    expr: vir::ExprGenBool<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>,
 }
 
-impl<'vir> PledgeExpiryObligation<'vir> {
-    pub fn new(expr: vir::ExprBool<'vir>, span: Span) -> Self {
-        Self { expr, span }
+#[derive(Debug, Clone, Copy)]
+pub struct PledgeArgs<'vir>(&'vir [vir::ExprSnap<'vir>]);
+
+impl<'vir> std::ops::Index<mir::Local> for PledgeArgs<'vir> {
+    type Output = vir::ExprSnap<'vir>;
+
+    fn index(&self, index: mir::Local) -> &Self::Output {
+        if index == mir::RETURN_PLACE {
+            self.0.last().unwrap()
+        } else {
+            &self.0[index.as_usize() - 1]
+        }
+    }
+}
+
+impl<'vir> PledgeExpr<'vir> {
+    pub fn new(
+        did: DefId,
+        expr: vir::ExprGenBool<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>,
+    ) -> Self {
+        Self { did, expr }
+    }
+
+    pub fn pledge_args<T: Borrow<vir::ExprSnap<'vir>>>(
+        result: vir::ExprSnap<'vir>,
+        args: impl IntoIterator<Item = T>,
+    ) -> PledgeArgs<'vir> {
+        let all_args = args
+            .into_iter()
+            .map(|a| *a.borrow())
+            .chain([result])
+            .collect::<Vec<_>>();
+        vir::with_vcx(|vcx| PledgeArgs(vcx.alloc_slice(&all_args)))
+    }
+
+    pub fn expr(&self, args: PledgeArgs<'vir>) -> vir::ExprBool<'vir> {
+        vir::with_vcx(|vcx| self.expr.reify(vcx, (self.did, args.0)))
+    }
+
+    pub fn span(&self) -> Span {
+        vir::with_vcx(|vcx| vcx.tcx().def_span(self.did))
     }
 }
 
@@ -39,27 +78,9 @@ impl<'vir> PledgeExpiryObligation<'vir> {
 pub struct EncodedPledge<'vir> {
     /// The VIR expression and span corresponding to the `assert_on_expiry`
     /// predicate, if present.
-    pub expiry_obligation: Option<PledgeExpiryObligation<'vir>>,
-    pub spec: vir::ExprBool<'vir>,
-    pub span: Span,
-}
-
-impl<'vir> EncodedPledge<'vir> {
-    pub fn expiry_obligation_expr(&self) -> Option<vir::ExprBool<'vir>> {
-        self.expiry_obligation.map(|lhs| lhs.expr)
-    }
-
-    pub fn new(
-        lhs: Option<PledgeExpiryObligation<'vir>>,
-        rhs: vir::ExprBool<'vir>,
-        span: Span,
-    ) -> Self {
-        Self {
-            expiry_obligation: lhs,
-            spec: rhs,
-            span,
-        }
-    }
+    pub expiry_obligation: Option<PledgeExpr<'vir>>,
+    /// The pure rhs of the wand.
+    pub expiry_postcondition: PledgeExpr<'vir>,
 }
 
 #[derive(Clone)]
@@ -202,13 +223,6 @@ impl TaskEncoder for MirSpecEnc {
                     })
                 })
                 .collect::<Result<Vec<vir::ExprBool<'_>>, _>>()?;
-            let pledge_args = vcx.alloc_slice(
-                &pre_args
-                    .iter()
-                    .map(|arg| vcx.mk_old_expr(arg))
-                    .chain([local_defs[mir::RETURN_PLACE].impure_snap])
-                    .collect::<Vec<_>>(),
-            );
             let pledges = specs
                 .pledges
                 .iter()
@@ -233,7 +247,7 @@ impl TaskEncoder for MirSpecEnc {
                             )
                             .unwrap()
                             .expr
-                            .downcast_ty()
+                            .downcast_ty::<vir::CSnap>()
                         });
                         let rhs_expr = deps
                             .require_dep::<crate::encoders::MirPureEnc>(
@@ -251,29 +265,26 @@ impl TaskEncoder for MirSpecEnc {
                             .expr
                             .downcast_ty();
                         let lhs_expr = lhs_expr.map(|lhs_expr| {
-                            lhs_expr.reify(vcx, (lhs_def_id.unwrap(), pledge_args))
+                            PledgeExpr::new(
+                                lhs_def_id.unwrap(),
+                                to_bool.call()(lhs_expr).downcast_ty(),
+                            )
                         });
-                        let rhs_expr = rhs_expr.reify(vcx, (*rhs_def_id, pledge_args));
                         let rhs_span = vcx.tcx().def_span(rhs_def_id);
-                        EncodedPledge::new(
-                            lhs_expr.map(|lhs_expr| {
-                                let lhs_span = vcx.tcx().def_span(lhs_def_id.unwrap());
-                                PledgeExpiryObligation::new(
-                                    vcx.with_span(lhs_span, |_| to_bool(lhs_expr).downcast_ty()),
-                                    lhs_span,
-                                )
-                            }),
-                            vcx.with_span(rhs_span, |vcx| {
-                                vcx.handle_error("exhale.failed:assertion.false", move |_| {
-                                    Some(vec![PrustiError::verification(
-                                        "pledge postcondition might not hold",
-                                        rhs_span.into(),
-                                    )])
-                                });
-                                to_bool(rhs_expr).downcast_ty()
-                            }),
-                            rhs_span,
-                        )
+                        let rhs_expr = vcx.with_span(rhs_span, move |vcx| {
+                            vcx.handle_error("exhale.failed:assertion.false", move |_| {
+                                Some(vec![PrustiError::verification(
+                                    "pledge postcondition might not hold",
+                                    rhs_span.into(),
+                                )])
+                            });
+                            to_bool.call()(rhs_expr).downcast_ty()
+                        });
+                        let rhs_expr = PledgeExpr::new(*rhs_def_id, rhs_expr);
+                        EncodedPledge {
+                            expiry_obligation: lhs_expr,
+                            expiry_postcondition: rhs_expr,
+                        }
                     },
                 )
                 .collect::<Vec<_>>();

--- a/prusti-encoder/src/encoders/ty/generics/casters.rs
+++ b/prusti-encoder/src/encoders/ty/generics/casters.rs
@@ -245,8 +245,8 @@ impl TaskEncoder for CastersEnc<Impure> {
             let self_expr = vcx.mk_local_ex(self_decl);
             let decls = (self_decl, generics.ty_decls(), generics.const_decls());
 
-            let predicate_ref = deps.require_dep::<TyImpureEnc>(concrete)?;
-            let generic_ref = deps.require_dep::<TyImpureEnc>(param)?;
+            let predicate_ref = deps.require_ref::<TyImpureEnc>(concrete)?;
+            let generic_ref = deps.require_ref::<TyImpureEnc>(param)?;
 
             let concrete_predicate = (predicate_ref.ref_to_pred)(
                 self_expr,

--- a/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
@@ -36,8 +36,10 @@ impl TaskEncoder for TraitImplEnc {
         vir::with_vcx(|vcx| {
             let tcx = vcx.tcx();
 
-            let ctx = GParams::from(*task_key);
+            let all_impls = tcx.trait_impls_in_crate(task_key.krate);
+            let idx = all_impls.iter().position(|did| did == task_key).unwrap();
 
+            let ctx = GParams::from(*task_key);
             let params = deps.require_dep::<GenericParamsEnc>(ctx)?;
 
             let trait_ref = tcx.impl_trait_ref(task_key).unwrap().instantiate_identity();
@@ -48,7 +50,9 @@ impl TaskEncoder for TraitImplEnc {
 
             let mut axs = Vec::new();
 
-            let struct_ty = tcx.type_of(task_key).instantiate_identity();
+            let implementing_ty = tcx.type_of(task_key).instantiate_identity();
+            let implementing_ty = RustTyDecomposition::from_ty(implementing_ty, *task_key);
+            let implementing_ty = implementing_ty.ty.name();
 
             let impl_fun = trait_data.impl_fun;
             let trait_ty_decls = params
@@ -60,7 +64,7 @@ impl TaskEncoder for TraitImplEnc {
 
             axs.push(
                 vcx.mk_domain_axiom(
-                    vir_format_identifier!(vcx, "{}_impl_{}", trait_data.trait_name, struct_ty),
+                    vir_format_identifier!(vcx, "{}_impl_{idx}_{implementing_ty}", trait_data.trait_name),
                     vir::expr! {forall ..[trait_ty_decls] :: {[impl_fun(trait_tys)]} [impl_fun(trait_tys)]}
                 )
             );
@@ -103,10 +107,9 @@ impl TaskEncoder for TraitImplEnc {
                     axs.push(vcx.mk_domain_axiom(
                         vir_format_identifier!(
                             vcx,
-                            "{}_Assoc_{}_{}",
+                            "{}_Assoc_{idx}_{}_{implementing_ty}",
                             trait_data.trait_name,
                             tcx.item_name(impl_item.def_id),
-                            struct_ty
                         ),
                         vir::expr! {forall ..[trait_ty_decls] :: {[assoc_fun(trait_tys)]} ([assoc_fun(trait_tys)]) == (assoc_type_expr)}
                     ));
@@ -116,9 +119,8 @@ impl TaskEncoder for TraitImplEnc {
                 vcx.mk_domain(
                     vir_format_identifier!(
                         vcx,
-                        "t_{}_{}",
+                        "t_{idx}_{}_{implementing_ty}",
                         trait_data.trait_name,
-                        tcx.type_of(*task_key).instantiate_identity().to_string()
                     ),
                     &[],
                     vcx.alloc_slice(&axs),

--- a/prusti-encoder/src/encoders/ty/impure.rs
+++ b/prusti-encoder/src/encoders/ty/impure.rs
@@ -114,6 +114,7 @@ impl TaskEncoder for TyImpureEnc {
     task_encoder::encoder_cache!(TyImpureEnc);
     type TaskDescription<'vir> = RustTy<'vir>;
 
+    type OutputRef<'vir> = TyImpureRef<'vir>;
     type OutputFullDependency<'vir> = TyImpure<'vir>;
     type OutputFullLocal<'vir> = TyImpureEncLocal<'vir>;
 
@@ -127,7 +128,6 @@ impl TaskEncoder for TyImpureEnc {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        deps.emit_output_ref(*task_key, ())?;
         let snap = deps.require_dep::<TyPureEnc>(*task_key)?;
         let snapshot = (snap.domain)();
 
@@ -153,6 +153,13 @@ impl TaskEncoder for TyImpureEnc {
                     vir::expr! { ([builder.ref_to_snap](ref_self, [..[builder.params.ty_exprs()]], [..[builder.params.const_exprs()]])) == (value) },
                 ],
             );
+
+            let data = TyImpureRef {
+                ref_to_pred: builder.ref_to_pred,
+                ref_to_snap: builder.ref_to_snap,
+                method_assign,
+            };
+            deps.emit_output_ref(*task_key, data)?;
 
             let specifics = match &ty.specifics {
                 TySpecifics::Param(param) => {
@@ -182,11 +189,6 @@ impl TaskEncoder for TyImpureEnc {
                 TySpecifics::Builtin(builtin) => TySpecifics::Builtin(
                     super::kinds::builtin::ty_impure(builtin, deps, &mut builder)?,
                 ),
-            };
-            let data = TyImpureRef {
-                ref_to_pred: builder.ref_to_pred,
-                ref_to_snap: builder.ref_to_snap,
-                method_assign,
             };
             let output = TyData::new(data, specifics).alloc();
 

--- a/prusti-encoder/src/encoders/ty/lifted/ty_constructor.rs
+++ b/prusti-encoder/src/encoders/ty/lifted/ty_constructor.rs
@@ -5,7 +5,7 @@ use crate::encoders::ty::{RustTy, generics::GenericParamsEnc};
 
 use super::r#typeof::{TypeOfEnc, TypeOfEncOutputRef};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct TyConstructorEncOutputRef<'vir> {
     /// Takes as input the generics for this type (if any),
     /// and returns the resulting type

--- a/prusti-encoder/src/encoders/ty/lifted/typeof.rs
+++ b/prusti-encoder/src/encoders/ty/lifted/typeof.rs
@@ -3,7 +3,7 @@ use vir::FunctionIdn;
 
 use crate::encoders::ty::{RustTy, pure::TyPureEnc};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct TypeOfEncOutputRef<'vir> {
     /// Returns the Viper representation of the type of a snapshot-encoded value
     pub typeof_function: vir::FunctionIdn<'vir, vir::Snap, vir::TyVal>,

--- a/prusti-tests/tests/verify/pass/slices/slice-elem_eq-range_inc.rs
+++ b/prusti-tests/tests/verify/pass/slices/slice-elem_eq-range_inc.rs
@@ -1,6 +1,7 @@
 // ignore-test: slicing with RangeInclusive (e.g. [x..=y]) currently not supported
 
 #![feature(const_panic)]
+#![feature(slice_index_methods)]
 
 use prusti_contracts::*;
 
@@ -16,12 +17,17 @@ use prusti_contracts::*;
 //     pub const fn end(&self) -> &usize;
 // }
 
+#[extern_spec]
+impl<T> std::slice::SliceIndex<[T]> for std::ops::Range<usize> {
+    #[ensures( result.len() == self.end - self.start )]
+    #[ensures( forall(|i: usize| (0 <= i && i < result.len()) ==> result[i] === slice[i+self.start]) )]
+    fn index(self, slice: &[T]) -> &[T];
+}
 
 #[extern_spec]
-impl<T> std::ops::Index<std::ops::Range<usize>> for [T] {
-    #[ensures( result.len() == index.end - index.start )]
-    #[ensures( forall(|i: usize| (0 <= i && i < result.len()) ==> result[i] == self[i+index.start]) )]
-    fn index(&self, index: std::ops::Range<usize>) -> &[T];
+impl<T, I: std::slice::SliceIndex<[T]>> std::ops::Index<I> for [T] {
+    #[ensures( result === <I as std::slice::SliceIndex<[T]>>::index(index, self) )]
+    fn index(&self, index: I) -> &I::Output;
 }
 
 fn main() {}

--- a/task-encoder/src/lib.rs
+++ b/task-encoder/src/lib.rs
@@ -101,7 +101,7 @@ pub trait TaskEncoder {
     /// A reference to an encoded item. Should be non-unit for tasks which can
     /// be "referred" to from other parts of a program, as opposed to tasks
     /// where only the full output matters.
-    type OutputRef<'vir>: Clone + OutputRefAny
+    type OutputRef<'vir>: Clone + std::fmt::Debug + OutputRefAny
         = ()
     where
         Self: 'vir;
@@ -490,7 +490,7 @@ pub trait TaskEncoder {
         Self: 'vir,
     {
         let (outputs, errored) = Self::all_outputs_local();
-        assert!(errored.is_empty());
+        assert!(errored.is_empty(), "Encoder {} has errored outputs: {:?}", Self::ENCODER_NAME, errored);
         outputs
     }
 

--- a/task-encoder/src/lib.rs
+++ b/task-encoder/src/lib.rs
@@ -490,7 +490,12 @@ pub trait TaskEncoder {
         Self: 'vir,
     {
         let (outputs, errored) = Self::all_outputs_local();
-        assert!(errored.is_empty(), "Encoder {} has errored outputs: {:?}", Self::ENCODER_NAME, errored);
+        assert!(
+            errored.is_empty(),
+            "Encoder {} has errored outputs: {:?}",
+            Self::ENCODER_NAME,
+            errored
+        );
         outputs
     }
 

--- a/task-encoder/src/result.rs
+++ b/task-encoder/src/result.rs
@@ -73,7 +73,7 @@ where
         match self {
             Self::EncodingError(err) => helper.field("EncodingError", err),
             Self::EnqueueingError(err) => helper.field("EnqueueingError", err),
-            Self::DependencyError(..) => helper.field("DependencyError", &""),
+            Self::DependencyError(stack) => helper.field("DependencyError", stack),
             Self::CyclicError => helper.field("CyclicError", &""),
         };
         helper.finish()


### PR DESCRIPTION
- Fix name clash in trait impl axioms
- Ignore `RepackOp::StorageDead`: @zgrannan does the PCG now emit a weakening before deallocation (i.e. the precondition of any StorageDead, be that MIR or PCG, is that the local is in W state)?
- Add proper error reporting for calls to pure functions in impure code (with the pure fn precondition not satisfied)
- Fix pledge spec expr translation
- Fixes a cyclic dependency error in the encoders
- Fixes the semantics of `%` and `/` for negative lhs