### PR TITLE
Fix `IndirectPredicatesEnc` on lifetime-annotated structs 

### DIFF
--- a/prusti-encoder/src/encoders/ty/indirect.rs
+++ b/prusti-encoder/src/encoders/ty/indirect.rs
@@ -1,6 +1,8 @@
 use pcg::borrow_pcg::region_projection::{LifetimeProjection, PcgRegion};
-use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{EncodeFullResult, EncodeFullError, TaskEncoder, TaskEncoderDependencies};
+use prusti_rustc_interface::type_ir::TypeVisitableExt;
 use vir::{CastType, Reify};
+
 
 use crate::encoders::{TyUseImpureEnc, ty::RustTyDecomposition};
 
@@ -127,18 +129,36 @@ impl TaskEncoder for IndirectPredicatesEnc {
 
                         // TODO: invalid recursion here if the defined struct is
                         // recursive!
-                        let field_ty = field_ty.decompose(ty.ty.params);
+                        let field_ty = field_ty.decompose_context(ty.ty.params, ty.args);
                         let new_projection =
-                            LifetimeProjection::new(field_ty, task_key.region(()), None, ())
-                                .unwrap();
-                        let field_indirect =
-                            deps.require_dep::<IndirectPredicatesEnc>(new_projection)?;
-                        predicate_applications.extend(
-                            field_indirect
-                                .predicate_applications
-                                .into_iter()
-                                .map(project),
-                        );
+                            LifetimeProjection::new(field_ty, task_key.region(()), None, ());
+                        match new_projection {
+                            Some(new_projection) => {
+                                let field_indirect =
+                                deps.require_dep::<IndirectPredicatesEnc>(new_projection)?;
+                                predicate_applications.extend(
+                                    field_indirect
+                                        .predicate_applications
+                                        .into_iter()
+                                        .map(project),
+                                );
+                            }
+                            None => {
+                                println!("skipping field with unsupported type for indirect predicates: {field_ty:?}");
+                                // The region is not a direct arg of this field type.
+                                // Check if it could be nested inside a type arg (e.g. Box<&'r mut i32>),
+                                // which we don't support. If so, return an encoding error rather than
+                                // silently producing an incomplete contract.
+                                if field_ty.args.args().iter()
+                                    .filter_map(|arg| arg.as_type())
+                                    .any(|ty| ty.has_free_regions())
+                                {
+                                    return Err(EncodeFullError::EncodingError((), None));
+                                }
+                                // No free regions in any type arg means the field genuinely has no
+                                // resources through this lifetime (e.g. Box<i32>) → safe to skip.
+                            }
+                        }
                     }
                 }
                 // TODO: recurse into other types

