### PR TITLE
Make `ENCODER_NAME` mandatory

### DIFF
--- a/prusti-encoder/src/encoders/addr.rs
+++ b/prusti-encoder/src/encoders/addr.rs
@@ -18,6 +18,7 @@ pub struct RefDataLocal<'vir> {
 
 impl TaskEncoder for RefDataEnc {
     task_encoder::encoder_cache!(RefDataEnc);
+    const ENCODER_NAME: &'static str = "ref data encoder";
     type TaskDescription<'vir> = ();
     type OutputFullLocal<'vir> = RefDataLocal<'vir>;
     type OutputFullDependency<'vir> = RefData<'vir>;

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -170,6 +170,7 @@ impl ConstEnc {
 
 impl TaskEncoder for ConstEnc {
     task_encoder::encoder_cache!(ConstEnc);
+    const ENCODER_NAME: &'static str = "const encoder";
 
     type TaskDescription<'vir> = ConstEncTask<'vir>;
     type OutputFullDependency<'vir> = vir::ExprCSnap<'vir>;

--- a/prusti-encoder/src/encoders/custom/pair.rs
+++ b/prusti-encoder/src/encoders/custom/pair.rs
@@ -13,6 +13,7 @@ pub struct PairUse<'vir> {
 
 impl TaskEncoder for PairUseEnc {
     task_encoder::encoder_cache!(PairUseEnc);
+    const ENCODER_NAME: &'static str = "pair use encoder";
     type TaskDescription<'vir> = Vec<vir::TypeDyn<'vir>>;
     type OutputFullDependency<'vir> = PairUse<'vir>;
 
@@ -63,6 +64,7 @@ struct PairEnc;
 
 impl TaskEncoder for PairEnc {
     task_encoder::encoder_cache!(PairEnc);
+    const ENCODER_NAME: &'static str = "pair encoder";
 
     type TaskDescription<'vir> = usize;
     type OutputFullDependency<'vir> = Pair<'vir>;

--- a/prusti-encoder/src/encoders/local_def.rs
+++ b/prusti-encoder/src/encoders/local_def.rs
@@ -182,6 +182,7 @@ impl<'vir> MirLocalDefEncTask<'vir> {
 
 impl TaskEncoder for MirLocalDefEnc {
     task_encoder::encoder_cache!(MirLocalDefEnc);
+    const ENCODER_NAME: &'static str = "MIR local def encoder";
 
     type TaskDescription<'vir> = MirLocalDefEncTask<'vir>;
 

--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -86,6 +86,7 @@ pub struct MirBuiltinEncOutput<'vir> {
 
 impl TaskEncoder for MirBuiltinEnc {
     task_encoder::encoder_cache!(MirBuiltinEnc);
+    const ENCODER_NAME: &'static str = "MIR builtin encoder";
 
     type TaskDescription<'vir> = MirBuiltinEncTask<'vir>;
 

--- a/prusti-encoder/src/encoders/mir_fn/function.rs
+++ b/prusti-encoder/src/encoders/mir_fn/function.rs
@@ -59,6 +59,7 @@ impl<'vir> FunctionCallEncOutput<'vir> {
 
 impl TaskEncoder for FunctionCallEnc {
     task_encoder::encoder_cache!(FunctionCallEnc);
+    const ENCODER_NAME: &'static str = "function call encoder";
     type TaskDescription<'tcx> = CallTaskDescription<'tcx>;
     type OutputFullDependency<'vir> = FunctionCallEncOutput<'vir>;
 
@@ -133,6 +134,7 @@ pub enum FunctionEncError {}
 
 impl TaskEncoder for FunctionEnc {
     task_encoder::encoder_cache!(FunctionEnc);
+    const ENCODER_NAME: &'static str = "function encoder";
     type TaskDescription<'tcx> = DefId;
 
     type OutputRef<'vir> = FunctionEncOutputRef<'vir>;

--- a/prusti-encoder/src/encoders/mir_fn/method.rs
+++ b/prusti-encoder/src/encoders/mir_fn/method.rs
@@ -56,6 +56,8 @@ impl TaskEncoder for MethodCallEnc {
     type TaskDescription<'tcx> = CallTaskDescription<'tcx>;
     type OutputFullDependency<'vir> = MethodCallEncOutput<'vir>;
 
+    const ENCODER_NAME: &'static str = "method call encoder";
+
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         *task
     }
@@ -124,6 +126,7 @@ pub enum MethodEncError {}
 
 impl TaskEncoder for MethodEnc {
     task_encoder::encoder_cache!(MethodEnc);
+    const ENCODER_NAME: &'static str = "method encoder";
     type TaskDescription<'tcx> = DefId;
 
     type OutputRef<'vir> = MethodEncOutputRef<'vir>;

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -89,6 +89,7 @@ pub struct MirPureEncTask<'vir> {
 
 impl TaskEncoder for MirPureEnc {
     task_encoder::encoder_cache!(MirPureEnc);
+    const ENCODER_NAME: &'static str = "MIR pure encoder";
 
     type TaskDescription<'vir> = MirPureEncTask<'vir>;
 

--- a/prusti-encoder/src/encoders/pure/spec.rs
+++ b/prusti-encoder/src/encoders/pure/spec.rs
@@ -112,6 +112,7 @@ pub enum MirSpecEncMode {
 
 impl TaskEncoder for MirSpecEnc {
     task_encoder::encoder_cache!(MirSpecEnc);
+    const ENCODER_NAME: &'static str = "MIR spec encoder";
 
     type TaskDescription<'tcx> = (
         DefId, // The function annotated with specs

--- a/prusti-encoder/src/encoders/spec.rs
+++ b/prusti-encoder/src/encoders/spec.rs
@@ -77,6 +77,7 @@ pub struct SpecEncTask {
 
 impl TaskEncoder for SpecEnc {
     task_encoder::encoder_cache!(SpecEnc);
+    const ENCODER_NAME: &'static str = "spec encoder";
 
     type TaskDescription<'vir> = SpecEncTask;
 

--- a/prusti-encoder/src/encoders/ty/generics/args_ty.rs
+++ b/prusti-encoder/src/encoders/ty/generics/args_ty.rs
@@ -30,6 +30,7 @@ impl<'vir> GArgsTy<'vir> {
 
 impl TaskEncoder for GArgsTyEnc {
     task_encoder::encoder_cache!(GArgsTyEnc);
+    const ENCODER_NAME: &'static str = "generic args type encoder";
     type TaskDescription<'tcx> = GArgs<'tcx>;
     type OutputFullDependency<'vir> = GArgsTy<'vir>;
 

--- a/prusti-encoder/src/encoders/ty/generics/casters.rs
+++ b/prusti-encoder/src/encoders/ty/generics/casters.rs
@@ -49,6 +49,7 @@ impl<'vir, P: PurityCasters> task_encoder::OutputRefAny for GArgCasters<'vir, P>
 
 impl TaskEncoder for CastersEnc<Pure> {
     task_encoder::encoder_cache!(CastersEnc<Pure>);
+    const ENCODER_NAME: &'static str = "pure casters encoder";
 
     type TaskDescription<'vir> = (RustTy<'vir>, RustTy<'vir>);
     type OutputRef<'vir> = GArgCasters<'vir, Pure>;
@@ -199,6 +200,7 @@ impl TaskEncoder for CastersEnc<Pure> {
 
 impl TaskEncoder for CastersEnc<Impure> {
     task_encoder::encoder_cache!(CastersEnc<Impure>);
+    const ENCODER_NAME: &'static str = "impure casters encoder";
 
     type TaskDescription<'vir> = (RustTy<'vir>, RustTy<'vir>);
     type OutputRef<'vir> = GArgCasters<'vir, Impure>;

--- a/prusti-encoder/src/encoders/ty/generics/params.rs
+++ b/prusti-encoder/src/encoders/ty/generics/params.rs
@@ -283,6 +283,7 @@ impl<'vir> GenericParams<'vir> {
 
 impl TaskEncoder for GenericParamsEnc {
     task_encoder::encoder_cache!(GenericParamsEnc);
+    const ENCODER_NAME: &'static str = "generic params encoder";
     type TaskDescription<'tcx> = GParams<'tcx>;
     type OutputFullDependency<'vir> = GenericParams<'vir>;
 

--- a/prusti-encoder/src/encoders/ty/generics/trait.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait.rs
@@ -19,6 +19,7 @@ impl<'vir> OutputRefAny for TraitEncOutputRef<'vir> {}
 
 impl TaskEncoder for TraitEnc {
     task_encoder::encoder_cache!(TraitEnc);
+    const ENCODER_NAME: &'static str = "trait encoder";
 
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         *task

--- a/prusti-encoder/src/encoders/ty/generics/trait_fn.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait_fn.rs
@@ -34,6 +34,7 @@ impl<'vir> OutputRefAny for TraitFnEncOutputRef<'vir> {}
 
 impl TaskEncoder for TraitFnEnc {
     task_encoder::encoder_cache!(TraitFnEnc);
+    const ENCODER_NAME: &'static str = "trait fn encoder";
 
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         *task

--- a/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
@@ -26,6 +26,7 @@ pub struct TraitImplEnc;
 
 impl TaskEncoder for TraitImplEnc {
     task_encoder::encoder_cache!(TraitImplEnc);
+    const ENCODER_NAME: &'static str = "trait impl encoder";
 
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         *task

--- a/prusti-encoder/src/encoders/ty/generics/use_casters.rs
+++ b/prusti-encoder/src/encoders/ty/generics/use_casters.rs
@@ -92,6 +92,7 @@ fn alloc_stmt<'vir>(stmt: vir::StmtKindData<'vir>) -> vir::Stmt<'vir> {
 
 impl TaskEncoder for GArgsCastEnc<Pure> {
     task_encoder::encoder_cache!(GArgsCastEnc<Pure>);
+    const ENCODER_NAME: &'static str = "pure generic args cast encoder";
     type TaskDescription<'tcx> = Option<RustTyNormalized<'tcx>>;
     type OutputFullDependency<'vir> = GArgCaster<'vir, Pure>;
     type OutputFullLocal<'vir> = ();
@@ -121,6 +122,7 @@ impl TaskEncoder for GArgsCastEnc<Pure> {
 
 impl TaskEncoder for GArgsCastEnc<Impure> {
     task_encoder::encoder_cache!(GArgsCastEnc<Impure>);
+    const ENCODER_NAME: &'static str = "impure generic args cast encoder";
     type TaskDescription<'tcx> = Option<RustTyNormalized<'tcx>>;
     type OutputFullDependency<'vir> = GArgCaster<'vir, Impure>;
     type OutputFullLocal<'vir> = ();

--- a/prusti-encoder/src/encoders/ty/impure.rs
+++ b/prusti-encoder/src/encoders/ty/impure.rs
@@ -112,6 +112,7 @@ pub struct TyImpureEncLocal<'vir> {
 
 impl TaskEncoder for TyImpureEnc {
     task_encoder::encoder_cache!(TyImpureEnc);
+    const ENCODER_NAME: &'static str = "type impure encoder";
     type TaskDescription<'vir> = RustTy<'vir>;
 
     type OutputRef<'vir> = TyImpureRef<'vir>;

--- a/prusti-encoder/src/encoders/ty/indirect.rs
+++ b/prusti-encoder/src/encoders/ty/indirect.rs
@@ -28,6 +28,7 @@ impl<'vir> task_encoder::OutputRefAny for IndirectPredicatesEncOutputRef<'vir> {
 
 impl TaskEncoder for IndirectPredicatesEnc {
     task_encoder::encoder_cache!(IndirectPredicatesEnc);
+    const ENCODER_NAME: &'static str = "indirect predicates encoder";
 
     type TaskDescription<'vir> = LifetimeProjection<'vir, RustTyDecomposition<'vir>>;
 

--- a/prusti-encoder/src/encoders/ty/interpretation/bitvec.rs
+++ b/prusti-encoder/src/encoders/ty/interpretation/bitvec.rs
@@ -21,6 +21,7 @@ pub struct BitVecEnc;
 
 impl TaskEncoder for BitVecEnc {
     task_encoder::encoder_cache!(BitVecEnc);
+    const ENCODER_NAME: &'static str = "bitvec encoder";
 
     type TaskDescription<'vir> = BitVecSize;
 

--- a/prusti-encoder/src/encoders/ty/lifted/ty_constructor.rs
+++ b/prusti-encoder/src/encoders/ty/lifted/ty_constructor.rs
@@ -56,6 +56,7 @@ pub struct TyConstructorEnc;
 
 impl TaskEncoder for TyConstructorEnc {
     task_encoder::encoder_cache!(TyConstructorEnc);
+    const ENCODER_NAME: &'static str = "type constructor encoder";
     type TaskDescription<'tcx> = RustTy<'tcx>;
 
     type OutputRef<'vir> = TyConstructorEncOutputRef<'vir>;

--- a/prusti-encoder/src/encoders/ty/lifted/typeof.rs
+++ b/prusti-encoder/src/encoders/ty/lifted/typeof.rs
@@ -17,6 +17,7 @@ pub struct TypeOfEnc;
 
 impl TaskEncoder for TypeOfEnc {
     task_encoder::encoder_cache!(TypeOfEnc);
+    const ENCODER_NAME: &'static str = "typeof encoder";
     type TaskDescription<'tcx> = RustTy<'tcx>;
 
     type TaskKey<'tcx> = Self::TaskDescription<'tcx>;

--- a/prusti-encoder/src/encoders/ty/pure.rs
+++ b/prusti-encoder/src/encoders/ty/pure.rs
@@ -207,6 +207,7 @@ pub enum TyPureEncError {}
 
 impl TaskEncoder for TyPureEnc {
     task_encoder::encoder_cache!(TyPureEnc);
+    const ENCODER_NAME: &'static str = "type pure encoder";
     type TaskDescription<'vir> = RustTy<'vir>;
 
     type OutputRef<'vir> = TyPureRef<'vir>;

--- a/prusti-encoder/src/encoders/ty/use_impure.rs
+++ b/prusti-encoder/src/encoders/ty/use_impure.rs
@@ -103,6 +103,7 @@ pub type TyUseImpureEnc = TyUseEnc<Impure>;
 
 impl TaskEncoder for TyUseImpureEnc {
     task_encoder::encoder_cache!(TyUseImpureEnc);
+    const ENCODER_NAME: &'static str = "impure type use encoder";
 
     type TaskDescription<'vir> = super::RustTyDecomposition<'vir>;
 

--- a/prusti-encoder/src/encoders/ty/viper_tuple.rs
+++ b/prusti-encoder/src/encoders/ty/viper_tuple.rs
@@ -51,6 +51,7 @@ impl<'vir> ViperTupleEncOutput<'vir> {
 
 impl TaskEncoder for ViperTupleEnc {
     task_encoder::encoder_cache!(ViperTupleEnc);
+    const ENCODER_NAME: &'static str = "Viper tuple encoder";
 
     type TaskDescription<'vir> = (DefId, Vec<ty::Ty<'vir>>);
     type TaskKey<'vir> = RustTyDecomposition<'vir>;

--- a/task-encoder/src/lib.rs
+++ b/task-encoder/src/lib.rs
@@ -126,7 +126,7 @@ pub trait TaskEncoder {
     type EncodingError: Clone + std::fmt::Debug = NeverError;
 
     /// User-presentable name of this encoder.
-    const ENCODER_NAME: &'static str = "<untitled encoder>";
+    const ENCODER_NAME: &'static str;
 
     fn describe_task<'vir>(task: Self::TaskDescription<'vir>) -> String {
         format!("{task:?}")


### PR DESCRIPTION
In the effort to make Prusti more user-friendly in the face of unsupported features, subsequent PRs will show task encoder names in error messages.
It is helpful for debugging to have user-readable names instead of `<untitled encoder>`. This PR makes the `TaskEncoder::ENCODER_NAME` mandatory and defines it for all encoders.