### PR TITLE
Fix ConstEnc

### DIFF
--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use prusti_rustc_interface::{
     const_eval::{
         const_eval::{CompileTimeMachine, mk_eval_cx_for_const_val},
@@ -15,7 +14,7 @@ use prusti_rustc_interface::{
     span::{Span, def_id::DefId},
 };
 use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
-use vir::{CastType, FunctionGenData, FunctionIdn};
+use vir::{CastType, FunctionGenData, FunctionIdn, VirCtxt};
 
 use crate::encoders::{
     MirPureEnc, MirPureEncTask, PureKind,
@@ -23,7 +22,7 @@ use crate::encoders::{
     ty::{
         RustTyDecomposition,
         generics::{GParams, GenericParamsEnc},
-        use_pure::TyUsePureEnc,
+        use_pure::{TyUsePureEnc, TyUsePureImmRef, TyUsePureMutRef},
     },
 };
 
@@ -40,6 +39,12 @@ pub enum ConstEncTask<'vir> {
         def_id: DefId,         // DefId of the current function
         span: Span,
     },
+}
+
+struct EncodeConstValData<'vir> {
+    ecx: &'vir InterpCx<'vir, CompileTimeMachine<'vir>>,
+    context: GParams<'vir>,
+    span: Span,
 }
 
 /// Encodes constants into snapshot expressions. The evaluation of a constant
@@ -89,11 +94,8 @@ impl ConstEnc {
                 }
                 ConstValue::Scalar(Scalar::Ptr(ptr, _)) => {
                     match vcx.tcx().global_alloc(ptr.provenance.alloc_id()) {
-                        GlobalAlloc::Function { .. } => todo!(),
-                        GlobalAlloc::VTable(_, _) => todo!(),
-                        GlobalAlloc::Static(_) => todo!(),
                         GlobalAlloc::Memory(_mem) => unreachable!(),
-                        GlobalAlloc::TypeId { .. } => todo!(),
+                        _ => todo!(),
                     }
                 }
                 ConstValue::ZeroSized => {
@@ -120,24 +122,80 @@ impl ConstEnc {
         })
     }
 
-    fn encode_const_val_tree<'vir, T>(
+    fn encode_ref<'vir, T, Ref>(
+        ref_val: &'vir Ref,
+        rec_data: &'vir EncodeConstValData<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
         val: T,
         ty: ty::Ty<'vir>,
