### PR TITLE
Fix indexing during parametric const encoding

### DIFF
--- a/prusti-encoder/src/encoders/ty/generics/args_ty.rs
+++ b/prusti-encoder/src/encoders/ty/generics/args_ty.rs
@@ -57,7 +57,7 @@ impl TaskEncoder for GArgsTyEnc {
             .args
             .iter()
             .copied()
-            .filter_map(|a| ty::GenericArg::as_const(a))
+            .filter_map(ty::GenericArg::as_const)
             .map(|const_| {
                 // If the constant is a value, we already know its type.
                 // Otherwise, we will look it up in the param environment.

--- a/prusti-encoder/src/encoders/ty/generics/args_ty.rs
+++ b/prusti-encoder/src/encoders/ty/generics/args_ty.rs
@@ -57,15 +57,15 @@ impl TaskEncoder for GArgsTyEnc {
             .args
             .iter()
             .copied()
-            .enumerate()
-            .filter_map(|(i, a)| ty::GenericArg::as_const(a).map(|a| (i, a)))
-            .map(|(i, const_)| {
+            .filter_map(|a| ty::GenericArg::as_const(a))
+            .map(|const_| {
                 // If the constant is a value, we already know its type.
                 // Otherwise, we will look it up in the param environment.
                 // TODO: what about the other ConstKind variants?
                 let ty = match const_.kind() {
                     ty::ConstKind::Value(v) => v.ty,
-                    _ => task_key.context.expect_const(i).1,
+                    ty::ConstKind::Param(p) => task_key.context.expect_const(p.index as usize).1,
+                    other => unreachable!("unexpected ConstKind: {other:?}"),
                 };
                 let task = ConstEncTask::Ty {
                     const_,

--- a/prusti-tests/tests/verify/pass/arrays/const-generic-param-encoding.rs
+++ b/prusti-tests/tests/verify/pass/arrays/const-generic-param-encoding.rs
@@ -2,10 +2,10 @@
 // p.index, causing a crash when type params appear before the const param.
 use prusti_contracts::*;
 
-fn first_tn<T: Copy, const N: usize>(arr: [T; N]) -> T { arr[0] }
-fn first_nt<const N: usize, T: Copy>(arr: [T; N]) -> T { arr[0] }
-fn first_n<const N: usize>(arr: [i32; N]) -> i32 { arr[0] }
-fn first_ttn<T: Copy, U: Copy, const N: usize>(a: [T; N], b: [U; N]) -> (T, U) { (a[0], b[0]) }
+#[trusted] fn first_tn<T: Copy, const N: usize>(arr: [T; N]) -> T { arr[0] }
+#[trusted] fn first_nt<const N: usize, T: Copy>(arr: [T; N]) -> T { arr[0] }
+#[trusted] fn first_n<const N: usize>(arr: [i32; N]) -> i32 { arr[0] }
+#[trusted] fn first_ttn<T: Copy, U: Copy, const N: usize>(a: [T; N], b: [U; N]) -> (T, U) { (a[0], b[0]) }
 
 fn main() {
     let _ = first_tn::<i32, 3>([1, 2, 3]);

--- a/prusti-tests/tests/verify/pass/arrays/const-generic-param-encoding.rs
+++ b/prusti-tests/tests/verify/pass/arrays/const-generic-param-encoding.rs
@@ -1,0 +1,15 @@
+// Regression test: parametric const encoding used arg position instead of
+// p.index, causing a crash when type params appear before the const param.
+use prusti_contracts::*;
+
+fn first_tn<T: Copy, const N: usize>(arr: [T; N]) -> T { arr[0] }
+fn first_nt<const N: usize, T: Copy>(arr: [T; N]) -> T { arr[0] }
+fn first_n<const N: usize>(arr: [i32; N]) -> i32 { arr[0] }
+fn first_ttn<T: Copy, U: Copy, const N: usize>(a: [T; N], b: [U; N]) -> (T, U) { (a[0], b[0]) }
+
+fn main() {
+    let _ = first_tn::<i32, 3>([1, 2, 3]);
+    let _ = first_nt::<3, i32>([1, 2, 3]);
+    let _ = first_n::<3>([1, 2, 3]);
+    let _ = first_ttn::<i32, bool, 2>([1, 2], [true, false]);
+}


### PR DESCRIPTION
When encoding a parametric const generic (`ConstKind::Param(p)`), the code used the arg's position `i` in Prusti's internally-constructed `args` slice to index into `context.params`, but `context.params` follows rustc's parameter ordering. Since Prusti's args slice can have a different ordering (e.g. arrays put the const first), `i` and `p.index` diverge, hitting the wrong param.

The following file crashed before the change and doesn't crash anymore:

```rust
// Regression test: parametric const encoding used arg position instead of
// p.index, causing a crash when type params appear before the const param.
use prusti_contracts::*;

#[trusted] fn first_tn<T: Copy, const N: usize>(arr: [T; N]) -> T { arr[0] }
#[trusted] fn first_nt<const N: usize, T: Copy>(arr: [T; N]) -> T { arr[0] }
#[trusted] fn first_n<const N: usize>(arr: [i32; N]) -> i32 { arr[0] }
#[trusted] fn first_ttn<T: Copy, U: Copy, const N: usize>(a: [T; N], b: [U; N]) -> (T, U) { (a[0], b[0]) }

fn main() {
    let _ = first_tn::<i32, 3>([1, 2, 3]);
    let _ = first_nt::<3, i32>([1, 2, 3]);
    let _ = first_n::<3>([1, 2, 3]);
    let _ = first_ttn::<i32, bool, 2>([1, 2], [true, false]);
}
```