--- a/prusti-encoder/src/encoders/ty/indirect.rs
+++ b/prusti-encoder/src/encoders/ty/indirect.rs
@@ -3,7 +3,6 @@ use task_encoder::{EncodeFullResult, EncodeFullError, TaskEncoder, TaskEncoderDe
 use prusti_rustc_interface::type_ir::TypeVisitableExt;
 use vir::{CastType, Reify};
 
-
 use crate::encoders::{TyUseImpureEnc, ty::RustTyDecomposition};
 
 use super::{data::TySpecifics, use_pure::TyUsePureEnc};
@@ -135,7 +134,7 @@ impl TaskEncoder for IndirectPredicatesEnc {
                         match new_projection {
                             Some(new_projection) => {
                                 let field_indirect =
-                                deps.require_dep::<IndirectPredicatesEnc>(new_projection)?;
+                                    deps.require_dep::<IndirectPredicatesEnc>(new_projection)?;
                                 predicate_applications.extend(
                                     field_indirect
                                         .predicate_applications
@@ -149,7 +148,10 @@ impl TaskEncoder for IndirectPredicatesEnc {
                                 // Check if it could be nested inside a type arg (e.g. Box<&'r mut i32>),
                                 // which we don't support. If so, return an encoding error rather than
                                 // silently producing an incomplete contract.
-                                if field_ty.args.args().iter()
+                                if field_ty
+                                    .args
+                                    .args()
+                                    .iter()
                                     .filter_map(|arg| arg.as_type())
                                     .any(|ty| ty.has_free_regions())
                                 {

--- a/prusti-encoder/src/encoders/ty/indirect.rs
+++ b/prusti-encoder/src/encoders/ty/indirect.rs
@@ -128,20 +128,17 @@ impl TaskEncoder for IndirectPredicatesEnc {
                         // TODO: invalid recursion here if the defined struct is
                         // recursive!
                         let field_ty = field_ty.decompose_context(ty.ty.params, ty.args);
-                        let new_projection =
-                            LifetimeProjection::new(field_ty, task_key.region(()), None, ());
-                        match new_projection {
-                            Some(new_projection) => {
-                                let field_indirect =
-                                    deps.require_dep::<IndirectPredicatesEnc>(new_projection)?;
-                                predicate_applications.extend(
-                                    field_indirect
-                                        .predicate_applications
-                                        .into_iter()
-                                        .map(project),
-                                );
-                            }
-                            None => {}
+                        if let Some(new_projection) =
+                            LifetimeProjection::new(field_ty, task_key.region(()), None, ())
+                        {
+                            let field_indirect =
+                                deps.require_dep::<IndirectPredicatesEnc>(new_projection)?;
+                            predicate_applications.extend(
+                                field_indirect
+                                    .predicate_applications
+                                    .into_iter()
+                                    .map(project),
+                            );
                         }
                     }
                 }

--- a/prusti-encoder/src/encoders/ty/indirect.rs
+++ b/prusti-encoder/src/encoders/ty/indirect.rs
@@ -1,6 +1,5 @@
 use pcg::borrow_pcg::region_projection::{LifetimeProjection, PcgRegion};
-use task_encoder::{EncodeFullResult, EncodeFullError, TaskEncoder, TaskEncoderDependencies};
-use prusti_rustc_interface::type_ir::TypeVisitableExt;
+use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 use vir::{CastType, Reify};
 
 use crate::encoders::{TyUseImpureEnc, ty::RustTyDecomposition};
@@ -142,24 +141,7 @@ impl TaskEncoder for IndirectPredicatesEnc {
                                         .map(project),
                                 );
                             }
-                            None => {
-                                println!("skipping field with unsupported type for indirect predicates: {field_ty:?}");
-                                // The region is not a direct arg of this field type.
-                                // Check if it could be nested inside a type arg (e.g. Box<&'r mut i32>),
-                                // which we don't support. If so, return an encoding error rather than
-                                // silently producing an incomplete contract.
-                                if field_ty
-                                    .args
-                                    .args()
-                                    .iter()
-                                    .filter_map(|arg| arg.as_type())
-                                    .any(|ty| ty.has_free_regions())
-                                {
-                                    return Err(EncodeFullError::EncodingError((), None));
-                                }
-                                // No free regions in any type arg means the field genuinely has no
-                                // resources through this lifetime (e.g. Box<i32>) → safe to skip.
-                            }
+                            None => {}
                         }
                     }
                 }

--- a/prusti-tests/tests/verify/pass/generic/lifetime-struct-fields.rs
+++ b/prusti-tests/tests/verify/pass/generic/lifetime-struct-fields.rs
@@ -1,0 +1,61 @@
+// Regression test for IndirectPredicatesEnc handling of lifetime-annotated
+// struct fields: direct lifetime on field, and no lifetime on field.
+use prusti_contracts::*;
+
+// Case 1: direct lifetime argument on field.
+struct Wrapper<'a> {
+    x: &'a i32,
+}
+
+#[ensures(result.x === x)]
+fn wrap(x: &i32) -> Wrapper<'_> {
+    Wrapper { x }
+}
+
+#[ensures(result == 42)]
+fn client_wrap() -> i32 {
+    let val = 42;
+    let w = wrap(&val);
+    *w.x
+}
+
+// Case 2: no lifetime argument on field (mixed struct).
+struct Mixed<'a> {
+    reference: &'a i32,
+    boxed: Box<i32>,
+}
+
+#[ensures(result.reference === x && *result.boxed == 42)]
+fn make_mixed(x: &i32) -> Mixed<'_> {
+    Mixed { boxed: Box::new(42), reference: x }
+}
+
+#[ensures(result == 42)]
+fn client_mixed() -> i32 {
+    let val = 0;
+    let m = make_mixed(&val);
+    *m.boxed
+}
+
+// Case 3: indirect lifetime argument on field (lifetime through type argument).
+struct Indirect<'a> {
+    boxed: Box<&'a i32>,
+}
+
+#[ensures(*result.boxed === x)]
+fn make_indirect(x: &i32) -> Indirect<'_> {
+    Indirect { boxed: Box::new(x) }
+}
+
+#[ensures(result == 42)]
+fn client_indirect() -> i32 {
+    let val = 42;
+    let m = make_indirect(&val);
+    *(*m.boxed)
+}
+
+fn main() {
+    let _ = client_wrap();
+    let _ = client_mixed();
+    let _ = client_indirect();
+}


### PR DESCRIPTION
This PR fixes the logic related to fields in lifetime-annotated structs in `IndirectPredicatesEnc`.
It applies to direct and no lifetime parameters. Indirect lifetime parameters (through type arguments) stay unsupported.

This PR keeps Prusti from crashing on the following test cases:

1. direct lifetime argument on field

```rust
use prusti_contracts::*;

struct Wrapper<'a> {
    x: &'a i32,
}

// Returning a struct with a lifetime: triggers the crash
#[ensures(result.x === x)]
fn wrap(x: &i32) -> Wrapper<'_> {
    Wrapper { x }
}

#[ensures(result == 42)]
fn client_wrap() -> i32 {
    let val = 42;
    let w = wrap(&val);
    *w.x
}
```

2. no lifetime argument on field:

```rust
use prusti_contracts::*;

struct Mixed<'a> {
    reference: &'a i32,
    boxed: Box<i32>,
}

fn make_mixed(x: &i32) -> Mixed<'_> {
    Mixed { boxed: Box::new(42), reference: x }
}

#[ensures(result == 42)]
fn client_mixed() -> i32 {
    let val = 0;
    let m = make_mixed(&val);
    *m.boxed
}

struct Mixed<'a> {
    boxed: Box<&'a i32>,
}

fn make_mixed(x: &i32) -> Mixed<'_> {
    Mixed { boxed: Box::new(x) }
}

#[ensures(result == 42)]
fn client_mixed() -> i32 {
    let val = 0;
    let m = make_mixed(&val);
    *(*m.boxed)
}
```