### PR TITLE
(WIP) Encode spec items as methods

### DIFF
--- a/prusti-encoder/src/encoders/mir_fn/mod.rs
+++ b/prusti-encoder/src/encoders/mir_fn/mod.rs
@@ -39,9 +39,6 @@ pub fn encode_all_in_crate<'tcx>(tcx: ty::TyCtxt<'tcx>) {
         match kind {
             hir::def::DefKind::Fn | hir::def::DefKind::AssocFn => {
                 let def_id = def_id.to_def_id();
-                if prusti_interface::specs::is_spec_fn(tcx, def_id) {
-                    continue;
-                }
 
                 let (is_pure, is_trusted) = crate::encoders::with_proc_spec(
                     SpecQuery::GetProcKind(def_id, ty::List::identity_for_item(tcx, def_id)),

--- a/prusti/src/callbacks.rs
+++ b/prusti/src/callbacks.rs
@@ -4,7 +4,7 @@ use ide::{fake_error, IdeInfo};
 use prusti_interface::{
     data::VerificationTask,
     environment::{mir_storage, Environment},
-    specs::{self, cross_crate::CrossCrateSpecs, is_spec_fn},
+    specs::{self, cross_crate::CrossCrateSpecs},
     PrustiError,
 };
 use prusti_rustc_interface::{
@@ -39,7 +39,7 @@ fn mir_borrowck<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> MirBorrowck<'tcx
     // when calling `get_body_with_borrowck_facts`. TODO: figure out if we need
     // (anon) const bodies at all, and if so, how to get them?
     if !is_anon_const {
-        let consumer_opts = if is_spec_fn(tcx, def_id.to_def_id()) || config::no_verify() {
+        let consumer_opts = if config::no_verify() {
             consumers::ConsumerOptions::RegionInferenceContext
         } else {
             consumers::ConsumerOptions::PoloniusOutputFacts


### PR DESCRIPTION
I separated this out from #127 because it's not really related and causes some tests to fail. Some TODOs:

- [ ] when encoding the method for a spec item, the previous spec items in the contract should be added as well; for example, preconditions might justify the well-formedness of a postcondition (e.g., [this postcondition](https://github.com/Aurel300/prusti-dev/blob/808a0924322bf426ab57059111f39080777e391c/prusti-tests/tests/verify/pass/issues/issue-815-2.rs#L14) depends on [this precondition](https://github.com/Aurel300/prusti-dev/blob/808a0924322bf426ab57059111f39080777e391c/prusti-tests/tests/verify/pass/issues/issue-815-2.rs#L9))
- [ ] properly deal with encoding spec-only constructs (like quantifiers)
