### PR TITLE
Disambiguate adt names

### DIFF
--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -7,7 +7,7 @@ use prusti_rustc_interface::{
     abi, hir,
     index::{self, IndexVec},
     middle::ty,
-    span::symbol,
+    span::{def_id::DefId, symbol},
 };
 
 use super::{
@@ -327,12 +327,39 @@ impl<'tcx> TyData<'tcx, RustTyDatas> {
         }
     }
 
+    fn full_item_name(tcx: ty::TyCtxt, did: DefId) -> String {
+        let def_path = tcx.def_path(did);
+        let path_segments = std::iter::chain(
+            std::iter::once(format!("{}", def_path.krate)),
+            def_path.data.iter().map(|elem|
+                // Adapted from https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_hir/definitions.rs.html#186-203
+                match elem.data.name() {
+                hir::definitions::DefPathDataName::Named(name) => {
+                    if elem.disambiguator != 0 {
+                        format!("{}${}", name, elem.disambiguator)
+                    } else {
+                        name.to_ident_string()
+                    }
+                }
+                hir::definitions::DefPathDataName::Anon { namespace } => {
+                    if let hir::definitions::DefPathData::AnonAssocTy(method) = elem.data {
+                        format!("{}${}${}", method, namespace, elem.disambiguator)
+                    } else {
+                        format!("{}${}", namespace, elem.disambiguator)
+                    }
+                }
+            }),
+        )
+        .collect::<Vec<_>>();
+        path_segments.join("$$")
+    }
+
     fn ty_name(ty: ty::Ty<'tcx>) -> String {
         match ty.kind() {
             _ if ty.is_primitive() => Self::prim_ty_name(ty),
             ty::TyKind::Str => String::from("Str"),
             ty::TyKind::Adt(adt, _) => {
-                vir::with_vcx(|vcx| vcx.tcx().item_name(adt.did()).to_ident_string())
+                vir::with_vcx(|vcx| Self::full_item_name(vcx.tcx(), adt.did()))
             }
             ty::TyKind::Tuple(params) => format!("{}_Tuple", params.len()),
             ty::TyKind::Never => String::from("Never"),

--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -327,8 +327,8 @@ impl<'tcx> TyData<'tcx, RustTyDatas> {
         }
     }
 
-    fn full_item_name(tcx: ty::TyCtxt, did: DefId) -> String {
-        let def_path = tcx.def_path(did);
+    fn full_item_name(did: DefId) -> String {
+        let def_path = vir::with_vcx(|vcx| vcx.tcx().def_path(did));
 
         let mut result = String::with_capacity(64);
         let _ = write!(result, "{}", def_path.krate);
@@ -360,9 +360,7 @@ impl<'tcx> TyData<'tcx, RustTyDatas> {
         match ty.kind() {
             _ if ty.is_primitive() => Self::prim_ty_name(ty),
             ty::TyKind::Str => String::from("Str"),
-            ty::TyKind::Adt(adt, _) => {
-                vir::with_vcx(|vcx| Self::full_item_name(vcx.tcx(), adt.did()))
-            }
+            ty::TyKind::Adt(adt, _) => Self::full_item_name(adt.did()),
             ty::TyKind::Tuple(params) => format!("{}_Tuple", params.len()),
             ty::TyKind::Never => String::from("Never"),
             ty::TyKind::Ref(_, _, ty::Mutability::Not) => String::from("Ref_immutable"),
@@ -370,22 +368,7 @@ impl<'tcx> TyData<'tcx, RustTyDatas> {
             ty::TyKind::RawPtr(_, ty::Mutability::Not) => String::from("RawPtr_immutable"),
             ty::TyKind::RawPtr(_, ty::Mutability::Mut) => String::from("RawPtr_mutable"),
             ty::TyKind::Param(_) | ty::TyKind::Alias(..) => String::from("Param"),
-            ty::TyKind::Closure(def_id, _) => vir::with_vcx(|vcx| {
-                let def_key = vcx.tcx().def_key(def_id);
-                match def_key.disambiguated_data.data {
-                    // Asking for the item_name of a closure triggers an ICE in
-                    // the compiler, so we give it a name based on its parent.
-                    hir::definitions::DefPathData::Closure => format!(
-                        "{}_Closure_{}",
-                        vcx.tcx().item_name(hir::def_id::DefId {
-                            krate: def_id.krate,
-                            index: def_key.parent.unwrap()
-                        }),
-                        def_key.disambiguated_data.disambiguator,
-                    ),
-                    _ => vcx.tcx().item_name(*def_id).to_ident_string(),
-                }
-            }),
+            ty::TyKind::Closure(def_id, _) => Self::full_item_name(*def_id),
             ty::TyKind::FnPtr(..) => String::from("FnPtr"),
             ty::TyKind::Array(..) => String::from("Array"),
             ty::TyKind::Slice(..) => String::from("Slice"),

--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{fmt::Write, ops::Deref};
 
 use itertools::Itertools;
 use pcg::borrow_pcg::region_projection::{HasRegions, PcgRegion, RegionIdx};
@@ -329,29 +329,31 @@ impl<'tcx> TyData<'tcx, RustTyDatas> {
 
     fn full_item_name(tcx: ty::TyCtxt, did: DefId) -> String {
         let def_path = tcx.def_path(did);
-        let path_segments = std::iter::chain(
-            std::iter::once(format!("{}", def_path.krate)),
-            def_path.data.iter().map(|elem|
-                // Adapted from https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_hir/definitions.rs.html#186-203
-                match elem.data.name() {
+
+        let mut result = String::with_capacity(64);
+        let _ = write!(result, "{}", def_path.krate);
+
+        for elem in &def_path.data {
+            result.push_str("$$");
+            // Adapted from https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_hir/definitions.rs.html#186-203
+            match elem.data.name() {
                 hir::definitions::DefPathDataName::Named(name) => {
                     if elem.disambiguator != 0 {
-                        format!("{}${}", name, elem.disambiguator)
+                        let _ = write!(result, "{}${}", name, elem.disambiguator);
                     } else {
-                        name.to_ident_string()
+                        result.push_str(name.as_str());
                     }
                 }
                 hir::definitions::DefPathDataName::Anon { namespace } => {
                     if let hir::definitions::DefPathData::AnonAssocTy(method) = elem.data {
-                        format!("{}${}${}", method, namespace, elem.disambiguator)
+                        let _ = write!(result, "{}${}${}", method, namespace, elem.disambiguator);
                     } else {
-                        format!("{}${}", namespace, elem.disambiguator)
+                        let _ = write!(result, "{}${}", namespace, elem.disambiguator);
                     }
                 }
-            }),
-        )
-        .collect::<Vec<_>>();
-        path_segments.join("$$")
+            }
+        }
+        result
     }
 
     fn ty_name(ty: ty::Ty<'tcx>) -> String {


### PR DESCRIPTION
Addresses #155.

### Problem
Using base names for types caused `ConsistencyError` collisions in the VIPER backend, notably for:
- **Cross-module (or crate) collisions:** e.g., `std::ascii::EscapeDefault` vs. `std::char::EscapeDefault`.
- **Local shadowing:** Multiple `struct Bar` definitions in different scopes of the same function.

### Solution
1. Joining the **crate name** and all **path segments** with `$$`.
2. Appending the compiler's internal **`disambiguator`** (using `$`) when it is non-zero.
3. Explicitly handling **anonymous namespaces** and **associated types** to ensure local uniqueness.

**Example Output:**
- `0$$core$$ascii$$EscapeDefault`
- `0$$main$$Bar` vs. `0$$main$$Bar$1`