-        context: GParams<'vir>,
-        ecx: &InterpCx<'vir, CompileTimeMachine<'vir>>,
-        span: Span,
-    ) -> Result<
-        (
-            vir::ExprCSnap<'vir>,
-            Vec<&'vir FunctionGenData<'vir, (), !>>,
-        ),
-        EncodeFullError<'vir, Self>,
-    >
+        vcx: &'vir VirCtxt,
+        prim_to_snap: fn(
+            &'vir Ref,
+            vir::ExprRef<'vir>,
+            vir::ExprSnap<'vir>,
+        ) -> vir::ExprCSnap<'vir>,
+    ) -> Result<(Vec<vir::Function<'vir>>, vir::ExprCSnap<'vir>), EncodeFullError<'vir, Self>>
     where
         T: Projectable<'vir, CtfeProvenance>,
     {
-        let ty_task = RustTyDecomposition::from_ty(ty, context);
+        let inner_ty = ty.builtin_deref(true).unwrap();
+        let addr_to_ref = deps.require_dep::<RefDataEnc>(())?.addr_to_ref;
+
+        Ok(
+            if ty.builtin_deref(true).is_some()
+                && (ty.builtin_deref(true).unwrap().is_str()
+                    || ty.builtin_deref(true).unwrap().is_slice())
+            {
+                let sl_ty = ty.peel_refs();
+                let sl_ty_task = RustTyDecomposition::from_ty(sl_ty, rec_data.context);
+                let sl_snap = deps.require_dep::<TyUsePureEnc>(sl_ty_task)?;
+                let sl_snap = sl_snap.expect_opaque();
+                // first, we create a slice snapshot
+                let snap = (sl_snap.arbitrary)().upcast_ty();
+                // wrap it in a ref
+                (vec![], prim_to_snap(ref_val, vcx.mk_null(), snap))
+            } else {
+                let ptr = rec_data.ecx.read_pointer(&val).expect("Expected a pointer");
+
+                let rel_addr = match ptr.into_pointer_or_addr() {
+                    Ok(ptr) => {
+                        ((ptr.provenance.alloc_id().0.get() as u128) << 64)
+                            | ptr.prov_and_relative_offset().1.bytes() as u128
+                    }
+                    Err(addr) => addr.bytes() as u128,
+                };
+                let ecx = rec_data.ecx;
+                let (snap_funs, snap) = Self::encode_const_val_tree(
+                    rec_data,
+                    deps,
+                    ecx.deref_pointer(&val).unwrap(),
+                    inner_ty,
+                )?;
+                (
+                    snap_funs,
+                    prim_to_snap(
+                        ref_val,
+                        addr_to_ref(
+                            vcx.mk_const_expr(vir::ConstData::Int(rel_addr))
+                                .downcast_ty(),
+                        ),
+                        snap.upcast_ty(),
+                    ),
+                )
+            },
+        )
+    }
+
+    fn encode_const_val_tree<'vir, T>(
+        rec_data: &'vir EncodeConstValData<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
+        val: T,
+        ty: ty::Ty<'vir>,
+    ) -> Result<(Vec<vir::Function<'vir>>, vir::ExprCSnap<'vir>), EncodeFullError<'vir, Self>>
+    where
+        T: Projectable<'vir, CtfeProvenance>,
+    {
+        let ty_task = RustTyDecomposition::from_ty(ty, rec_data.context);
         let kind = deps.require_dep::<TyUsePureEnc>(ty_task)?;
 
         vir::with_vcx(|vcx| {
@@ -152,14 +210,13 @@ impl ConstEnc {
                     };
                     let mut posts = vec![];
                     let mut funs = vec![];
+                    let ecx = rec_data.ecx;
                     for idx in 0..elem_len {
-                        let (snap, snap_funs) = Self::encode_const_val_tree(
+                        let (snap_funs, snap) = Self::encode_const_val_tree(
+                            rec_data,
                             deps,
                             ecx.project_index(&val, idx).unwrap(),
                             *elem_ty,
-                            context,
-                            ecx,
-                            span,
                         )
                         .unwrap();
                         posts.push(
@@ -174,7 +231,11 @@ impl ConstEnc {
                         );
                         funs.extend(snap_funs);
                     }
-                    let span_pos = vcx.tcx().sess.source_map().lookup_char_pos(span.lo());
+                    let span_pos = vcx
+                        .tcx()
+                        .sess
+                        .source_map()
+                        .lookup_char_pos(rec_data.span.lo());
                     let gen_snap_func_idn: FunctionIdn<'_, (), vir::CSnap> = FunctionIdn::new(
                         vir::vir_format_identifier!(
                             vcx,
@@ -188,149 +249,68 @@ impl ConstEnc {
                     let gen_snap_func =
                         vcx.mk_function(gen_snap_func_idn, (), &[], vcx.alloc(posts), None, None);
                     funs.push(gen_snap_func);
-                    ((gen_snap_func_idn)(), funs)
+                    (funs, (gen_snap_func_idn)())
                 }
                 super::ty::TySpecifics::Param(_) => todo!(),
                 super::ty::TySpecifics::Opaque(_) => todo!(),
                 super::ty::TySpecifics::Primitive(prim) => {
-                    let int = ecx
+                    let int = rec_data
+                        .ecx
                         .read_scalar(&val)
                         .unwrap()
                         .try_to_scalar_int()
-                        .expect("Expected an integer");
+                        .expect("scalar should be an integer");
                     let val = int.to_bits(int.size());
                     let val = prim.expr_from_bits(ty, val);
-                    ((prim.prim_to_snap)(val), vec![])
+                    (vec![], (prim.prim_to_snap)(val))
                 }
-                super::ty::TySpecifics::ImmRef(imm_ref) => {
-                    let inner_ty = ty.builtin_deref(true).unwrap();
-                    let addr_to_ref = deps.require_dep::<RefDataEnc>(())?.addr_to_ref;
-
-                    if ty.builtin_deref(true).is_some()
-                        && (ty.builtin_deref(true).unwrap().is_str()
-                            || ty.builtin_deref(true).unwrap().is_slice())
-                    {
-                        let sl_ty = ty.peel_refs();
-                        let sl_ty_task = RustTyDecomposition::from_ty(sl_ty, context);
-                        let sl_snap = deps.require_dep::<TyUsePureEnc>(sl_ty_task)?;
-                        let sl_snap = sl_snap.expect_opaque();
-                        // first, we create a slice snapshot
-                        let snap = (sl_snap.arbitrary)().upcast_ty();
-                        // wrap it in a ref
-                        (
-                            vir::with_vcx(|vcx| imm_ref.prim_to_snap(vcx.mk_null(), snap)),
-                            vec![],
-                        )
-                    } else {
-                        let ptr = ecx.read_pointer(&val).expect("Expected a pointer");
-
-                        let rel_addr = match ptr.into_pointer_or_addr() {
-                            Ok(ptr) => {
-                                ((ptr.provenance.alloc_id().0.get() as u128) << 64)
-                                    | ptr.prov_and_relative_offset().1.bytes() as u128
-                            }
-                            Err(addr) => addr.bytes() as u128,
-                        };
-                        let (snap, snap_funs) = Self::encode_const_val_tree(
-                            deps,
-                            ecx.deref_pointer(&val).unwrap(),
-                            inner_ty,
-                            context,
-                            ecx,
-                            span,
-                        )?;
-                        (
-                            imm_ref.prim_to_snap(
-                                addr_to_ref(
-                                    vcx.mk_const_expr(vir::ConstData::Int(rel_addr))
-                                        .downcast_ty(),
-                                ),
-                                snap.upcast_ty(),
-                            ),
-                            snap_funs,
-                        )
-                    }
-                }
-                super::ty::TySpecifics::MutRef(mutref) => {
-                    let inner_ty = ty.builtin_deref(true).unwrap();
-                    let addr_to_ref = deps.require_dep::<RefDataEnc>(())?.addr_to_ref;
-
-                    if ty.builtin_deref(true).is_some()
-                        && (ty.builtin_deref(true).unwrap().is_str()
-                            || ty.builtin_deref(true).unwrap().is_slice())
-                    {
-                        let sl_ty = ty.peel_refs();
-                        let sl_ty_task = RustTyDecomposition::from_ty(sl_ty, context);
-                        let sl_snap = deps.require_dep::<TyUsePureEnc>(sl_ty_task)?;
-                        let sl_snap = sl_snap.expect_opaque();
-                        // first, we create a slice snapshot
-                        let snap = (sl_snap.arbitrary)().upcast_ty();
-                        // wrap it in a ref
-                        (
-                            vir::with_vcx(|vcx| mutref.prim_to_snap(vcx.mk_null(), snap)),
-                            vec![],
-                        )
-                    } else {
-                        let ptr = ecx.read_pointer(&val).expect("Expected a pointer");
-
-                        let rel_addr = match ptr.into_pointer_or_addr() {
-                            Ok(ptr) => {
-                                ((ptr.provenance.alloc_id().0.get() as u128) << 64)
-                                    | ptr.prov_and_relative_offset().1.bytes() as u128
-                            }
-                            Err(addr) => addr.bytes() as u128,
-                        };
-
-                        let (snap, snap_funs) = Self::encode_const_val_tree(
-                            deps,
-                            ecx.deref_pointer(&val).unwrap(),
-                            inner_ty,
-                            context,
-                            ecx,
-                            span,
-                        )?;
-                        (
-                            mutref.prim_to_snap(
-                                addr_to_ref(
-                                    vcx.mk_const_expr(vir::ConstData::Int(rel_addr))
-                                        .downcast_ty(),
-                                ),
-                                snap.upcast_ty(),
-                            ),
-                            snap_funs,
-                        )
-                    }
-                }
+                super::ty::TySpecifics::ImmRef(imm_ref) => Self::encode_ref(
+                    imm_ref,
+                    rec_data,
+                    deps,
+                    val,
+                    ty,
+                    vcx,
+                    TyUsePureImmRef::prim_to_snap,
+                )?,
+                super::ty::TySpecifics::MutRef(mutref) => Self::encode_ref(
+                    mutref,
+                    rec_data,
+                    deps,
+                    val,
+                    ty,
+                    vcx,
+                    TyUsePureMutRef::prim_to_snap,
+                )?,
                 super::ty::TySpecifics::StructLike(struct_data) => {
                     let tys = match ty.kind() {
                         TyKind::Tuple(tys) => tys.as_slice(),
                         TyKind::Adt(adt_def, args) if adt_def.is_struct() => &adt_def
                             .all_fields()
                             .map(|f| f.ty(vcx.tcx(), args))
-                            .collect_vec(),
+                            .collect::<Vec<_>>(),
                         TyKind::Closure(_closure_def, args) => &args
                             .as_slice()
                             .iter()
                             .map(|arg| arg.expect_ty())
-                            .collect_vec(),
+                            .collect::<Vec<_>>(),
                         _ => unreachable!(),
                     };
                     let mut snaps = vec![];
                     let mut funs = vec![];
+                    let ecx = rec_data.ecx;
                     for (idx, ty) in tys.iter().enumerate().take(struct_data.fields.len()) {
-                        let (snap, snap_funs) = Self::encode_const_val_tree(
+                        let (snap_funs, snap) = Self::encode_const_val_tree(
+                            rec_data,
                             deps,
                             ecx.project_field(&val, idx.into()).unwrap(),
                             *ty,
-                            context,
-                            ecx,
-                            span,
                         )
                         .unwrap();
                         snaps.push(snap.upcast_ty());
                         funs.extend(snap_funs);
                     }
-                    (kind.expect_structlike().field_snaps_to_snap(snaps), funs)
+                    (funs, kind.expect_structlike().field_snaps_to_snap(snaps))
                 }
 
                 super::ty::TySpecifics::EnumLike(enum_data) => {
@@ -338,28 +318,27 @@ impl ConstEnc {
                         TyKind::Adt(adt_def, args) if adt_def.is_enum() => (adt_def, args),
                         _ => unreachable!(),
                     };
-                    let variant_idx = ecx.read_discriminant(&val).unwrap();
-                    let fields = enum_ty.all_fields().collect_vec();
+                    let variant_idx = rec_data.ecx.read_discriminant(&val).unwrap();
+                    let fields = enum_ty.all_fields().collect::<Vec<_>>();
                     let mut snaps = vec![];
                     let mut funs = vec![];
+                    let ecx = rec_data.ecx;
                     for (idx, field) in fields.iter().enumerate() {
-                        let (snap, snap_funs) = Self::encode_const_val_tree(
+                        let (snap_funs, snap) = Self::encode_const_val_tree(
+                            rec_data,
                             deps,
                             ecx.project_field(&val, idx.into()).unwrap(),
                             field.ty(vcx.tcx(), args),
-                            context,
-                            ecx,
-                            span,
                         )
                         .unwrap();
                         snaps.push(snap.upcast_ty());
                         funs.extend(snap_funs);
                     }
                     (
+                        funs,
                         enum_data.variants[variant_idx.as_usize()]
                             .inner
                             .field_snaps_to_snap(snaps),
-                        funs,
                     )
                 }
                 _ => unreachable!(),
@@ -375,8 +354,8 @@ impl ConstEnc {
         span: Span,
     ) -> Result<
         (
-            vir::ExprCSnap<'vir>,
             Vec<&'vir FunctionGenData<'vir, (), !>>,
+            vir::ExprCSnap<'vir>,
         ),
         EncodeFullError<'vir, Self>,
     > {
@@ -384,8 +363,14 @@ impl ConstEnc {
         let (ecx, v) =
             mk_eval_cx_for_const_val(ty_ctxt_at, TypingEnv::fully_monomorphized(), val, ty)
                 .unwrap();
-
-        Self::encode_const_val_tree(deps, v, ty, context, &ecx, span)
+        vir::with_vcx(|vcx| {
+            let rec_data = EncodeConstValData {
+                ecx: vcx.alloc(ecx),
+                context,
+                span,
+            };
+            Self::encode_const_val_tree(vcx.alloc(rec_data), deps, v, ty)
+        })
     }
 }
 
@@ -395,7 +380,7 @@ impl TaskEncoder for ConstEnc {
 
     type TaskDescription<'vir> = ConstEncTask<'vir>;
     type OutputFullDependency<'vir> = vir::ExprCSnap<'vir>;
-    type OutputFullLocal<'vir> = Vec<&'vir FunctionGenData<'vir, (), !>>;
+    type OutputFullLocal<'vir> = Vec<vir::Function<'vir>>;
     type EncodingError = ();
 
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
@@ -403,7 +388,7 @@ impl TaskEncoder for ConstEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in ConstEnc::all_outputs_local_no_errors() {
+        for output in Self::all_outputs_local_no_errors() {
             for fun in output {
                 program.add_function(fun);
             }
@@ -415,12 +400,13 @@ impl TaskEncoder for ConstEnc {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(*task_key, ())?;
-        let (res, functions) = match *task_key {
+
+        Ok(match *task_key {
             ConstEncTask::Ty {
                 const_,
                 ty,
                 context,
-            } => (Self::encode_ty_const(deps, const_, ty, context)?, vec![]),
+            } => (vec![], Self::encode_ty_const(deps, const_, ty, context)?),
             ConstEncTask::Mir {
                 const_,
                 encoding_depth,
@@ -449,17 +435,16 @@ impl TaskEncoder for ConstEnc {
                         };
                         let expr = deps.require_dep::<MirPureEnc>(task)?.expr;
                         use vir::Reify;
-                        Ok((expr.reify(vcx, (uneval.def, &[])).downcast_ty(), vec![]))
+                        Ok((vec![], expr.reify(vcx, (uneval.def, &[])).downcast_ty()))
                     } else {
                         todo!("const too generic")
                     }
                 })?,
                 mir::Const::Ty(ty, const_) => (
-                    Self::encode_ty_const(deps, const_, ty, def_id.into())?,
                     vec![],
+                    Self::encode_ty_const(deps, const_, ty, def_id.into())?,
                 ),
             },
-        };
-        Ok((functions, res))
+        })
     }
 }

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -230,8 +230,16 @@ impl ConstEnc {
                         )
                     }
                 }
-                super::ty::TySpecifics::StructLike(struct_data) => match ty.kind() {
-                    TyKind::Tuple(tys) => struct_data.field_snaps_to_snap(
+                super::ty::TySpecifics::StructLike(struct_data) => {
+                    let tys = match ty.kind() {
+                        TyKind::Tuple(tys) => tys.as_slice(),
+                        TyKind::Adt(adt_def, args) if adt_def.is_struct() => &adt_def
+                            .all_fields()
+                            .map(|f| f.ty(vcx.tcx(), args))
+                            .collect_vec(),
+                        _ => unreachable!(),
+                    };
+                    kind.expect_structlike().field_snaps_to_snap(
                         (0..struct_data.fields.len())
                             .map(|idx| {
                                 Self::encode_const_val_tree(
@@ -245,11 +253,20 @@ impl ConstEnc {
                                 .upcast_ty()
                             })
                             .collect_vec(),
-                    ),
-                    TyKind::Adt(def, args) => {
-                        let fields = def.all_fields().collect_vec();
-                        struct_data.field_snaps_to_snap(
-                            (0..struct_data.fields.len())
+                    )
+                }
+
+                super::ty::TySpecifics::EnumLike(enum_data) => {
+                    let (enum_ty, args) = match ty.kind() {
+                        TyKind::Adt(adt_def, args) if adt_def.is_enum() => (adt_def, args),
+                        _ => unreachable!(),
+                    };
+                    let variant_idx = ecx.read_discriminant(&val).unwrap();
+                    let fields = enum_ty.all_fields().collect_vec();
+                    enum_data.variants[variant_idx.as_usize()]
+                        .inner
+                        .field_snaps_to_snap(
+                            (0..fields.len())
                                 .map(|idx| {
                                     Self::encode_const_val_tree(
                                         deps,
@@ -263,33 +280,8 @@ impl ConstEnc {
                                 })
                                 .collect_vec(),
                         )
-                    }
-                    _ => unreachable!(),
-                },
-                super::ty::TySpecifics::EnumLike(enum_data) => match ty.kind() {
-                    TyKind::Adt(def, args) => {
-                        let fields = def.all_fields().collect_vec();
-                        let variant_idx = ecx.read_discriminant(&val).unwrap();
-                        let struct_data = &enum_data.variants[variant_idx.as_usize()].inner;
-                        struct_data.field_snaps_to_snap(
-                            (0..struct_data.fields.len())
-                                .map(|idx| {
-                                    Self::encode_const_val_tree(
-                                        deps,
-                                        ecx.project_field(&val, idx.into()).unwrap(),
-                                        fields[idx].ty(vcx.tcx(), args),
-                                        context,
-                                        ecx,
-                                    )
-                                    .unwrap()
-                                    .upcast_ty()
-                                })
-                                .collect_vec(),
-                        )
-                    }
-                    _ => unreachable!(),
-                },
-                super::ty::TySpecifics::Builtin(_) => unreachable!(),
+                }
+                _ => unreachable!(),
             })
         })
     }

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -1,12 +1,13 @@
+use itertools::Itertools;
 use prusti_rustc_interface::{
-    abi::HasDataLayout,
-    const_eval::interpret::AllocRange,
+    const_eval::{
+        const_eval::{CompileTimeMachine, mk_eval_cx_for_const_val},
+        interpret::{CtfeProvenance, InterpCx, Projectable},
+    },
     middle::{
-        mir::{
-            self, ConstValue,
-            interpret::{GlobalAlloc, Scalar},
-        },
+        mir::{self, ConstValue},
         ty,
+        ty::{TyKind, TypingEnv},
     },
     span::{Span, def_id::DefId},
 };
@@ -67,68 +68,176 @@ impl ConstEnc {
         }
     }
 
-    fn encode_scalar<'vir>(
+    fn encode_const_val_tree<'vir, T>(
         deps: &mut TaskEncoderDependencies<'vir, Self>,
-        val: Scalar,
+        val: T,
         ty: ty::Ty<'vir>,
         context: GParams<'vir>,
-    ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, Self>> {
+        ecx: &InterpCx<'vir, CompileTimeMachine<'vir>>,
+    ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, Self>>
+    where
+        T: Projectable<'vir, CtfeProvenance>,
+    {
         let ty_task = RustTyDecomposition::from_ty(ty, context);
         let kind = deps.require_dep::<TyUsePureEnc>(ty_task)?;
+
         vir::with_vcx(|vcx| {
-            Ok(match val {
-                Scalar::Int(int) => {
-                    // TODO: Aggregates like structs will also show up as scalars
-                    // This means that the scalar doesn't contain all the data
-                    // and that it doesn't match the type of ty, which will lead
-                    // to a panic. We would have to encode these by looking at
-                    // the memory layout and iterating over the individual fields
-                    let prim = kind.expect_primitive();
+            Ok(match &kind.specifics {
+                super::ty::TySpecifics::ArrayLike(_array_data) => todo!(),
+                super::ty::TySpecifics::Param(_) => todo!(),
+                super::ty::TySpecifics::Opaque(_) => todo!(),
+                super::ty::TySpecifics::Primitive(prim) => {
+                    let int = ecx
+                        .read_scalar(&val)
+                        .unwrap()
+                        .try_to_scalar_int()
+                        .expect("Expected an integer");
                     let val = int.to_bits(int.size());
                     let val = prim.expr_from_bits(ty, val);
                     (prim.prim_to_snap)(val)
                 }
-                Scalar::Ptr(ptr, _) => match vcx.tcx().global_alloc(ptr.provenance.alloc_id()) {
-                    GlobalAlloc::Function { .. } => todo!(),
-                    GlobalAlloc::VTable(_, _) => todo!(),
-                    GlobalAlloc::Static(_) => todo!(),
-                    GlobalAlloc::Memory(mem) => {
-                        let (prov, offset) = ptr.prov_and_relative_offset();
+                super::ty::TySpecifics::ImmRef(imm_ref) => {
+                    let inner_ty = ty.builtin_deref(true).unwrap();
+                    let addr_to_ref = deps.require_dep::<RefDataEnc>(())?.addr_to_ref;
 
-                        let inner_ty = ty.builtin_deref(true).unwrap();
+                    if ty.builtin_deref(true).is_some()
+                        && (ty.builtin_deref(true).unwrap().is_str()
+                            || ty.builtin_deref(true).unwrap().is_slice())
+                    {
+                        let sl_ty = ty.peel_refs();
+                        let sl_ty_task = RustTyDecomposition::from_ty(sl_ty, context);
+                        let sl_snap = deps.require_dep::<TyUsePureEnc>(sl_ty_task)?;
+                        let sl_snap = sl_snap.expect_opaque();
+                        // first, we create a slice snapshot
+                        let snap = (sl_snap.arbitrary)().upcast_ty();
+                        // wrap it in a ref
+                        vir::with_vcx(|vcx| imm_ref.prim_to_snap(vcx.mk_null(), snap))
+                    } else {
+                        let ptr = ecx.read_pointer(&val).expect("Expected a pointer");
 
-                        let size = if inner_ty.is_any_ptr() {
-                            vcx.tcx().data_layout().pointer_size()
-                        } else {
-                            mem.0.size()
+                        let rel_addr = match ptr.into_pointer_or_addr() {
+                            Ok(ptr) => {
+                                ((ptr.provenance.alloc_id().0.get() as u128) << 64)
+                                    | ptr.prov_and_relative_offset().1.bytes() as u128
+                            }
+                            Err(addr) => addr.bytes() as u128,
                         };
-
-                        // TODO: the unwrap can fail, e.g., for zero-sized types or empty strs/slices
-                        let bytes = mem
-                            .0
-                            .read_scalar(
-                                &vcx.tcx(),
-                                AllocRange {
-                                    start: offset,
-                                    size,
-                                },
-                                inner_ty.is_any_ptr(),
-                            )
-                            .unwrap();
-                        let alloc_id = prov.alloc_id().0;
-                        let rel_addr = ((alloc_id.get() as u128) << 64) | offset.bytes() as u128;
-
-                        let addr_to_ref = deps.require_dep::<RefDataEnc>(())?.addr_to_ref;
-                        kind.expect_immref().prim_to_snap(
+                        imm_ref.prim_to_snap(
                             addr_to_ref(
                                 vcx.mk_const_expr(vir::ConstData::Int(rel_addr))
                                     .downcast_ty(),
                             ),
-                            Self::encode_scalar(deps, bytes, inner_ty, context)?.upcast_ty(),
+                            Self::encode_const_val_tree(
+                                deps,
+                                ecx.deref_pointer(&val).unwrap(),
+                                inner_ty,
+                                context,
+                                ecx,
+                            )?
+                            .upcast_ty(),
                         )
                     }
-                    GlobalAlloc::TypeId { .. } => todo!(),
+                }
+                super::ty::TySpecifics::MutRef(mutref) => {
+                    let inner_ty = ty.builtin_deref(true).unwrap();
+                    let addr_to_ref = deps.require_dep::<RefDataEnc>(())?.addr_to_ref;
+
+                    if ty.peel_refs().is_str() || ty.peel_refs().is_slice() {
+                        let sl_ty = ty.peel_refs();
+                        let sl_ty_task = RustTyDecomposition::from_ty(sl_ty, context);
+                        let sl_snap = deps.require_dep::<TyUsePureEnc>(sl_ty_task)?;
+                        let sl_snap = sl_snap.expect_opaque();
+                        // first, we create a slice snapshot
+                        let snap = (sl_snap.arbitrary)().upcast_ty();
+                        // wrap it in a ref
+                        vir::with_vcx(|vcx| mutref.prim_to_snap(vcx.mk_null(), snap))
+                    } else {
+                        let ptr = ecx.read_pointer(&val).expect("Expected a pointer");
+
+                        let rel_addr = match ptr.into_pointer_or_addr() {
+                            Ok(ptr) => {
+                                ((ptr.provenance.alloc_id().0.get() as u128) << 64)
+                                    | ptr.prov_and_relative_offset().1.bytes() as u128
+                            }
+                            Err(addr) => addr.bytes() as u128,
+                        };
+
+                        mutref.prim_to_snap(
+                            addr_to_ref(
+                                vcx.mk_const_expr(vir::ConstData::Int(rel_addr))
+                                    .downcast_ty(),
+                            ),
+                            Self::encode_const_val_tree(
+                                deps,
+                                ecx.deref_pointer(&val).unwrap(),
+                                inner_ty,
+                                context,
+                                ecx,
+                            )?
+                            .upcast_ty(),
+                        )
+                    }
+                }
+                super::ty::TySpecifics::StructLike(struct_data) => match ty.kind() {
+                    TyKind::Tuple(tys) => struct_data.field_snaps_to_snap(
+                        (0..struct_data.fields.len())
+                            .map(|idx| {
+                                Self::encode_const_val_tree(
+                                    deps,
+                                    ecx.project_field(&val, idx.into()).unwrap(),
+                                    tys[idx],
+                                    context,
+                                    ecx,
+                                )
+                                .unwrap()
+                                .upcast_ty()
+                            })
+                            .collect_vec(),
+                    ),
+                    TyKind::Adt(def, args) => {
+                        let fields = def.all_fields().collect_vec();
+                        struct_data.field_snaps_to_snap(
+                            (0..struct_data.fields.len())
+                                .map(|idx| {
+                                    Self::encode_const_val_tree(
+                                        deps,
+                                        ecx.project_field(&val, idx.into()).unwrap(),
+                                        fields[idx].ty(vcx.tcx(), args),
+                                        context,
+                                        ecx,
+                                    )
+                                    .unwrap()
+                                    .upcast_ty()
+                                })
+                                .collect_vec(),
+                        )
+                    }
+                    _ => unreachable!(),
                 },
+                super::ty::TySpecifics::EnumLike(enum_data) => match ty.kind() {
+                    TyKind::Adt(def, args) => {
+                        let fields = def.all_fields().collect_vec();
+                        let variant_idx = ecx.read_discriminant(&val).unwrap();
+                        let struct_data = &enum_data.variants[variant_idx.as_usize()].inner;
+                        struct_data.field_snaps_to_snap(
+                            (0..struct_data.fields.len())
+                                .map(|idx| {
+                                    Self::encode_const_val_tree(
+                                        deps,
+                                        ecx.project_field(&val, idx.into()).unwrap(),
+                                        fields[idx].ty(vcx.tcx(), args),
+                                        context,
+                                        ecx,
+                                    )
+                                    .unwrap()
+                                    .upcast_ty()
+                                })
+                                .collect_vec(),
+                        )
+                    }
+                    _ => unreachable!(),
+                },
+                super::ty::TySpecifics::Builtin(_) => unreachable!(),
             })
         })
     }
@@ -138,33 +247,14 @@ impl ConstEnc {
         val: ConstValue,
         ty: ty::Ty<'vir>,
         context: GParams<'vir>,
-        _span: Option<Span>,
+        span: Option<Span>,
     ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, Self>> {
-        let ty_task = RustTyDecomposition::from_ty(ty, context);
-        let kind = deps.require_dep::<TyUsePureEnc>(ty_task)?;
-        Ok(match val {
-            ConstValue::Scalar(scalar) => Self::encode_scalar(deps, scalar, ty, context)?,
-            ConstValue::ZeroSized => {
-                let s = kind.expect_structlike();
-                s.field_snaps_to_snap(Vec::new())
-            }
-            // Encode `&str` constants to an opaque domain. If we ever want to perform string reasoning
-            // we will need to revisit this encoding, but for the moment this allows assertions to avoid
-            // crashing Prusti.
-            ConstValue::Slice { .. } if ty.peel_refs().is_str() => {
-                let ref_ty = kind.expect_immref();
-                let str_ty = ty.peel_refs();
-                let str_ty_task = RustTyDecomposition::from_ty(str_ty, context);
-                let str_snap = deps.require_dep::<TyUsePureEnc>(str_ty_task)?;
-                let str_snap = str_snap.expect_opaque();
-                // first, we create a string snapshot
-                let snap = (str_snap.arbitrary)().upcast_ty();
-                // wrap it in a ref
-                vir::with_vcx(|vcx| ref_ty.prim_to_snap(vcx.mk_null(), snap))
-            }
-            ConstValue::Slice { .. } => todo!("ConstValue::Slice: {ty:?}"),
-            ConstValue::Indirect { .. } => todo!("ConstValue::Indirect"),
-        })
+        let ty_ctxt_at = vir::with_vcx(|vcx| vcx.tcx().at(span.unwrap()));
+        let (ecx, v) =
+            mk_eval_cx_for_const_val(ty_ctxt_at, TypingEnv::fully_monomorphized(), val, ty)
+                .unwrap();
+
+        Self::encode_const_val_tree(deps, v, ty, context, &ecx)
     }
 }
 

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -14,7 +14,7 @@ use prusti_rustc_interface::{
     span::{Span, def_id::DefId},
 };
 use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
-use vir::{CastType, FunctionGenData, FunctionIdn, VirCtxt};
+use vir::{CastType, FunctionIdn, VirCtxt};
 
 use crate::encoders::{
     MirPureEnc, MirPureEncTask, PureKind,
@@ -134,7 +134,7 @@ impl ConstEnc {
             vir::ExprRef<'vir>,
             vir::ExprSnap<'vir>,
         ) -> vir::ExprCSnap<'vir>,
-    ) -> Result<(Vec<vir::Function<'vir>>, vir::ExprCSnap<'vir>), EncodeFullError<'vir, Self>>
+    ) -> EncodeFullResult<'vir, Self>
     where
         T: Projectable<'vir, CtfeProvenance>,
     {
@@ -149,7 +149,7 @@ impl ConstEnc {
             // first, we create a slice snapshot
             let snap = (sl_snap.arbitrary)().upcast_ty();
             // wrap it in a ref
-            (vec![], prim_to_snap(ref_val, vcx.mk_null(), snap))
+            (Vec::new(), prim_to_snap(ref_val, vcx.mk_null(), snap))
         } else {
             let ptr = rec_data.ecx.read_pointer(&val).expect("Expected a pointer");
 
@@ -186,7 +186,7 @@ impl ConstEnc {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
         val: T,
         ty: RustTyDecomposition<'vir>,
-    ) -> Result<(Vec<vir::Function<'vir>>, vir::ExprCSnap<'vir>), EncodeFullError<'vir, Self>>
+    ) -> EncodeFullResult<'vir, Self>
     where
         T: Projectable<'vir, CtfeProvenance>,
     {
@@ -201,8 +201,8 @@ impl ConstEnc {
                         .expect_const()
                         .try_to_target_usize(vcx.tcx())
                         .unwrap();
-                    let mut posts = vec![];
-                    let mut funs = vec![];
+                    let mut posts = Vec::new();
+                    let mut funs = Vec::new();
                     let ecx = rec_data.ecx;
                     for idx in 0..elem_len {
                         let (snap_funs, snap) = Self::encode_const_val_tree(
@@ -254,7 +254,7 @@ impl ConstEnc {
                         .expect("scalar should be an integer");
                     let val = int.to_bits(int.size());
                     let val = prim.expr_from_bits(*ty.ty.expect_primitive(), val);
-                    (vec![], (prim.prim_to_snap)(val))
+                    (Vec::new(), (prim.prim_to_snap)(val))
                 }
                 super::ty::TySpecifics::ImmRef(imm_ref) => Self::encode_ref(
                     imm_ref,
@@ -275,8 +275,8 @@ impl ConstEnc {
                     TyUsePureMutRef::prim_to_snap,
                 )?,
                 super::ty::TySpecifics::StructLike(struct_data) => {
-                    let mut snaps = vec![];
-                    let mut funs = vec![];
+                    let mut snaps = Vec::new();
+                    let mut funs = Vec::new();
                     let ecx = rec_data.ecx;
                     for (idx, field) in ty.ty.expect_structlike().fields.iter().enumerate() {
                         let (snap_funs, snap) = Self::encode_const_val_tree(
@@ -294,8 +294,8 @@ impl ConstEnc {
 
                 super::ty::TySpecifics::EnumLike(enum_data) => {
                     let variant_idx = rec_data.ecx.read_discriminant(&val).unwrap();
-                    let mut snaps = vec![];
-                    let mut funs = vec![];
+                    let mut snaps = Vec::new();
+                    let mut funs = Vec::new();
                     let ecx = rec_data.ecx;
                     for (idx, field) in ty.ty.expect_enumlike().variants[variant_idx.as_usize()]
                         .inner
@@ -331,13 +331,7 @@ impl ConstEnc {
         ty: ty::Ty<'vir>,
         context: GParams<'vir>,
         span: Span,
-    ) -> Result<
-        (
-            Vec<&'vir FunctionGenData<'vir, (), !>>,
-            vir::ExprCSnap<'vir>,
-        ),
-        EncodeFullError<'vir, Self>,
-    > {
+    ) -> EncodeFullResult<'vir, Self> {
         let ty_ctxt_at = vir::with_vcx(|vcx| vcx.tcx().at(span));
         let (ecx, v) =
             mk_eval_cx_for_const_val(ty_ctxt_at, TypingEnv::fully_monomorphized(), val, ty)
@@ -390,7 +384,10 @@ impl TaskEncoder for ConstEnc {
                 const_,
                 ty,
                 context,
-            } => (vec![], Self::encode_ty_const(deps, const_, ty, context)?),
+            } => (
+                Vec::new(),
+                Self::encode_ty_const(deps, const_, ty, context)?,
+            ),
             ConstEncTask::Mir {
                 const_,
                 encoding_depth,
@@ -419,13 +416,13 @@ impl TaskEncoder for ConstEnc {
                         };
                         let expr = deps.require_dep::<MirPureEnc>(task)?.expr;
                         use vir::Reify;
-                        Ok((vec![], expr.reify(vcx, (uneval.def, &[])).downcast_ty()))
+                        Ok((Vec::new(), expr.reify(vcx, (uneval.def, &[])).downcast_ty()))
                     } else {
                         todo!("const too generic")
                     }
                 })?,
                 mir::Const::Ty(ty, const_) => (
-                    vec![],
+                    Vec::new(),
                     Self::encode_ty_const(deps, const_, ty, def_id.into())?,
                 ),
             },

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -308,6 +308,11 @@ impl ConstEnc {
                             .all_fields()
                             .map(|f| f.ty(vcx.tcx(), args))
                             .collect_vec(),
+                        TyKind::Closure(_closure_def, args) => &args
+                            .as_slice()
+                            .iter()
+                            .map(|arg| arg.expect_ty())
+                            .collect_vec(),
                         _ => unreachable!(),
                     };
                     let mut snaps = vec![];

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -14,7 +14,7 @@ use prusti_rustc_interface::{
     span::{Span, def_id::DefId},
 };
 use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
-use vir::{CastType, FunctionIdn, VirCtxt};
+use vir::{CastType, FunctionIdn};
 
 use crate::encoders::{
     MirPureEnc, MirPureEncTask, PureKind,
@@ -41,12 +41,6 @@ pub enum ConstEncTask<'vir> {
     },
 }
 
-struct EncodeConstValData<'vir> {
-    ecx: &'vir InterpCx<'vir, CompileTimeMachine<'vir>>,
-    context: GParams<'vir>,
-    span: Span,
-}
-
 /// Encodes constants into snapshot expressions. The evaluation of a constant
 /// is assumed to be side-effect free, as enforced by the compiler. This encoder
 /// handles two different kinds of constants: ones coming from the MIR and ones
@@ -56,13 +50,175 @@ struct EncodeConstValData<'vir> {
 /// https://rustc-dev-guide.rust-lang.org/mir/index.html#representing-constants
 pub struct ConstEnc;
 
+struct Enc<'enc, 'vir: 'enc> {
+    deps: &'enc mut TaskEncoderDependencies<'vir, ConstEnc>,
+    ecx: &'enc InterpCx<'vir, CompileTimeMachine<'vir>>,
+    context: GParams<'vir>,
+    span: Span,
+    functions: Vec<vir::Function<'vir>>,
+}
+
+impl<'enc, 'vir: 'enc> Enc<'enc, 'vir> {
+    fn encode_ref_addr_snap(
+        &mut self,
+        val: impl Projectable<'vir, CtfeProvenance>,
+        ty: RustTyDecomposition<'vir>,
+    ) -> Result<(vir::ExprRef<'vir>, vir::ExprSnap<'vir>), EncodeFullError<'vir, ConstEnc>> {
+        let inner_ty = ty.args.args()[1].expect_ty();
+        let addr_to_ref = self.deps.require_dep::<RefDataEnc>(())?.addr_to_ref;
+        vir::with_vcx(|vcx| {
+            Ok(if inner_ty.is_str() || inner_ty.is_slice() {
+                let sl_ty = inner_ty.peel_refs();
+                let sl_ty_task = RustTyDecomposition::from_ty(sl_ty, self.context);
+                let sl_snap = self.deps.require_dep::<TyUsePureEnc>(sl_ty_task)?;
+                let sl_snap = sl_snap.expect_opaque();
+                let snap = (sl_snap.arbitrary)().upcast_ty();
+                (vcx.mk_null(), snap)
+            } else {
+                let ptr = self.ecx.read_pointer(&val).expect("Expected a pointer");
+                let rel_addr = match ptr.into_pointer_or_addr() {
+                    Ok(ptr) => {
+                        ((ptr.provenance.alloc_id().0.get() as u128) << 64)
+                            | ptr.prov_and_relative_offset().1.bytes() as u128
+                    }
+                    Err(addr) => addr.bytes() as u128,
+                };
+                let snap = self.encode_const_val_tree(
+                    self.ecx.deref_pointer(&val).unwrap(),
+                    RustTyDecomposition::from_ty(inner_ty, self.context),
+                )?;
+                (
+                    addr_to_ref(
+                        vcx.mk_const_expr(vir::ConstData::Int(rel_addr))
+                            .downcast_ty(),
+                    ),
+                    snap.upcast_ty(),
+                )
+            })
+        })
+    }
+
+    fn encode_const_val_tree(
+        &mut self,
+        val: impl Projectable<'vir, CtfeProvenance>,
+        ty: RustTyDecomposition<'vir>,
+    ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, ConstEnc>> {
+        let kind = self.deps.require_dep::<TyUsePureEnc>(ty)?;
+        vir::with_vcx(|vcx| {
+            Ok(match &kind.specifics {
+                super::ty::TySpecifics::ArrayLike(array_data) => {
+                    assert!(!array_data.slice);
+                    let elem_ty = ty.args.args()[1].expect_ty();
+                    let elem_len = ty.args.args()[0]
+                        .expect_const()
+                        .try_to_target_usize(vcx.tcx())
+                        .unwrap();
+                    let mut posts = Vec::new();
+                    for idx in 0..elem_len {
+                        let snap = self.encode_const_val_tree(
+                            self.ecx.project_index(&val, idx).unwrap(),
+                            RustTyDecomposition::from_ty(elem_ty, self.context),
+                        )?;
+                        posts.push(
+                            vcx.mk_eq_expr(
+                                snap.upcast_ty(),
+                                array_data.index(
+                                    vcx.mk_result(kind.snapshot.downcast_ty()),
+                                    vcx.mk_const_expr(vir::ConstData::Int(idx as u128))
+                                        .downcast_ty(),
+                                ),
+                            ),
+                        );
+                    }
+                    // TODO: this might run into collisions
+                    let span_pos = vcx.tcx().sess.source_map().lookup_char_pos(self.span.lo());
+                    let gen_snap_func_idn: FunctionIdn<'_, (), vir::CSnap> = FunctionIdn::new(
+                        vir::vir_format_identifier!(
+                            vcx,
+                            "const_{}_{}",
+                            span_pos.line,
+                            span_pos.col_display
+                        ),
+                        (),
+                        kind.snapshot.downcast_ty(),
+                    );
+                    self.functions.push(vcx.mk_function(
+                        gen_snap_func_idn,
+                        (),
+                        &[],
+                        vcx.alloc_slice(&posts),
+                        None,
+                        None,
+                    ));
+                    (gen_snap_func_idn)()
+                }
+                super::ty::TySpecifics::Opaque(_) => todo!(),
+                super::ty::TySpecifics::Primitive(prim) => {
+                    let int = self
+                        .ecx
+                        .read_scalar(&val)
+                        .unwrap()
+                        .try_to_scalar_int()
+                        .expect("scalar should be an integer");
+                    let val = int.to_bits(int.size());
+                    let val = prim.expr_from_bits(*ty.ty.expect_primitive(), val);
+                    (prim.prim_to_snap)(val)
+                }
+                super::ty::TySpecifics::ImmRef(immref) => {
+                    let (addr, snap) = self.encode_ref_addr_snap(val, ty)?;
+                    TyUsePureImmRef::prim_to_snap(immref, addr, snap)
+                }
+                super::ty::TySpecifics::MutRef(mutref) => {
+                    let (addr, snap) = self.encode_ref_addr_snap(val, ty)?;
+                    TyUsePureMutRef::prim_to_snap(mutref, addr, snap)
+                }
+                super::ty::TySpecifics::StructLike(struct_data) => {
+                    let mut snaps = Vec::new();
+                    for (idx, field) in ty.ty.expect_structlike().fields.iter().enumerate() {
+                        snaps.push(
+                            self.encode_const_val_tree(
+                                self.ecx.project_field(&val, idx.into()).unwrap(),
+                                field.decompose_normalize(ty.args),
+                            )?
+                            .upcast_ty(),
+                        );
+                    }
+                    struct_data.field_snaps_to_snap(snaps)
+                }
+                super::ty::TySpecifics::EnumLike(enum_data) => {
+                    let variant_idx = self.ecx.read_discriminant(&val).unwrap();
+                    let mut snaps = Vec::new();
+                    for (idx, field) in ty.ty.expect_enumlike().variants[variant_idx.as_usize()]
+                        .inner
+                        .fields
+                        .iter()
+                        .enumerate()
+                    {
+                        snaps.push(
+                            self.encode_const_val_tree(
+                                self.ecx.project_field(&val, idx.into()).unwrap(),
+                                field.decompose_normalize(ty.args),
+                            )?
+                            .upcast_ty(),
+                        );
+                    }
+                    enum_data.variants[variant_idx.as_usize()]
+                        .inner
+                        .field_snaps_to_snap(snaps)
+                }
+                _ => unreachable!(),
+            })
+        })
+    }
+}
+
 impl ConstEnc {
     fn encode_ty_const<'vir>(
         deps: &mut TaskEncoderDependencies<'vir, Self>,
         const_: ty::Const<'vir>,
         ty: ty::Ty<'vir>,
         context: GParams<'vir>,
-    ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, Self>> {
+    ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, ConstEnc>> {
         match const_.kind() {
             ty::ConstKind::Param(param) => {
                 let params = deps.require_dep::<GenericParamsEnc>(context)?;
@@ -81,7 +237,7 @@ impl ConstEnc {
         val: ConstValue,
         ty: ty::Ty<'vir>,
         context: GParams<'vir>,
-    ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, Self>> {
+    ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, ConstEnc>> {
         vir::with_vcx(|vcx| {
             let ty_task = RustTyDecomposition::from_ty(ty, context);
             let kind = deps.require_dep::<TyUsePureEnc>(ty_task)?;
@@ -122,209 +278,6 @@ impl ConstEnc {
         })
     }
 
-    fn encode_ref<'vir, T, Ref>(
-        ref_val: &'vir Ref,
-        rec_data: &'vir EncodeConstValData<'vir>,
-        deps: &mut TaskEncoderDependencies<'vir, Self>,
-        val: T,
-        ty: RustTyDecomposition<'vir>,
-        vcx: &'vir VirCtxt,
-        prim_to_snap: fn(
-            &'vir Ref,
-            vir::ExprRef<'vir>,
-            vir::ExprSnap<'vir>,
-        ) -> vir::ExprCSnap<'vir>,
-    ) -> EncodeFullResult<'vir, Self>
-    where
-        T: Projectable<'vir, CtfeProvenance>,
-    {
-        let inner_ty = ty.args.args()[1].expect_ty();
-        let addr_to_ref = deps.require_dep::<RefDataEnc>(())?.addr_to_ref;
-
-        Ok(if inner_ty.is_str() || inner_ty.is_slice() {
-            let sl_ty = inner_ty.peel_refs();
-            let sl_ty_task = RustTyDecomposition::from_ty(sl_ty, rec_data.context);
-            let sl_snap = deps.require_dep::<TyUsePureEnc>(sl_ty_task)?;
-            let sl_snap = sl_snap.expect_opaque();
-            // first, we create a slice snapshot
-            let snap = (sl_snap.arbitrary)().upcast_ty();
-            // wrap it in a ref
-            (Vec::new(), prim_to_snap(ref_val, vcx.mk_null(), snap))
-        } else {
-            let ptr = rec_data.ecx.read_pointer(&val).expect("Expected a pointer");
-
-            let rel_addr = match ptr.into_pointer_or_addr() {
-                Ok(ptr) => {
-                    ((ptr.provenance.alloc_id().0.get() as u128) << 64)
-                        | ptr.prov_and_relative_offset().1.bytes() as u128
-                }
-                Err(addr) => addr.bytes() as u128,
-            };
-            let ecx = rec_data.ecx;
-            let (snap_funs, snap) = Self::encode_const_val_tree(
-                rec_data,
-                deps,
-                ecx.deref_pointer(&val).unwrap(),
-                RustTyDecomposition::from_ty(inner_ty, rec_data.context),
-            )?;
-            (
-                snap_funs,
-                prim_to_snap(
-                    ref_val,
-                    addr_to_ref(
-                        vcx.mk_const_expr(vir::ConstData::Int(rel_addr))
-                            .downcast_ty(),
-                    ),
-                    snap.upcast_ty(),
-                ),
-            )
-        })
-    }
-
-    fn encode_const_val_tree<'vir, T>(
-        rec_data: &'vir EncodeConstValData<'vir>,
-        deps: &mut TaskEncoderDependencies<'vir, Self>,
-        val: T,
-        ty: RustTyDecomposition<'vir>,
-    ) -> EncodeFullResult<'vir, Self>
-    where
-        T: Projectable<'vir, CtfeProvenance>,
-    {
-        let kind = deps.require_dep::<TyUsePureEnc>(ty)?;
-
-        vir::with_vcx(|vcx| {
-            Ok(match &kind.specifics {
-                super::ty::TySpecifics::ArrayLike(array_data) => {
-                    assert!(!array_data.slice);
-                    let elem_ty = ty.args.args()[1].expect_ty();
-                    let elem_len = ty.args.args()[0]
-                        .expect_const()
-                        .try_to_target_usize(vcx.tcx())
-                        .unwrap();
-                    let mut posts = Vec::new();
-                    let mut funs = Vec::new();
-                    let ecx = rec_data.ecx;
-                    for idx in 0..elem_len {
-                        let (snap_funs, snap) = Self::encode_const_val_tree(
-                            rec_data,
-                            deps,
-                            ecx.project_index(&val, idx).unwrap(),
-                            RustTyDecomposition::from_ty(elem_ty, rec_data.context),
-                        )
-                        .unwrap();
-                        posts.push(
-                            vcx.mk_eq_expr(
-                                snap.upcast_ty(),
-                                array_data.index(
-                                    vcx.mk_result(kind.snapshot.downcast_ty()),
-                                    vcx.mk_const_expr(vir::ConstData::Int(idx as u128))
-                                        .downcast_ty(),
-                                ),
-                            ),
-                        );
-                        funs.extend(snap_funs);
-                    }
-                    let span_pos = vcx
-                        .tcx()
-                        .sess
-                        .source_map()
-                        .lookup_char_pos(rec_data.span.lo());
-                    let gen_snap_func_idn: FunctionIdn<'_, (), vir::CSnap> = FunctionIdn::new(
-                        vir::vir_format_identifier!(
-                            vcx,
-                            "const_{}:{}",
-                            span_pos.line,
-                            span_pos.col_display
-                        ),
-                        (),
-                        kind.snapshot.downcast_ty(),
-                    );
-                    let gen_snap_func =
-                        vcx.mk_function(gen_snap_func_idn, (), &[], vcx.alloc(posts), None, None);
-                    funs.push(gen_snap_func);
-                    (funs, (gen_snap_func_idn)())
-                }
-                super::ty::TySpecifics::Opaque(_) => todo!(),
-                super::ty::TySpecifics::Primitive(prim) => {
-                    let int = rec_data
-                        .ecx
-                        .read_scalar(&val)
-                        .unwrap()
-                        .try_to_scalar_int()
-                        .expect("scalar should be an integer");
-                    let val = int.to_bits(int.size());
-                    let val = prim.expr_from_bits(*ty.ty.expect_primitive(), val);
-                    (Vec::new(), (prim.prim_to_snap)(val))
-                }
-                super::ty::TySpecifics::ImmRef(imm_ref) => Self::encode_ref(
-                    imm_ref,
-                    rec_data,
-                    deps,
-                    val,
-                    ty,
-                    vcx,
-                    TyUsePureImmRef::prim_to_snap,
-                )?,
-                super::ty::TySpecifics::MutRef(mutref) => Self::encode_ref(
-                    mutref,
-                    rec_data,
-                    deps,
-                    val,
-                    ty,
-                    vcx,
-                    TyUsePureMutRef::prim_to_snap,
-                )?,
-                super::ty::TySpecifics::StructLike(struct_data) => {
-                    let mut snaps = Vec::new();
-                    let mut funs = Vec::new();
-                    let ecx = rec_data.ecx;
-                    for (idx, field) in ty.ty.expect_structlike().fields.iter().enumerate() {
-                        let (snap_funs, snap) = Self::encode_const_val_tree(
-                            rec_data,
-                            deps,
-                            ecx.project_field(&val, idx.into()).unwrap(),
-                            field.decompose_normalize(ty.args),
-                        )
-                        .unwrap();
-                        snaps.push(snap.upcast_ty());
-                        funs.extend(snap_funs);
-                    }
-                    (funs, struct_data.field_snaps_to_snap(snaps))
-                }
-
-                super::ty::TySpecifics::EnumLike(enum_data) => {
-                    let variant_idx = rec_data.ecx.read_discriminant(&val).unwrap();
-                    let mut snaps = Vec::new();
-                    let mut funs = Vec::new();
-                    let ecx = rec_data.ecx;
-                    for (idx, field) in ty.ty.expect_enumlike().variants[variant_idx.as_usize()]
-                        .inner
-                        .fields
-                        .iter()
-                        .enumerate()
-                    {
-                        let (snap_funs, snap) = Self::encode_const_val_tree(
-                            rec_data,
-                            deps,
-                            ecx.project_field(&val, idx.into()).unwrap(),
-                            field.decompose_normalize(ty.args),
-                        )
-                        .unwrap();
-                        snaps.push(snap.upcast_ty());
-                        funs.extend(snap_funs);
-                    }
-                    (
-                        funs,
-                        enum_data.variants[variant_idx.as_usize()]
-                            .inner
-                            .field_snaps_to_snap(snaps),
-                    )
-                }
-                _ => unreachable!(),
-            })
-        })
-    }
-
     fn encode_const_val<'vir>(
         deps: &mut TaskEncoderDependencies<'vir, Self>,
         val: ConstValue,
@@ -333,22 +286,18 @@ impl ConstEnc {
         span: Span,
     ) -> EncodeFullResult<'vir, Self> {
         let ty_ctxt_at = vir::with_vcx(|vcx| vcx.tcx().at(span));
-        let (ecx, v) =
+        let (ecx, valtree) =
             mk_eval_cx_for_const_val(ty_ctxt_at, TypingEnv::fully_monomorphized(), val, ty)
                 .unwrap();
-        vir::with_vcx(|vcx| {
-            let rec_data = EncodeConstValData {
-                ecx: vcx.alloc(ecx),
-                context,
-                span,
-            };
-            Self::encode_const_val_tree(
-                vcx.alloc(rec_data),
-                deps,
-                v,
-                RustTyDecomposition::from_ty(ty, context),
-            )
-        })
+        let mut enc = Enc {
+            ecx: &ecx,
+            deps,
+            context,
+            span,
+            functions: Vec::new(),
+        };
+        let expr = enc.encode_const_val_tree(valtree, RustTyDecomposition::from_ty(ty, context))?;
+        Ok((enc.functions, expr))
     }
 }
 
@@ -378,7 +327,6 @@ impl TaskEncoder for ConstEnc {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(*task_key, ())?;
-
         Ok(match *task_key {
             ConstEncTask::Ty {
                 const_,

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -5,7 +5,10 @@ use prusti_rustc_interface::{
         interpret::{CtfeProvenance, InterpCx, Projectable},
     },
     middle::{
-        mir::{self, ConstValue},
+        mir::{
+            self, ConstValue,
+            interpret::{GlobalAlloc, Scalar},
+        },
         ty,
         ty::{TyKind, TypingEnv},
     },
@@ -62,10 +65,59 @@ impl ConstEnc {
             }
             ty::ConstKind::Value(val) => {
                 let val = vir::with_vcx(|vcx| vcx.tcx().valtree_to_const_val(val));
-                Self::encode_const_val(deps, val, ty, context, None)
+                Self::encode_const_val_ty(deps, val, ty, context)
             }
             k => todo!("const kind {k:?}"),
         }
+    }
+
+    fn encode_const_val_ty<'vir>(
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
+        val: ConstValue,
+        ty: ty::Ty<'vir>,
+        context: GParams<'vir>,
+    ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, Self>> {
+        vir::with_vcx(|vcx| {
+            let ty_task = RustTyDecomposition::from_ty(ty, context);
+            let kind = deps.require_dep::<TyUsePureEnc>(ty_task)?;
+            Ok(match val {
+                ConstValue::Scalar(Scalar::Int(int)) => {
+                    let prim = kind.expect_primitive();
+                    let val = int.to_bits(int.size());
+                    let val = prim.expr_from_bits(ty, val);
+                    (prim.prim_to_snap)(val)
+                }
+                ConstValue::Scalar(Scalar::Ptr(ptr, _)) => {
+                    match vcx.tcx().global_alloc(ptr.provenance.alloc_id()) {
+                        GlobalAlloc::Function { .. } => todo!(),
+                        GlobalAlloc::VTable(_, _) => todo!(),
+                        GlobalAlloc::Static(_) => todo!(),
+                        GlobalAlloc::Memory(_mem) => unreachable!(),
+                        GlobalAlloc::TypeId { .. } => todo!(),
+                    }
+                }
+                ConstValue::ZeroSized => {
+                    let s = kind.expect_structlike();
+                    s.field_snaps_to_snap(Vec::new())
+                }
+                // Encode `&str` constants to an opaque domain. If we ever want to perform string reasoning
+                // we will need to revisit this encoding, but for the moment this allows assertions to avoid
+                // crashing Prusti.
+                ConstValue::Slice { .. } if ty.peel_refs().is_str() => {
+                    let ref_ty = kind.expect_immref();
+                    let str_ty = ty.peel_refs();
+                    let str_ty_task = RustTyDecomposition::from_ty(str_ty, context);
+                    let str_snap = deps.require_dep::<TyUsePureEnc>(str_ty_task)?;
+                    let str_snap = str_snap.expect_opaque();
+                    // first, we create a string snapshot
+                    let snap = (str_snap.arbitrary)().upcast_ty();
+                    // wrap it in a ref
+                    vir::with_vcx(|vcx| ref_ty.prim_to_snap(vcx.mk_null(), snap))
+                }
+                ConstValue::Slice { .. } => todo!("ConstValue::Slice: {ty:?}"),
+                ConstValue::Indirect { .. } => todo!("ConstValue::Indirect"),
+            })
+        })
     }
 
     fn encode_const_val_tree<'vir, T>(
@@ -247,9 +299,9 @@ impl ConstEnc {
         val: ConstValue,
         ty: ty::Ty<'vir>,
         context: GParams<'vir>,
-        span: Option<Span>,
+        span: Span,
     ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, Self>> {
-        let ty_ctxt_at = vir::with_vcx(|vcx| vcx.tcx().at(span.unwrap()));
+        let ty_ctxt_at = vir::with_vcx(|vcx| vcx.tcx().at(span));
         let (ecx, v) =
             mk_eval_cx_for_const_val(ty_ctxt_at, TypingEnv::fully_monomorphized(), val, ty)
                 .unwrap();
@@ -288,7 +340,7 @@ impl TaskEncoder for ConstEnc {
                 span,
             } => match const_ {
                 mir::Const::Val(val, ty) => {
-                    Self::encode_const_val(deps, val, ty, def_id.into(), Some(span))?
+                    Self::encode_const_val(deps, val, ty, def_id.into(), span)?
                 }
                 mir::Const::Unevaluated(uneval, ty) => vir::with_vcx(|vcx| {
                     let resolved = {
@@ -297,7 +349,7 @@ impl TaskEncoder for ConstEnc {
                             .const_eval_resolve(typing_env, uneval, vcx.tcx().def_span(def_id))
                     };
                     if let Ok(val) = resolved {
-                        Self::encode_const_val(deps, val, ty, def_id.into(), Some(span))
+                        Self::encode_const_val(deps, val, ty, def_id.into(), span)
                     } else if let Some(promoted) = uneval.promoted {
                         let task = MirPureEncTask {
                             encoding_depth: encoding_depth + 1,

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -372,7 +372,7 @@ impl TaskEncoder for ConstEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local_no_errors() {
+        for output in Self::all_outputs_local_no_errors(program) {
             for fun in output {
                 program.add_function(fun);
             }

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -9,7 +9,7 @@ use prusti_rustc_interface::{
             interpret::{GlobalAlloc, Scalar},
         },
         ty,
-        ty::{TyKind, TypingEnv},
+        ty::TypingEnv,
     },
     span::{Span, def_id::DefId},
 };
@@ -127,7 +127,7 @@ impl ConstEnc {
         rec_data: &'vir EncodeConstValData<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
         val: T,
-        ty: ty::Ty<'vir>,
+        ty: RustTyDecomposition<'vir>,
         vcx: &'vir VirCtxt,
         prim_to_snap: fn(
             &'vir Ref,
@@ -138,76 +138,69 @@ impl ConstEnc {
     where
         T: Projectable<'vir, CtfeProvenance>,
     {
-        let inner_ty = ty.builtin_deref(true).unwrap();
+        let inner_ty = ty.args.args()[1].expect_ty();
         let addr_to_ref = deps.require_dep::<RefDataEnc>(())?.addr_to_ref;
 
-        Ok(
-            if ty.builtin_deref(true).is_some()
-                && (ty.builtin_deref(true).unwrap().is_str()
-                    || ty.builtin_deref(true).unwrap().is_slice())
-            {
-                let sl_ty = ty.peel_refs();
-                let sl_ty_task = RustTyDecomposition::from_ty(sl_ty, rec_data.context);
-                let sl_snap = deps.require_dep::<TyUsePureEnc>(sl_ty_task)?;
-                let sl_snap = sl_snap.expect_opaque();
-                // first, we create a slice snapshot
-                let snap = (sl_snap.arbitrary)().upcast_ty();
-                // wrap it in a ref
-                (vec![], prim_to_snap(ref_val, vcx.mk_null(), snap))
-            } else {
-                let ptr = rec_data.ecx.read_pointer(&val).expect("Expected a pointer");
+        Ok(if inner_ty.is_str() || inner_ty.is_slice() {
+            let sl_ty = inner_ty.peel_refs();
+            let sl_ty_task = RustTyDecomposition::from_ty(sl_ty, rec_data.context);
+            let sl_snap = deps.require_dep::<TyUsePureEnc>(sl_ty_task)?;
+            let sl_snap = sl_snap.expect_opaque();
+            // first, we create a slice snapshot
+            let snap = (sl_snap.arbitrary)().upcast_ty();
+            // wrap it in a ref
+            (vec![], prim_to_snap(ref_val, vcx.mk_null(), snap))
+        } else {
+            let ptr = rec_data.ecx.read_pointer(&val).expect("Expected a pointer");
 
-                let rel_addr = match ptr.into_pointer_or_addr() {
-                    Ok(ptr) => {
-                        ((ptr.provenance.alloc_id().0.get() as u128) << 64)
-                            | ptr.prov_and_relative_offset().1.bytes() as u128
-                    }
-                    Err(addr) => addr.bytes() as u128,
-                };
-                let ecx = rec_data.ecx;
-                let (snap_funs, snap) = Self::encode_const_val_tree(
-                    rec_data,
-                    deps,
-                    ecx.deref_pointer(&val).unwrap(),
-                    inner_ty,
-                )?;
-                (
-                    snap_funs,
-                    prim_to_snap(
-                        ref_val,
-                        addr_to_ref(
-                            vcx.mk_const_expr(vir::ConstData::Int(rel_addr))
-                                .downcast_ty(),
-                        ),
-                        snap.upcast_ty(),
+            let rel_addr = match ptr.into_pointer_or_addr() {
+                Ok(ptr) => {
+                    ((ptr.provenance.alloc_id().0.get() as u128) << 64)
+                        | ptr.prov_and_relative_offset().1.bytes() as u128
+                }
+                Err(addr) => addr.bytes() as u128,
+            };
+            let ecx = rec_data.ecx;
+            let (snap_funs, snap) = Self::encode_const_val_tree(
+                rec_data,
+                deps,
+                ecx.deref_pointer(&val).unwrap(),
+                RustTyDecomposition::from_ty(inner_ty, rec_data.context),
+            )?;
+            (
+                snap_funs,
+                prim_to_snap(
+                    ref_val,
+                    addr_to_ref(
+                        vcx.mk_const_expr(vir::ConstData::Int(rel_addr))
+                            .downcast_ty(),
                     ),
-                )
-            },
-        )
+                    snap.upcast_ty(),
+                ),
+            )
+        })
     }
 
     fn encode_const_val_tree<'vir, T>(
         rec_data: &'vir EncodeConstValData<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, Self>,
         val: T,
-        ty: ty::Ty<'vir>,
+        ty: RustTyDecomposition<'vir>,
     ) -> Result<(Vec<vir::Function<'vir>>, vir::ExprCSnap<'vir>), EncodeFullError<'vir, Self>>
     where
         T: Projectable<'vir, CtfeProvenance>,
     {
-        let ty_task = RustTyDecomposition::from_ty(ty, rec_data.context);
-        let kind = deps.require_dep::<TyUsePureEnc>(ty_task)?;
+        let kind = deps.require_dep::<TyUsePureEnc>(ty)?;
 
         vir::with_vcx(|vcx| {
             Ok(match &kind.specifics {
                 super::ty::TySpecifics::ArrayLike(array_data) => {
-                    let (elem_ty, elem_len) = match ty.kind() {
-                        TyKind::Array(elem_ty, len) => (
-                            elem_ty,
-                            len.to_value().try_to_target_usize(vcx.tcx()).unwrap(),
-                        ),
-                        _ => unreachable!(),
-                    };
+                    assert!(!array_data.slice);
+                    let elem_ty = ty.args.args()[1].expect_ty();
+                    let elem_len = ty.args.args()[0]
+                        .expect_const()
+                        .try_to_target_usize(vcx.tcx())
+                        .unwrap();
                     let mut posts = vec![];
                     let mut funs = vec![];
                     let ecx = rec_data.ecx;
@@ -216,7 +209,7 @@ impl ConstEnc {
                             rec_data,
                             deps,
                             ecx.project_index(&val, idx).unwrap(),
-                            *elem_ty,
+                            RustTyDecomposition::from_ty(elem_ty, rec_data.context),
                         )
                         .unwrap();
                         posts.push(
@@ -251,7 +244,6 @@ impl ConstEnc {
                     funs.push(gen_snap_func);
                     (funs, (gen_snap_func_idn)())
                 }
-                super::ty::TySpecifics::Param(_) => todo!(),
                 super::ty::TySpecifics::Opaque(_) => todo!(),
                 super::ty::TySpecifics::Primitive(prim) => {
                     let int = rec_data
@@ -261,7 +253,7 @@ impl ConstEnc {
                         .try_to_scalar_int()
                         .expect("scalar should be an integer");
                     let val = int.to_bits(int.size());
-                    let val = prim.expr_from_bits(ty, val);
+                    let val = prim.expr_from_bits(*ty.ty.expect_primitive(), val);
                     (vec![], (prim.prim_to_snap)(val))
                 }
                 super::ty::TySpecifics::ImmRef(imm_ref) => Self::encode_ref(
@@ -283,52 +275,39 @@ impl ConstEnc {
                     TyUsePureMutRef::prim_to_snap,
                 )?,
                 super::ty::TySpecifics::StructLike(struct_data) => {
-                    let tys = match ty.kind() {
-                        TyKind::Tuple(tys) => tys.as_slice(),
-                        TyKind::Adt(adt_def, args) if adt_def.is_struct() => &adt_def
-                            .all_fields()
-                            .map(|f| f.ty(vcx.tcx(), args))
-                            .collect::<Vec<_>>(),
-                        TyKind::Closure(_closure_def, args) => &args
-                            .as_slice()
-                            .iter()
-                            .map(|arg| arg.expect_ty())
-                            .collect::<Vec<_>>(),
-                        _ => unreachable!(),
-                    };
                     let mut snaps = vec![];
                     let mut funs = vec![];
                     let ecx = rec_data.ecx;
-                    for (idx, ty) in tys.iter().enumerate().take(struct_data.fields.len()) {
+                    for (idx, field) in ty.ty.expect_structlike().fields.iter().enumerate() {
                         let (snap_funs, snap) = Self::encode_const_val_tree(
                             rec_data,
                             deps,
                             ecx.project_field(&val, idx.into()).unwrap(),
-                            *ty,
+                            field.decompose_normalize(ty.args),
                         )
                         .unwrap();
                         snaps.push(snap.upcast_ty());
                         funs.extend(snap_funs);
                     }
-                    (funs, kind.expect_structlike().field_snaps_to_snap(snaps))
+                    (funs, struct_data.field_snaps_to_snap(snaps))
                 }
 
                 super::ty::TySpecifics::EnumLike(enum_data) => {
-                    let (enum_ty, args) = match ty.kind() {
-                        TyKind::Adt(adt_def, args) if adt_def.is_enum() => (adt_def, args),
-                        _ => unreachable!(),
-                    };
                     let variant_idx = rec_data.ecx.read_discriminant(&val).unwrap();
-                    let fields = enum_ty.all_fields().collect::<Vec<_>>();
                     let mut snaps = vec![];
                     let mut funs = vec![];
                     let ecx = rec_data.ecx;
-                    for (idx, field) in fields.iter().enumerate() {
+                    for (idx, field) in ty.ty.expect_enumlike().variants[variant_idx.as_usize()]
+                        .inner
+                        .fields
+                        .iter()
+                        .enumerate()
+                    {
                         let (snap_funs, snap) = Self::encode_const_val_tree(
                             rec_data,
                             deps,
                             ecx.project_field(&val, idx.into()).unwrap(),
-                            field.ty(vcx.tcx(), args),
+                            field.decompose_normalize(ty.args),
                         )
                         .unwrap();
                         snaps.push(snap.upcast_ty());
@@ -369,7 +348,12 @@ impl ConstEnc {
                 context,
                 span,
             };
-            Self::encode_const_val_tree(vcx.alloc(rec_data), deps, v, ty)
+            Self::encode_const_val_tree(
+                vcx.alloc(rec_data),
+                deps,
+                v,
+                RustTyDecomposition::from_ty(ty, context),
+            )
         })
     }
 }

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -15,7 +15,7 @@ use prusti_rustc_interface::{
     span::{Span, def_id::DefId},
 };
 use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
-use vir::CastType;
+use vir::{CastType, FunctionGenData, FunctionIdn};
 
 use crate::encoders::{
     MirPureEnc, MirPureEncTask, PureKind,
@@ -126,7 +126,14 @@ impl ConstEnc {
         ty: ty::Ty<'vir>,
         context: GParams<'vir>,
         ecx: &InterpCx<'vir, CompileTimeMachine<'vir>>,
-    ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, Self>>
+        span: Span,
+    ) -> Result<
+        (
+            vir::ExprCSnap<'vir>,
+            Vec<&'vir FunctionGenData<'vir, (), !>>,
+        ),
+        EncodeFullError<'vir, Self>,
+    >
     where
         T: Projectable<'vir, CtfeProvenance>,
     {
@@ -135,7 +142,54 @@ impl ConstEnc {
 
         vir::with_vcx(|vcx| {
             Ok(match &kind.specifics {
-                super::ty::TySpecifics::ArrayLike(_array_data) => todo!(),
+                super::ty::TySpecifics::ArrayLike(array_data) => {
+                    let (elem_ty, elem_len) = match ty.kind() {
+                        TyKind::Array(elem_ty, len) => (
+                            elem_ty,
+                            len.to_value().try_to_target_usize(vcx.tcx()).unwrap(),
+                        ),
+                        _ => unreachable!(),
+                    };
+                    let mut posts = vec![];
+                    let mut funs = vec![];
+                    for idx in 0..elem_len {
+                        let (snap, snap_funs) = Self::encode_const_val_tree(
+                            deps,
+                            ecx.project_index(&val, idx).unwrap(),
+                            *elem_ty,
+                            context,
+                            ecx,
+                            span,
+                        )
+                        .unwrap();
+                        posts.push(
+                            vcx.mk_eq_expr(
+                                snap.upcast_ty(),
+                                array_data.index(
+                                    vcx.mk_result(kind.snapshot.downcast_ty()),
+                                    vcx.mk_const_expr(vir::ConstData::Int(idx as u128))
+                                        .downcast_ty(),
+                                ),
+                            ),
+                        );
+                        funs.extend(snap_funs);
+                    }
+                    let span_pos = vcx.tcx().sess.source_map().lookup_char_pos(span.lo());
+                    let gen_snap_func_idn: FunctionIdn<'_, (), vir::CSnap> = FunctionIdn::new(
+                        vir::vir_format_identifier!(
+                            vcx,
+                            "const_{}:{}",
+                            span_pos.line,
+                            span_pos.col_display
+                        ),
+                        (),
+                        kind.snapshot.downcast_ty(),
+                    );
+                    let gen_snap_func =
+                        vcx.mk_function(gen_snap_func_idn, (), &[], vcx.alloc(posts), None, None);
+                    funs.push(gen_snap_func);
+                    ((gen_snap_func_idn)(), funs)
+                }
                 super::ty::TySpecifics::Param(_) => todo!(),
                 super::ty::TySpecifics::Opaque(_) => todo!(),
                 super::ty::TySpecifics::Primitive(prim) => {
@@ -146,7 +200,7 @@ impl ConstEnc {
                         .expect("Expected an integer");
                     let val = int.to_bits(int.size());
                     let val = prim.expr_from_bits(ty, val);
-                    (prim.prim_to_snap)(val)
+                    ((prim.prim_to_snap)(val), vec![])
                 }
                 super::ty::TySpecifics::ImmRef(imm_ref) => {
                     let inner_ty = ty.builtin_deref(true).unwrap();
@@ -163,7 +217,10 @@ impl ConstEnc {
                         // first, we create a slice snapshot
                         let snap = (sl_snap.arbitrary)().upcast_ty();
                         // wrap it in a ref
-                        vir::with_vcx(|vcx| imm_ref.prim_to_snap(vcx.mk_null(), snap))
+                        (
+                            vir::with_vcx(|vcx| imm_ref.prim_to_snap(vcx.mk_null(), snap)),
+                            vec![],
+                        )
                     } else {
                         let ptr = ecx.read_pointer(&val).expect("Expected a pointer");
 
@@ -174,19 +231,23 @@ impl ConstEnc {
                             }
                             Err(addr) => addr.bytes() as u128,
                         };
-                        imm_ref.prim_to_snap(
-                            addr_to_ref(
-                                vcx.mk_const_expr(vir::ConstData::Int(rel_addr))
-                                    .downcast_ty(),
+                        let (snap, snap_funs) = Self::encode_const_val_tree(
+                            deps,
+                            ecx.deref_pointer(&val).unwrap(),
+                            inner_ty,
+                            context,
+                            ecx,
+                            span,
+                        )?;
+                        (
+                            imm_ref.prim_to_snap(
+                                addr_to_ref(
+                                    vcx.mk_const_expr(vir::ConstData::Int(rel_addr))
+                                        .downcast_ty(),
+                                ),
+                                snap.upcast_ty(),
                             ),
-                            Self::encode_const_val_tree(
-                                deps,
-                                ecx.deref_pointer(&val).unwrap(),
-                                inner_ty,
-                                context,
-                                ecx,
-                            )?
-                            .upcast_ty(),
+                            snap_funs,
                         )
                     }
                 }
@@ -194,7 +255,10 @@ impl ConstEnc {
                     let inner_ty = ty.builtin_deref(true).unwrap();
                     let addr_to_ref = deps.require_dep::<RefDataEnc>(())?.addr_to_ref;
 
-                    if ty.peel_refs().is_str() || ty.peel_refs().is_slice() {
+                    if ty.builtin_deref(true).is_some()
+                        && (ty.builtin_deref(true).unwrap().is_str()
+                            || ty.builtin_deref(true).unwrap().is_slice())
+                    {
                         let sl_ty = ty.peel_refs();
                         let sl_ty_task = RustTyDecomposition::from_ty(sl_ty, context);
                         let sl_snap = deps.require_dep::<TyUsePureEnc>(sl_ty_task)?;
@@ -202,7 +266,10 @@ impl ConstEnc {
                         // first, we create a slice snapshot
                         let snap = (sl_snap.arbitrary)().upcast_ty();
                         // wrap it in a ref
-                        vir::with_vcx(|vcx| mutref.prim_to_snap(vcx.mk_null(), snap))
+                        (
+                            vir::with_vcx(|vcx| mutref.prim_to_snap(vcx.mk_null(), snap)),
+                            vec![],
+                        )
                     } else {
                         let ptr = ecx.read_pointer(&val).expect("Expected a pointer");
 
@@ -214,19 +281,23 @@ impl ConstEnc {
                             Err(addr) => addr.bytes() as u128,
                         };
 
-                        mutref.prim_to_snap(
-                            addr_to_ref(
-                                vcx.mk_const_expr(vir::ConstData::Int(rel_addr))
-                                    .downcast_ty(),
+                        let (snap, snap_funs) = Self::encode_const_val_tree(
+                            deps,
+                            ecx.deref_pointer(&val).unwrap(),
+                            inner_ty,
+                            context,
+                            ecx,
+                            span,
+                        )?;
+                        (
+                            mutref.prim_to_snap(
+                                addr_to_ref(
+                                    vcx.mk_const_expr(vir::ConstData::Int(rel_addr))
+                                        .downcast_ty(),
+                                ),
+                                snap.upcast_ty(),
                             ),
-                            Self::encode_const_val_tree(
-                                deps,
-                                ecx.deref_pointer(&val).unwrap(),
-                                inner_ty,
-                                context,
-                                ecx,
-                            )?
-                            .upcast_ty(),
+                            snap_funs,
                         )
                     }
                 }
@@ -239,21 +310,22 @@ impl ConstEnc {
                             .collect_vec(),
                         _ => unreachable!(),
                     };
-                    kind.expect_structlike().field_snaps_to_snap(
-                        (0..struct_data.fields.len())
-                            .map(|idx| {
-                                Self::encode_const_val_tree(
-                                    deps,
-                                    ecx.project_field(&val, idx.into()).unwrap(),
-                                    tys[idx],
-                                    context,
-                                    ecx,
-                                )
-                                .unwrap()
-                                .upcast_ty()
-                            })
-                            .collect_vec(),
-                    )
+                    let mut snaps = vec![];
+                    let mut funs = vec![];
+                    for (idx, ty) in tys.iter().enumerate().take(struct_data.fields.len()) {
+                        let (snap, snap_funs) = Self::encode_const_val_tree(
+                            deps,
+                            ecx.project_field(&val, idx.into()).unwrap(),
+                            *ty,
+                            context,
+                            ecx,
+                            span,
+                        )
+                        .unwrap();
+                        snaps.push(snap.upcast_ty());
+                        funs.extend(snap_funs);
+                    }
+                    (kind.expect_structlike().field_snaps_to_snap(snaps), funs)
                 }
 
                 super::ty::TySpecifics::EnumLike(enum_data) => {
@@ -263,23 +335,27 @@ impl ConstEnc {
                     };
                     let variant_idx = ecx.read_discriminant(&val).unwrap();
                     let fields = enum_ty.all_fields().collect_vec();
-                    enum_data.variants[variant_idx.as_usize()]
-                        .inner
-                        .field_snaps_to_snap(
-                            (0..fields.len())
-                                .map(|idx| {
-                                    Self::encode_const_val_tree(
-                                        deps,
-                                        ecx.project_field(&val, idx.into()).unwrap(),
-                                        fields[idx].ty(vcx.tcx(), args),
-                                        context,
-                                        ecx,
-                                    )
-                                    .unwrap()
-                                    .upcast_ty()
-                                })
-                                .collect_vec(),
+                    let mut snaps = vec![];
+                    let mut funs = vec![];
+                    for (idx, field) in fields.iter().enumerate() {
+                        let (snap, snap_funs) = Self::encode_const_val_tree(
+                            deps,
+                            ecx.project_field(&val, idx.into()).unwrap(),
+                            field.ty(vcx.tcx(), args),
+                            context,
+                            ecx,
+                            span,
                         )
+                        .unwrap();
+                        snaps.push(snap.upcast_ty());
+                        funs.extend(snap_funs);
+                    }
+                    (
+                        enum_data.variants[variant_idx.as_usize()]
+                            .inner
+                            .field_snaps_to_snap(snaps),
+                        funs,
+                    )
                 }
                 _ => unreachable!(),
             })
@@ -292,13 +368,19 @@ impl ConstEnc {
         ty: ty::Ty<'vir>,
         context: GParams<'vir>,
         span: Span,
-    ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, Self>> {
+    ) -> Result<
+        (
+            vir::ExprCSnap<'vir>,
+            Vec<&'vir FunctionGenData<'vir, (), !>>,
+        ),
+        EncodeFullError<'vir, Self>,
+    > {
         let ty_ctxt_at = vir::with_vcx(|vcx| vcx.tcx().at(span));
         let (ecx, v) =
             mk_eval_cx_for_const_val(ty_ctxt_at, TypingEnv::fully_monomorphized(), val, ty)
                 .unwrap();
 
-        Self::encode_const_val_tree(deps, v, ty, context, &ecx)
+        Self::encode_const_val_tree(deps, v, ty, context, &ecx, span)
     }
 }
 
@@ -308,10 +390,19 @@ impl TaskEncoder for ConstEnc {
 
     type TaskDescription<'vir> = ConstEncTask<'vir>;
     type OutputFullDependency<'vir> = vir::ExprCSnap<'vir>;
+    type OutputFullLocal<'vir> = Vec<&'vir FunctionGenData<'vir, (), !>>;
     type EncodingError = ();
 
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         *task
+    }
+
+    fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
+        for output in ConstEnc::all_outputs_local_no_errors() {
+            for fun in output {
+                program.add_function(fun);
+            }
+        }
     }
 
     fn do_encode_full<'vir>(
@@ -319,12 +410,12 @@ impl TaskEncoder for ConstEnc {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(*task_key, ())?;
-        let res = match *task_key {
+        let (res, functions) = match *task_key {
             ConstEncTask::Ty {
                 const_,
                 ty,
                 context,
-            } => Self::encode_ty_const(deps, const_, ty, context)?,
+            } => (Self::encode_ty_const(deps, const_, ty, context)?, vec![]),
             ConstEncTask::Mir {
                 const_,
                 encoding_depth,
@@ -353,16 +444,17 @@ impl TaskEncoder for ConstEnc {
                         };
                         let expr = deps.require_dep::<MirPureEnc>(task)?.expr;
                         use vir::Reify;
-                        Ok(expr.reify(vcx, (uneval.def, &[])).downcast_ty())
+                        Ok((expr.reify(vcx, (uneval.def, &[])).downcast_ty(), vec![]))
                     } else {
                         todo!("const too generic")
                     }
                 })?,
-                mir::Const::Ty(ty, const_) => {
-                    Self::encode_ty_const(deps, const_, ty, def_id.into())?
-                }
+                mir::Const::Ty(ty, const_) => (
+                    Self::encode_ty_const(deps, const_, ty, def_id.into())?,
+                    vec![],
+                ),
             },
         };
-        Ok(((), res))
+        Ok((functions, res))
     }
 }

--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -153,7 +153,7 @@ impl<'tcx> LazyRustTy<'tcx> {
     /// removing definitional generics. For example a `Foo<i32>` with definition
     /// `struct Foo<T>(T);` would yield `i32` instead of `T` when called on the
     /// field of `Foo`.
-    pub(super) fn decompose_normalize(&self, args: GArgs<'tcx>) -> RustTyDecomposition<'tcx> {
+    pub fn decompose_normalize(&self, args: GArgs<'tcx>) -> RustTyDecomposition<'tcx> {
         RustTyDecomposition::from_ty(args.normalize(self.0), args.context())
     }
 

--- a/prusti-encoder/src/lib.rs
+++ b/prusti-encoder/src/lib.rs
@@ -105,10 +105,12 @@ pub fn test_entrypoint<'tcx>(
     TyConstructorEnc::emit_outputs(&mut program);
     TypeOfEnc::emit_outputs(&mut program);
 
+    program.header("constants");
+    ConstEnc::emit_outputs(&mut program);
+
     program.header("custom");
     PairUseEnc::emit_outputs(&mut program);
     RefDataEnc::emit_outputs(&mut program);
-    ConstEnc::emit_outputs(&mut program);
 
     program.header("traits");
     TraitEnc::emit_outputs(&mut program);

--- a/prusti-encoder/src/lib.rs
+++ b/prusti-encoder/src/lib.rs
@@ -19,7 +19,7 @@ use prusti_utils::config;
 use task_encoder::TaskEncoder;
 
 use crate::encoders::{
-    Impure, Pure,
+    ConstEnc, Impure, Pure,
     addr::RefDataEnc,
     custom::PairUseEnc,
     ty::{
@@ -108,6 +108,7 @@ pub fn test_entrypoint<'tcx>(
     program.header("custom");
     PairUseEnc::emit_outputs(&mut program);
     RefDataEnc::emit_outputs(&mut program);
+    ConstEnc::emit_outputs(&mut program);
 
     program.header("traits");
     TraitEnc::emit_outputs(&mut program);


### PR DESCRIPTION
This PR adapts the ConstEnc by recursing on the type information and using InterpCx to project fields. This fixes issues where we can't just look at the information available by MIR 