### PR TITLE
Encode trait objects as opaque 

### DIFF
--- a/prusti-encoder/src/encoders/ty/generics/args.rs
+++ b/prusti-encoder/src/encoders/ty/generics/args.rs
@@ -13,6 +13,7 @@ pub struct GArgs<'tcx> {
 pub enum GParamVariant<'tcx> {
     Param(ty::ParamTy),
     Alias(ty::AliasTy<'tcx>),
+    Dyn,
 }
 
 impl<'tcx> GArgs<'tcx> {
@@ -40,6 +41,9 @@ impl<'tcx> GArgs<'tcx> {
     }
 
     pub fn expect_param(self) -> GParamVariant<'tcx> {
+        if self.args.is_empty() {
+            return GParamVariant::Dyn;
+        }
         assert_eq!(self.args.len(), 1);
         match self.args[0].expect_ty().kind() {
             ty::TyKind::Param(p) => GParamVariant::Param(*p),

--- a/prusti-encoder/src/encoders/ty/generics/args.rs
+++ b/prusti-encoder/src/encoders/ty/generics/args.rs
@@ -13,7 +13,6 @@ pub struct GArgs<'tcx> {
 pub enum GParamVariant<'tcx> {
     Param(ty::ParamTy),
     Alias(ty::AliasTy<'tcx>),
-    Dyn,
 }
 
 impl<'tcx> GArgs<'tcx> {
@@ -41,9 +40,6 @@ impl<'tcx> GArgs<'tcx> {
     }
 
     pub fn expect_param(self) -> GParamVariant<'tcx> {
-        if self.args.is_empty() {
-            return GParamVariant::Dyn;
-        }
         assert_eq!(self.args.len(), 1);
         match self.args[0].expect_ty().kind() {
             ty::TyKind::Param(p) => GParamVariant::Param(*p),

--- a/prusti-encoder/src/encoders/ty/generics/params.rs
+++ b/prusti-encoder/src/encoders/ty/generics/params.rs
@@ -9,7 +9,7 @@ use vir::{CastType, HasType};
 use crate::encoders::{
     TyUsePureEnc,
     ty::{
-        RustTyDecomposition,
+        RustParamData, RustTyDecomposition,
         data::TySpecifics,
         generics::{GArgs, GArgsTyEnc, GParamVariant, r#trait::TraitEnc},
         lifted::TyConstructorEnc,
@@ -258,26 +258,19 @@ impl<'vir> GenericParams<'vir> {
         deps: &mut TaskEncoderDependencies<'vir, E>,
         ty: RustTyDecomposition<'vir>,
     ) -> vir::ExprTyVal<'vir> {
-        if let TySpecifics::Param(()) = &ty.ty.specifics {
-            if ty.args.args().is_empty() {
-                // dyn Trait: the only TySpecifics::Param type with no synthetic type params.
-                // Real generic T and Alias always have exactly one.
-                assert!(ty.ty.params.rust_params().is_empty());
-                // fall through to TyConstructorEnc
-            } else {
-                let param = ty.args.expect_param();
-                return match param {
-                    GParamVariant::Param(p) => self.ty_exprs[self.map_idx(p.index).unwrap()],
-                    GParamVariant::Alias(alias) => vir::with_vcx(|vcx| {
-                        let tcx = vcx.tcx();
-                        let trait_did = tcx.associated_item(alias.def_id).container_id(tcx);
-                        let trait_data = deps.require_ref::<TraitEnc>(trait_did).unwrap();
-                        let args = GArgs::new(ty.args.context, alias.args);
-                        let args = deps.require_dep::<GArgsTyEnc>(args).unwrap();
-                        (trait_data.assoc_types[&alias.def_id])(args.get_ty(), args.get_const())
-                    }),
-                };
-            }
+        if let TySpecifics::Param(RustParamData::Generic) = &ty.ty.specifics {
+            let param = ty.args.expect_param();
+            return match param {
+                GParamVariant::Param(p) => self.ty_exprs[self.map_idx(p.index).unwrap()],
+                GParamVariant::Alias(alias) => vir::with_vcx(|vcx| {
+                    let tcx = vcx.tcx();
+                    let trait_did = tcx.associated_item(alias.def_id).container_id(tcx);
+                    let trait_data = deps.require_ref::<TraitEnc>(trait_did).unwrap();
+                    let args = GArgs::new(ty.args.context, alias.args);
+                    let args = deps.require_dep::<GArgsTyEnc>(args).unwrap();
+                    (trait_data.assoc_types[&alias.def_id])(args.get_ty(), args.get_const())
+                }),
+            };
         }
         let ty_constructor = deps
             .require_ref::<TyConstructorEnc>(ty.ty)

--- a/prusti-encoder/src/encoders/ty/generics/params.rs
+++ b/prusti-encoder/src/encoders/ty/generics/params.rs
@@ -265,9 +265,10 @@ impl<'vir> GenericParams<'vir> {
                 assert!(ty.ty.params.rust_params().is_empty());
                 // fall through to TyConstructorEnc
             } else {
-                match ty.args.expect_param()  {
-                    GParamVariant::Param(p) => return self.ty_exprs[self.map_idx(p.index).unwrap()],
-                    GParamVariant::Alias(alias) => return vir::with_vcx(|vcx| {
+                let param = ty.args.expect_param();
+                return match param {
+                    GParamVariant::Param(p) => self.ty_exprs[self.map_idx(p.index).unwrap()],
+                    GParamVariant::Alias(alias) => vir::with_vcx(|vcx| {
                         let tcx = vcx.tcx();
                         let trait_did = tcx.associated_item(alias.def_id).container_id(tcx);
                         let trait_data = deps.require_ref::<TraitEnc>(trait_did).unwrap();
@@ -275,7 +276,7 @@ impl<'vir> GenericParams<'vir> {
                         let args = deps.require_dep::<GArgsTyEnc>(args).unwrap();
                         (trait_data.assoc_types[&alias.def_id])(args.get_ty(), args.get_const())
                     }),
-                }
+                };
             }
         }
         let ty_constructor = deps

--- a/prusti-encoder/src/encoders/ty/generics/params.rs
+++ b/prusti-encoder/src/encoders/ty/generics/params.rs
@@ -259,22 +259,24 @@ impl<'vir> GenericParams<'vir> {
         ty: RustTyDecomposition<'vir>,
     ) -> vir::ExprTyVal<'vir> {
         if let TySpecifics::Param(()) = &ty.ty.specifics {
-            let param = ty.args.expect_param();
-            match param {
-                GParamVariant::Param(p) => return self.ty_exprs[self.map_idx(p.index).unwrap()],
-                GParamVariant::Alias(alias) => return vir::with_vcx(|vcx| {
-                    let tcx = vcx.tcx();
-                    let trait_did = tcx.associated_item(alias.def_id).container_id(tcx);
-                    let trait_data = deps.require_ref::<TraitEnc>(trait_did).unwrap();
-                    let args = GArgs::new(ty.args.context, alias.args);
-                    let args = deps.require_dep::<GArgsTyEnc>(args).unwrap();
-                    (trait_data.assoc_types[&alias.def_id])(args.get_ty(), args.get_const())
-                }),
-                GParamVariant::Dyn => {
-                    // Only dyn Trait (TySpecifics::Param with no type params) falls through.
-                    assert!(ty.ty.params.rust_params().is_empty());
+            if ty.args.args().is_empty() {
+                // dyn Trait: the only TySpecifics::Param type with no synthetic type params.
+                // Real generic T and Alias always have exactly one.
+                assert!(ty.ty.params.rust_params().is_empty());
+                // fall through to TyConstructorEnc
+            } else {
+                match ty.args.expect_param()  {
+                    GParamVariant::Param(p) => return self.ty_exprs[self.map_idx(p.index).unwrap()],
+                    GParamVariant::Alias(alias) => return vir::with_vcx(|vcx| {
+                        let tcx = vcx.tcx();
+                        let trait_did = tcx.associated_item(alias.def_id).container_id(tcx);
+                        let trait_data = deps.require_ref::<TraitEnc>(trait_did).unwrap();
+                        let args = GArgs::new(ty.args.context, alias.args);
+                        let args = deps.require_dep::<GArgsTyEnc>(args).unwrap();
+                        (trait_data.assoc_types[&alias.def_id])(args.get_ty(), args.get_const())
+                    }),
                 }
-            };
+            }
         }
         let ty_constructor = deps
             .require_ref::<TyConstructorEnc>(ty.ty)

--- a/prusti-encoder/src/encoders/ty/generics/params.rs
+++ b/prusti-encoder/src/encoders/ty/generics/params.rs
@@ -260,9 +260,9 @@ impl<'vir> GenericParams<'vir> {
     ) -> vir::ExprTyVal<'vir> {
         if let TySpecifics::Param(()) = &ty.ty.specifics {
             let param = ty.args.expect_param();
-            return match param {
-                GParamVariant::Param(p) => self.ty_exprs[self.map_idx(p.index).unwrap()],
-                GParamVariant::Alias(alias) => vir::with_vcx(|vcx| {
+            match param {
+                GParamVariant::Param(p) => return self.ty_exprs[self.map_idx(p.index).unwrap()],
+                GParamVariant::Alias(alias) => return vir::with_vcx(|vcx| {
                     let tcx = vcx.tcx();
                     let trait_did = tcx.associated_item(alias.def_id).container_id(tcx);
                     let trait_data = deps.require_ref::<TraitEnc>(trait_did).unwrap();
@@ -270,6 +270,7 @@ impl<'vir> GenericParams<'vir> {
                     let args = deps.require_dep::<GArgsTyEnc>(args).unwrap();
                     (trait_data.assoc_types[&alias.def_id])(args.get_ty(), args.get_const())
                 }),
+                GParamVariant::Dyn => {}
             };
         }
         let ty_constructor = deps

--- a/prusti-encoder/src/encoders/ty/generics/params.rs
+++ b/prusti-encoder/src/encoders/ty/generics/params.rs
@@ -270,7 +270,10 @@ impl<'vir> GenericParams<'vir> {
                     let args = deps.require_dep::<GArgsTyEnc>(args).unwrap();
                     (trait_data.assoc_types[&alias.def_id])(args.get_ty(), args.get_const())
                 }),
-                GParamVariant::Dyn => {}
+                GParamVariant::Dyn => {
+                    // Only dyn Trait (TySpecifics::Param with no type params) falls through.
+                    assert!(ty.ty.params.rust_params().is_empty());
+                }
             };
         }
         let ty_constructor = deps

--- a/prusti-encoder/src/encoders/ty/lifted/ty_constructor.rs
+++ b/prusti-encoder/src/encoders/ty/lifted/ty_constructor.rs
@@ -72,6 +72,10 @@ impl TaskEncoder for TyConstructorEnc {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
+        // Valid for dyn Trait (TySpecifics::Param with no type params of its own).
+        // Real generic params (T, Alias) always have one synthetic param and are
+        // short-circuited in ty_expr before reaching TyConstructorEnc.
+        assert!(!task_key.specifics.is_param() || task_key.params.rust_params().is_empty());
         vir::with_vcx(|vcx| {
             let base_name = task_key.name();
             let params = deps.require_dep::<GenericParamsEnc>(task_key.params)?;

--- a/prusti-encoder/src/encoders/ty/lifted/ty_constructor.rs
+++ b/prusti-encoder/src/encoders/ty/lifted/ty_constructor.rs
@@ -72,10 +72,10 @@ impl TaskEncoder for TyConstructorEnc {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        assert!(
-            !task_key.specifics.is_param()
-                || matches!(&task_key.specifics, TySpecifics::Param(RustParamData::Dyn))
-        );
+        assert!(!matches!(
+            &task_key.specifics,
+            TySpecifics::Param(RustParamData::Generic)
+        ));
         vir::with_vcx(|vcx| {
             let base_name = task_key.name();
             let params = deps.require_dep::<GenericParamsEnc>(task_key.params)?;

--- a/prusti-encoder/src/encoders/ty/lifted/ty_constructor.rs
+++ b/prusti-encoder/src/encoders/ty/lifted/ty_constructor.rs
@@ -72,7 +72,6 @@ impl TaskEncoder for TyConstructorEnc {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        assert!(!task_key.specifics.is_param());
         vir::with_vcx(|vcx| {
             let base_name = task_key.name();
             let params = deps.require_dep::<GenericParamsEnc>(task_key.params)?;

--- a/prusti-encoder/src/encoders/ty/lifted/ty_constructor.rs
+++ b/prusti-encoder/src/encoders/ty/lifted/ty_constructor.rs
@@ -1,7 +1,7 @@
 use task_encoder::{EncodeFullResult, OutputRefAny, TaskEncoder};
 use vir::{CallableIdn, CastType, FunctionIdn, HasType};
 
-use crate::encoders::ty::{RustTy, generics::GenericParamsEnc};
+use crate::encoders::ty::{RustParamData, RustTy, TySpecifics, generics::GenericParamsEnc};
 
 use super::r#typeof::{TypeOfEnc, TypeOfEncOutputRef};
 
@@ -72,10 +72,10 @@ impl TaskEncoder for TyConstructorEnc {
         task_key: &Self::TaskKey<'vir>,
         deps: &mut task_encoder::TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
-        // Valid for dyn Trait (TySpecifics::Param with no type params of its own).
-        // Real generic params (T, Alias) always have one synthetic param and are
-        // short-circuited in ty_expr before reaching TyConstructorEnc.
-        assert!(!task_key.specifics.is_param() || task_key.params.rust_params().is_empty());
+        assert!(
+            !task_key.specifics.is_param()
+                || matches!(&task_key.specifics, TySpecifics::Param(RustParamData::Dyn))
+        );
         vir::with_vcx(|vcx| {
             let base_name = task_key.name();
             let params = deps.require_dep::<GenericParamsEnc>(task_key.params)?;

--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -360,6 +360,7 @@ impl<'tcx> TyData<'tcx, RustTyDatas> {
             ty::TyKind::FnPtr(..) => String::from("FnPtr"),
             ty::TyKind::Array(..) => String::from("Array"),
             ty::TyKind::Slice(..) => String::from("Slice"),
+            ty::TyKind::Dynamic(_, _, _) => String::from("Dyn"),
             other => unimplemented!("ty_name for {:?}", other),
         }
     }
@@ -439,7 +440,7 @@ impl<'tcx> TyData<'tcx, RustTyDatas> {
                     args,
                 )
             }),
-            ty::TyKind::Never | ty::TyKind::Str | ty::TyKind::FnPtr(..) => {
+            ty::TyKind::Never | ty::TyKind::Str | ty::TyKind::FnPtr(..) | ty::TyKind::Dynamic(..) => {
                 (GParams::empty(), ty::GenericArgs::empty())
             }
             _ => todo!("instantiate_identity_for_type for {:?}", ty),
@@ -529,6 +530,8 @@ impl<'tcx> TySpecifics<'tcx, RustTyDatas> {
             }
             // TODO: add str support
             ty::TyKind::Str => TySpecifics::mk_opaque(()),
+            // TODO: add dyn support
+            ty::TyKind::Dynamic(_, _, _) => TySpecifics::mk_opaque(()),
             _ => TySpecifics::mk_opaque(()),
         }
     }

--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -532,7 +532,7 @@ impl<'tcx> TySpecifics<'tcx, RustTyDatas> {
             // TODO: add str support
             ty::TyKind::Str => TySpecifics::mk_opaque(()),
             // TODO: add dyn support
-            ty::TyKind::Dynamic(_, _, _) => TySpecifics::mk_opaque(()),
+            ty::TyKind::Dynamic(_, _, _) => TySpecifics::mk_param(()),
             _ => TySpecifics::mk_opaque(()),
         }
     }

--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -440,9 +440,10 @@ impl<'tcx> TyData<'tcx, RustTyDatas> {
                     args,
                 )
             }),
-            ty::TyKind::Never | ty::TyKind::Str | ty::TyKind::FnPtr(..) | ty::TyKind::Dynamic(..) => {
-                (GParams::empty(), ty::GenericArgs::empty())
-            }
+            ty::TyKind::Never
+            | ty::TyKind::Str
+            | ty::TyKind::FnPtr(..)
+            | ty::TyKind::Dynamic(..) => (GParams::empty(), ty::GenericArgs::empty()),
             _ => todo!("instantiate_identity_for_type for {:?}", ty),
         };
         params.check(args);

--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -278,7 +278,9 @@ pub struct RustEnumData<'tcx> {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum RustParamData {
+    /// Represents actual type parameters.
     Generic,
+    /// Represents a trait object (`dyn Trait`).
     Dyn,
 }
 

--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -360,7 +360,7 @@ impl<'tcx> TyData<'tcx, RustTyDatas> {
             ty::TyKind::FnPtr(..) => String::from("FnPtr"),
             ty::TyKind::Array(..) => String::from("Array"),
             ty::TyKind::Slice(..) => String::from("Slice"),
-            ty::TyKind::Dynamic(_, _, _) => String::from("Dyn"),
+            ty::TyKind::Dynamic(..) => String::from("Dyn"),
             other => unimplemented!("ty_name for {:?}", other),
         }
     }
@@ -532,7 +532,7 @@ impl<'tcx> TySpecifics<'tcx, RustTyDatas> {
             // TODO: add str support
             ty::TyKind::Str => TySpecifics::mk_opaque(()),
             // TODO: add dyn support
-            ty::TyKind::Dynamic(_, _, _) => TySpecifics::mk_param(()),
+            ty::TyKind::Dynamic(..) => TySpecifics::mk_param(()),
             _ => TySpecifics::mk_opaque(()),
         }
     }

--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -531,7 +531,8 @@ impl<'tcx> TySpecifics<'tcx, RustTyDatas> {
             }
             // TODO: add str support
             ty::TyKind::Str => TySpecifics::mk_opaque(()),
-            // TODO: add dyn support
+            // TODO: give dyn Trait a type witness parameter (the concrete type behind the
+            // pointer), enabling virtual dispatch and distinguishing dyn TraitA from dyn TraitB.
             ty::TyKind::Dynamic(..) => TySpecifics::mk_param(()),
             _ => TySpecifics::mk_opaque(()),
         }

--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -211,7 +211,7 @@ pub struct RustTyDatas;
 impl<'tcx> TyDatas<'tcx> for RustTyDatas {
     type TyData = RustTyData<'tcx>;
     type PrimitiveData = ty::Ty<'tcx>;
-    type ParamData = ();
+    type ParamData = RustParamData;
     type ArrayData = LazyRustTy<'tcx>;
     type ImmRefData = LazyRustTy<'tcx>;
     type MutRefData = LazyRustTy<'tcx>;
@@ -274,6 +274,12 @@ pub struct RustVariantData {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct RustEnumData<'tcx> {
     pub discr: ty::Ty<'tcx>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum RustParamData {
+    Generic,
+    Dyn,
 }
 
 // Internal methods
@@ -507,7 +513,9 @@ impl<'tcx> TySpecifics<'tcx, RustTyDatas> {
             },
             // TODO: add raw pointer support
             ty::TyKind::RawPtr(..) => TySpecifics::mk_opaque(()),
-            ty::TyKind::Alias(..) | ty::TyKind::Param(_) => TySpecifics::mk_param(()),
+            ty::TyKind::Alias(..) | ty::TyKind::Param(_) => {
+                TySpecifics::mk_param(RustParamData::Generic)
+            }
             ty::TyKind::Closure(_, args) => {
                 let captured = args.as_closure().upvar_tys();
                 let fields = vir::with_vcx(|vcx| {
@@ -533,7 +541,7 @@ impl<'tcx> TySpecifics<'tcx, RustTyDatas> {
             ty::TyKind::Str => TySpecifics::mk_opaque(()),
             // TODO: give dyn Trait a type witness parameter (the concrete type behind the
             // pointer), enabling virtual dispatch and distinguishing dyn TraitA from dyn TraitB.
-            ty::TyKind::Dynamic(..) => TySpecifics::mk_param(()),
+            ty::TyKind::Dynamic(..) => TySpecifics::mk_param(RustParamData::Dyn),
             _ => TySpecifics::mk_opaque(()),
         }
     }

--- a/prusti-tests/tests/verify/pass/traits/dyn_fn_arg.rs
+++ b/prusti-tests/tests/verify/pass/traits/dyn_fn_arg.rs
@@ -1,0 +1,7 @@
+trait MyTrait {}
+
+struct S { x: i32 }
+
+impl MyTrait for S {}
+
+fn consume(_v: &dyn MyTrait) {}

--- a/prusti-tests/tests/verify/pass/traits/dyn_fn_arg.rs
+++ b/prusti-tests/tests/verify/pass/traits/dyn_fn_arg.rs
@@ -7,3 +7,12 @@ impl MyTrait for S {}
 fn consume(_v: &dyn MyTrait) {}
 
 fn consume2(_v: &mut dyn MyTrait) {}
+
+trait Foo<X> {}
+
+impl<X> Foo<X> for S {}
+
+fn consume3(_v: &dyn Foo<i32>) {}
+
+fn consume4(_v: &dyn Foo<u32>) {}
+

--- a/prusti-tests/tests/verify/pass/traits/dyn_fn_arg.rs
+++ b/prusti-tests/tests/verify/pass/traits/dyn_fn_arg.rs
@@ -5,3 +5,5 @@ struct S { x: i32 }
 impl MyTrait for S {}
 
 fn consume(_v: &dyn MyTrait) {}
+
+fn consume2(_v: &mut dyn MyTrait) {}


### PR DESCRIPTION
At the moment, Prusti crashes when trying to encode trait objects it encounters, e.g. `&dyn MyTrait`.
Many standard library features use trait objects, e.g. `#[derive(Debug)]`.
Implementing these is a lot of work, but for the time being, I propose encoding these as opaque to keep the verifier from crashing.

This unblocks encoding of the type itself. For instance, the following test case encodes correctly:

```rust
trait MyTrait {}

struct S { x: i32 }

impl MyTrait for S {}

fn consume(_v: &dyn MyTrait) {}
```

However, passing trait objects around does not work yet, due to a different issue: Trait objects are unsized before being passed into functions, and Prusti assumes that only arrays are unsized to slices at the moment. However, this would be a different change and is left for a separate PR.