### PR TITLE
Catch and report encoder panics

### DIFF
--- a/prusti-encoder/src/encoders/addr.rs
+++ b/prusti-encoder/src/encoders/addr.rs
@@ -41,7 +41,7 @@ impl TaskEncoder for RefDataEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        let outputs = RefDataEnc::all_outputs_local_no_errors();
+        let outputs = RefDataEnc::all_outputs_local_no_errors(program);
         for output in outputs {
             program.add_function(output.addr_to_ref_fn);
         }

--- a/prusti-encoder/src/encoders/custom/pair.rs
+++ b/prusti-encoder/src/encoders/custom/pair.rs
@@ -115,7 +115,7 @@ impl TaskEncoder for PairEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        let outputs = Self::all_outputs_local_no_errors();
+        let outputs = Self::all_outputs_local_no_errors(program);
         for output in outputs {
             program.add_adt(output);
         }

--- a/prusti-encoder/src/encoders/mir_builtin.rs
+++ b/prusti-encoder/src/encoders/mir_builtin.rs
@@ -130,7 +130,7 @@ impl TaskEncoder for MirBuiltinEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local_no_errors() {
+        for output in Self::all_outputs_local_no_errors(program) {
             for function in output.functions {
                 program.add_function(function);
             }

--- a/prusti-encoder/src/encoders/mir_fn/function.rs
+++ b/prusti-encoder/src/encoders/mir_fn/function.rs
@@ -257,7 +257,7 @@ impl TaskEncoder for FunctionEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local_no_errors() {
+        for output in Self::all_outputs_local_no_errors(program) {
             program.add_function(output.caller);
             program.add_function(output.function);
         }

--- a/prusti-encoder/src/encoders/mir_fn/method.rs
+++ b/prusti-encoder/src/encoders/mir_fn/method.rs
@@ -339,7 +339,7 @@ impl TaskEncoder for MethodEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local_no_errors() {
+        for output in Self::all_outputs_local_no_errors(program) {
             program.add_method(output.method);
         }
     }

--- a/prusti-encoder/src/encoders/ty/generics/casters.rs
+++ b/prusti-encoder/src/encoders/ty/generics/casters.rs
@@ -189,7 +189,7 @@ impl TaskEncoder for CastersEnc<Pure> {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local_no_errors() {
+        for output in Self::all_outputs_local_no_errors(program) {
             for function in output {
                 program.add_function(function);
             }
@@ -307,7 +307,7 @@ impl TaskEncoder for CastersEnc<Impure> {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local_no_errors() {
+        for output in Self::all_outputs_local_no_errors(program) {
             for method in output {
                 program.add_method(method);
             }

--- a/prusti-encoder/src/encoders/ty/generics/trait.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait.rs
@@ -30,7 +30,7 @@ impl TaskEncoder for TraitEnc {
     type OutputFullLocal<'vir> = vir::Domain<'vir>;
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for dom in Self::all_outputs_local_no_errors() {
+        for dom in Self::all_outputs_local_no_errors(program) {
             program.add_domain(dom);
         }
     }

--- a/prusti-encoder/src/encoders/ty/generics/trait_fn.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait_fn.rs
@@ -49,7 +49,7 @@ impl TaskEncoder for TraitFnEnc {
     );
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for (dom, funcs, methods) in Self::all_outputs_local_no_errors() {
+        for (dom, funcs, methods) in Self::all_outputs_local_no_errors(program) {
             program.add_domain(dom);
             for func in funcs {
                 program.add_function(func);

--- a/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
@@ -32,7 +32,7 @@ impl TaskEncoder for TraitImplEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for (dom, methods) in Self::all_outputs_local_no_errors() {
+        for (dom, methods) in Self::all_outputs_local_no_errors(program) {
             program.add_domain(dom);
             for method in methods {
                 program.add_method(method);

--- a/prusti-encoder/src/encoders/ty/impure.rs
+++ b/prusti-encoder/src/encoders/ty/impure.rs
@@ -197,7 +197,7 @@ impl TaskEncoder for TyImpureEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local_no_errors() {
+        for output in Self::all_outputs_local_no_errors(program) {
             for field in output.fields {
                 program.add_field(field);
             }

--- a/prusti-encoder/src/encoders/ty/interpretation/bitvec.rs
+++ b/prusti-encoder/src/encoders/ty/interpretation/bitvec.rs
@@ -35,7 +35,7 @@ impl TaskEncoder for BitVecEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local_no_errors() {
+        for output in Self::all_outputs_local_no_errors(program) {
             program.add_domain(output);
         }
     }

--- a/prusti-encoder/src/encoders/ty/lifted/ty_constructor.rs
+++ b/prusti-encoder/src/encoders/ty/lifted/ty_constructor.rs
@@ -135,7 +135,7 @@ impl TaskEncoder for TyConstructorEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        let mut constructors = Self::all_outputs_local_no_errors();
+        let mut constructors = Self::all_outputs_local_no_errors(program);
         vir::with_vcx(|vcx| {
             let args = vcx.alloc_array(&[vcx.mk_local_decl("non_unit", vir::TYPE_INT)]);
             let unknown = vcx.mk_adt_constructor("Unknown_type", args);

--- a/prusti-encoder/src/encoders/ty/lifted/typeof.rs
+++ b/prusti-encoder/src/encoders/ty/lifted/typeof.rs
@@ -52,7 +52,7 @@ impl TaskEncoder for TypeOfEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        let typeof_fns = Self::all_outputs_local_no_errors();
+        let typeof_fns = Self::all_outputs_local_no_errors(program);
         vir::with_vcx(|vcx| {
             let domain = vcx.mk_domain(
                 vir::ViperIdent::new("TypeOf"),

--- a/prusti-encoder/src/encoders/ty/pure.rs
+++ b/prusti-encoder/src/encoders/ty/pure.rs
@@ -285,7 +285,7 @@ impl TaskEncoder for TyPureEnc {
     }
 
     fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        for output in Self::all_outputs_local_no_errors() {
+        for output in Self::all_outputs_local_no_errors(program) {
             program.add_function(output.unreachable_to_snap);
             for function in output.functions {
                 program.add_function(function);

--- a/prusti-encoder/src/lib.rs
+++ b/prusti-encoder/src/lib.rs
@@ -118,6 +118,11 @@ pub fn test_entrypoint<'tcx>(
         std::fs::write("local-testing/simple.vpr", program.code()).unwrap();
     }
 
+    for error_msg in program.encoder_errors().drain(..) {
+        PrustiError::internal(error_msg, prusti_rustc_interface::span::DUMMY_SP.into())
+            .emit(env_diagnostic);
+    }
+
     let program = program.mk_program();
 
     request::RequestWithContext {

--- a/task-encoder/src/dependencies.rs
+++ b/task-encoder/src/dependencies.rs
@@ -58,6 +58,7 @@ impl<'vir, E: TaskEncoder + 'vir + ?Sized> TaskEncoderDependencies<'vir, E> {
                             "? DependencyError".to_string()
                         }
                         TaskEncoderError::CyclicError => "? CyclicError".to_string(),
+                        TaskEncoderError::PanicError(_) => "? PanicError".to_string(),
                     },
                     Vec::new(),
                 ),

--- a/task-encoder/src/lib.rs
+++ b/task-encoder/src/lib.rs
@@ -3,6 +3,7 @@
 
 use hashlink::LinkedHashMap;
 use prusti_rustc_interface::span::Span;
+use core::panic;
 use std::cell::RefCell;
 
 mod cache;
@@ -23,6 +24,7 @@ pub struct Program<'vir> {
     methods: Vec<vir::Method<'vir>>,
 
     code: String,
+    encoder_errors: Vec<String>,
 }
 
 impl<'vir> Program<'vir> {
@@ -77,6 +79,10 @@ impl<'vir> Program<'vir> {
                 vcx.alloc_slice(&self.methods),
             )
         })
+    }
+
+    pub fn encoder_errors(&mut self) -> &mut Vec<String> {
+        &mut self.encoder_errors
     }
 }
 
@@ -265,8 +271,49 @@ pub trait TaskEncoder {
             return in_cache;
         }
 
-        let mut deps = TaskEncoderDependencies::new();
-        let encode_result = Self::do_encode_full(&task_key, &mut deps);
+        let value = task_key.clone();
+        let catch_result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+                let mut deps = TaskEncoderDependencies::new();
+                let encode_result = Self::do_encode_full(&value, &mut deps);
+                (encode_result, deps)
+            }));
+
+        let (encode_result, deps) = match catch_result {
+            Ok(result) => result,
+            // there was a panic within the encoder. We want to report it and return an error to the caller. 
+            Err(panic_payload) => {
+                let msg = if let Some(s) = panic_payload.downcast_ref::<&str>() {
+                    s.to_string()
+                } else if let Some(s) = panic_payload.downcast_ref::<String>() {
+                    s.clone()
+                } else {
+                    "<unknown panic>".to_string()
+                };
+                let error = TaskEncoderError::PanicError(msg);
+                Self::with_cache(|cache| {
+                    let mut cache = cache.borrow_mut();
+                    match cache.get(&task_key) {
+                        Some(TaskEncoderCacheState::Started { output_ref }) => {
+                            let output_ref = output_ref.clone();
+                            cache.insert(task_key.clone(), TaskEncoderCacheState::ErrorEncode {
+                                output_ref,
+                                deps: TaskEncoderDependencies::new(),
+                                error: error.clone(),
+                                output_dep: None,
+                            });
+                        }
+                        _ => {
+                            cache.insert(task_key.clone(), TaskEncoderCacheState::ErrorEnqueue {
+                                error: error.clone(),
+                            });
+                        }
+                    }
+                });
+                return Err(error);
+            }
+        };
+
 
         let output_ref = Self::with_cache(|cache| match cache.borrow().get(&task_key) {
             Some(
@@ -484,29 +531,25 @@ pub trait TaskEncoder {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self>;
 
-    #[track_caller]
-    fn all_outputs_local_no_errors<'vir>() -> Vec<Self::OutputFullLocal<'vir>>
+    fn all_outputs_local_no_errors<'vir>(program: &mut Program<'vir>) -> Vec<Self::OutputFullLocal<'vir>>
     where
         Self: 'vir,
     {
         let (outputs, errored) = Self::all_outputs_local();
-        assert!(
-            errored.is_empty(),
-            "Encoder {} has errored outputs: {:?}",
-            Self::ENCODER_NAME,
-            errored
-        );
+        for (key, error) in errored {
+            program.encoder_errors.push(format!(
+                "encoder '{}' failed to encode {:?}:\n {:?}",
+                Self::ENCODER_NAME,
+                key,
+                error
+            ));
+        }
         outputs
     }
 
-    #[allow(clippy::type_complexity)]
     fn all_outputs_local<'vir>() -> (
         Vec<Self::OutputFullLocal<'vir>>,
-        Vec<(
-            Self::TaskKey<'vir>,
-            Self::OutputRef<'vir>,
-            TaskEncoderError<Self>,
-        )>,
+        Vec<(Self::TaskKey<'vir>, TaskEncoderError<Self>)>,
     )
     where
         Self: 'vir,
@@ -519,10 +562,9 @@ pub trait TaskEncoder {
                     TaskEncoderCacheState::Encoded { output_local, .. } => {
                         outputs.push(output_local.clone());
                     }
-                    TaskEncoderCacheState::ErrorEncode {
-                        output_ref, error, ..
-                    } => {
-                        errored.push((key.clone(), output_ref.clone(), error.clone()));
+                    TaskEncoderCacheState::ErrorEncode { error, .. }
+                    | TaskEncoderCacheState::ErrorEnqueue { error } => {
+                        errored.push((key.clone(), error.clone()));
                     }
                     _ => panic!("task encoder not completed: {key:?}"),
                 }

--- a/task-encoder/src/lib.rs
+++ b/task-encoder/src/lib.rs
@@ -1,9 +1,9 @@
 #![feature(rustc_private)]
 #![feature(associated_type_defaults)]
 
+use core::panic;
 use hashlink::LinkedHashMap;
 use prusti_rustc_interface::span::Span;
-use core::panic;
 use std::cell::RefCell;
 
 mod cache;
@@ -272,16 +272,15 @@ pub trait TaskEncoder {
         }
 
         let value = task_key.clone();
-        let catch_result =
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-                let mut deps = TaskEncoderDependencies::new();
-                let encode_result = Self::do_encode_full(&value, &mut deps);
-                (encode_result, deps)
-            }));
+        let catch_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let mut deps = TaskEncoderDependencies::new();
+            let encode_result = Self::do_encode_full(&value, &mut deps);
+            (encode_result, deps)
+        }));
 
         let (encode_result, deps) = match catch_result {
             Ok(result) => result,
-            // there was a panic within the encoder. We want to report it and return an error to the caller. 
+            // there was a panic within the encoder. We want to report it and return an error to the caller.
             Err(panic_payload) => {
                 let msg = if let Some(s) = panic_payload.downcast_ref::<&str>() {
                     s.to_string()
@@ -296,24 +295,29 @@ pub trait TaskEncoder {
                     match cache.get(&task_key) {
                         Some(TaskEncoderCacheState::Started { output_ref }) => {
                             let output_ref = output_ref.clone();
-                            cache.insert(task_key.clone(), TaskEncoderCacheState::ErrorEncode {
-                                output_ref,
-                                deps: TaskEncoderDependencies::new(),
-                                error: error.clone(),
-                                output_dep: None,
-                            });
+                            cache.insert(
+                                task_key.clone(),
+                                TaskEncoderCacheState::ErrorEncode {
+                                    output_ref,
+                                    deps: TaskEncoderDependencies::new(),
+                                    error: error.clone(),
+                                    output_dep: None,
+                                },
+                            );
                         }
                         _ => {
-                            cache.insert(task_key.clone(), TaskEncoderCacheState::ErrorEnqueue {
-                                error: error.clone(),
-                            });
+                            cache.insert(
+                                task_key.clone(),
+                                TaskEncoderCacheState::ErrorEnqueue {
+                                    error: error.clone(),
+                                },
+                            );
                         }
                     }
                 });
                 return Err(error);
             }
         };
-
 
         let output_ref = Self::with_cache(|cache| match cache.borrow().get(&task_key) {
             Some(
@@ -531,7 +535,9 @@ pub trait TaskEncoder {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self>;
 
-    fn all_outputs_local_no_errors<'vir>(program: &mut Program<'vir>) -> Vec<Self::OutputFullLocal<'vir>>
+    fn all_outputs_local_no_errors<'vir>(
+        program: &mut Program<'vir>,
+    ) -> Vec<Self::OutputFullLocal<'vir>>
     where
         Self: 'vir,
     {

--- a/task-encoder/src/lib.rs
+++ b/task-encoder/src/lib.rs
@@ -278,46 +278,44 @@ pub trait TaskEncoder {
             (encode_result, deps)
         }));
 
-        let (encode_result, deps) = match catch_result {
-            Ok(result) => result,
-            // there was a panic within the encoder. We want to report it and return an error to the caller.
-            Err(panic_payload) => {
-                let msg = if let Some(s) = panic_payload.downcast_ref::<&str>() {
-                    s.to_string()
-                } else if let Some(s) = panic_payload.downcast_ref::<String>() {
-                    s.clone()
-                } else {
-                    "<unknown panic>".to_string()
-                };
-                let error = TaskEncoderError::PanicError(msg);
-                Self::with_cache(|cache| {
-                    let mut cache = cache.borrow_mut();
-                    match cache.get(&task_key) {
-                        Some(TaskEncoderCacheState::Started { output_ref }) => {
-                            let output_ref = output_ref.clone();
-                            cache.insert(
-                                task_key.clone(),
-                                TaskEncoderCacheState::ErrorEncode {
-                                    output_ref,
-                                    deps: TaskEncoderDependencies::new(),
-                                    error: error.clone(),
-                                    output_dep: None,
-                                },
-                            );
-                        }
-                        _ => {
-                            cache.insert(
-                                task_key.clone(),
-                                TaskEncoderCacheState::ErrorEnqueue {
-                                    error: error.clone(),
-                                },
-                            );
-                        }
+        let (encode_result, deps) = catch_result.map_err(|panic_payload| {
+            // There was a panic within the encoder. We want to report it
+            // and return an error to the caller.
+            let msg = if let Some(s) = panic_payload.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "<unknown panic>".to_string()
+            };
+            let error = TaskEncoderError::PanicError(msg);
+            Self::with_cache(|cache| {
+                let mut cache = cache.borrow_mut();
+                match cache.get(&task_key) {
+                    Some(TaskEncoderCacheState::Started { output_ref }) => {
+                        let output_ref = output_ref.clone();
+                        cache.insert(
+                            task_key.clone(),
+                            TaskEncoderCacheState::ErrorEncode {
+                                output_ref,
+                                deps: TaskEncoderDependencies::new(),
+                                error: error.clone(),
+                                output_dep: None,
+                            },
+                        );
                     }
-                });
-                return Err(error);
-            }
-        };
+                    _ => {
+                        cache.insert(
+                            task_key.clone(),
+                            TaskEncoderCacheState::ErrorEnqueue {
+                                error: error.clone(),
+                            },
+                        );
+                    }
+                }
+            });
+            error
+        })?;
 
         let output_ref = Self::with_cache(|cache| match cache.borrow().get(&task_key) {
             Some(

--- a/task-encoder/src/lib.rs
+++ b/task-encoder/src/lib.rs
@@ -553,6 +553,7 @@ pub trait TaskEncoder {
         outputs
     }
 
+    #[allow(clippy::type_complexity)]
     fn all_outputs_local<'vir>() -> (
         Vec<Self::OutputFullLocal<'vir>>,
         Vec<(Self::TaskKey<'vir>, TaskEncoderError<Self>)>,

--- a/task-encoder/src/result.rs
+++ b/task-encoder/src/result.rs
@@ -62,6 +62,7 @@ pub enum TaskEncoderError<E: TaskEncoder + ?Sized> {
     EncodingError(<E as TaskEncoder>::EncodingError),
     DependencyError(Vec<(&'static str, String, Vec<Span>)>),
     CyclicError,
+    PanicError(String),
 }
 
 impl<E: TaskEncoder + ?Sized> std::fmt::Debug for TaskEncoderError<E>
@@ -75,6 +76,7 @@ where
             Self::EnqueueingError(err) => helper.field("EnqueueingError", err),
             Self::DependencyError(stack) => helper.field("DependencyError", stack),
             Self::CyclicError => helper.field("CyclicError", &""),
+            Self::PanicError(msg) => helper.field("PanicError", msg),
         };
         helper.finish()
     }
@@ -88,6 +90,7 @@ impl<E: TaskEncoder + ?Sized> Clone for TaskEncoderError<E> {
             Self::EnqueueingError(err) => Self::EnqueueingError(err.clone()),
             Self::DependencyError(stack) => Self::DependencyError(stack.clone()),
             Self::CyclicError => Self::CyclicError,
+            Self::PanicError(msg) => Self::PanicError(msg.clone()),
         }
     }
 }


### PR DESCRIPTION
Right now, if there is a single unsupported language feature inside a file, the respective `TaskEncoder` will often panic and keep even unrelated code from being verified. The `TaskEncoder` framework generally supports graceful handling of errors, but this is often not used throughout the codebase, and panics are still frequent.
For now, it's infeasible to review every single `panic!`, `unwrap!` etc. within the codebase. Therefore, this PR introduces the following changes:

- Within `TaskEncoder::encode`, call `TaskEncoder::do_encode_full` within a panic handler. When the encoder panics, the panic will be caught. The wrapper code converts the panic into a `TaskEncoderError::PanicError` and updates the cache to either be `TaskEncoderCacheState::ErrorEnqueue` or `TaskEncoderCacheState::ErrorEncode`.
- All top-level encoders (encoders on which `emit_outputs` is called within `test_entrypoint`) are no longer assumed to be error-free. Instead, one verification error is output for every failing encoder. This is supposed to be a failure of last resort, as errors are generally user-unfriendly as they don't present any context, and for common unsupported features, encoders should try to return better error messages. However, this PR now allows for partial verification of a file.

For instance, consider the following file:

```rust
use prusti_contracts::*;

#[ensures(result == 1)]
fn boxed() -> i32 {
    let b = Box::new([1]);
    let b2: Box<[i32]> = b;
    b2[0]
}

#[ensures(result == 2)]
fn boxed2() -> i32 {
    let b = Box::new(1);
    *b
}
```

The first function uses a feature that is currently unsupported (unsizing of boxed arrays to boxed slices). The second function returns an error on its own. Before, Prusti would not attempt to verify the second function at all, because of the panic when encoding the unsizing operation for the first one. Now, Prusti outputs the following, showing the verification error for the second function properly:

```txt
error: [Prusti internal error] Prusti encountered an unexpected internal error
  |
  = note: We would appreciate a bug report: https://github.com/viperproject/prusti-dev/issues/new
  = note: Details: encoder '<untitled encoder>' failed to encode DefId(0:6 ~ 11b_box_unsizing[ccae]::boxed):
           TaskEncoderError { PanicError: "called `Result::unwrap()` on an `Err` value: DependencyError([(\"<untitled encoder>\", \"Unsize(std::boxed::Box<[i32; 1_usize], std::alloc::Global>, std::boxed::Box<[i32], std::alloc::Global>, DefId(0:6 ~ 11b_box_unsizing[ccae]::boxed))\", []), (\"<untitled encoder>\", \"? PanicError\", [])])" }

error: [Prusti internal error] Prusti encountered an unexpected internal error
  |
  = note: We would appreciate a bug report: https://github.com/viperproject/prusti-dev/issues/new
  = note: Details: encoder '<untitled encoder>' failed to encode Unsize(std::boxed::Box<[i32; 1_usize], std::alloc::Global>, std::boxed::Box<[i32], std::alloc::Global>, DefId(0:6 ~ 11b_box_unsizing[ccae]::boxed)):
           TaskEncoderError { PanicError: "expected array (was TyData { data: TyUsePureRef { snapshot: s_Box, args: GArgsTy { ty_args: [s_Array_type(s_Int_i32_type(), s_UInt_usize_cons(1)), s_Global_type()], const_args: [] }, ty_pure_ref: TyPureRef { domain: DomainIdn { idn: ViperIdent(\"s_Box\"), params: 0, _p: PhantomData<vir::type::Snap> }, unreachable_to_snap: FunctionIdn { idn: ViperIdent(\"s_Box_unreachable\"), args: ([Type, Type], []), result_ty: s_Box, debug_info: DebugInfo(PhantomData<&()>) } } }, specifics: StructLike(StructData { data: TyUsePureStructData { args: GArgsTy { ty_args: [s_Array_type(s_Int_i32_type(), s_UInt_usize_cons(1)), s_Global_type()], const_args: [] }, pure: TyPureStructData { field_snaps_to_snap: FunctionIdn { idn: ViperIdent(\"s_Box_cons\"), args: [s_Param], result_ty: s_Box, debug_info: DebugInfo(PhantomData<&()>) } } }, fields: [TyUsePureField { caster: Casters(Casters { cast: GArgCasters { make_generic: FunctionIdn { idn: ViperIdent(\"make_generic_s_Array\"), args: (s_Array, [Type], [s_UInt_usize]), result_ty: s_Param, debug_info: DebugInfo(PhantomData<&()>) }, make_concrete: FunctionIdn { idn: ViperIdent(\"make_concrete_s_Array\"), args: (s_Param, [Type], [s_UInt_usize]), result_ty: s_Array, debug_info: DebugInfo(PhantomData<&()>) } }, ty_args: GArgsTy { ty_args: [s_Int_i32_type()], const_args: [s_UInt_usize_cons(1)] } }), args: GArgsTy { ty_args: [s_Array_type(s_Int_i32_type(), s_UInt_usize_cons(1)), s_Global_type()], const_args: [] }, pure: TyPureFieldData { read: AdtDestructorData { name: \"s_Box_0\", input: s_Box, ty: s_Param }, ref_to_field_ref: FunctionIdn { idn: ViperIdent(\"s_Box_field_0\"), args: (Ref, [Type, Type], []), result_ty: Ref, debug_info: DebugInfo(PhantomData<&()>) } } }] }) })" }

error: [Prusti: verification error] postcondition might not hold
  --> richard_experiments/11b_box_unsizing.rs:10:11
   |
10 | #[ensures(result == 2)]
   |           ^^^^^^^^^^^

error: aborting due to 3 previous errors; 2 warnings emitted
```

Note that the default rustc panic handler still runs whenever `panic!` is called. I chose to keep it this way, to allow for easier debugging. Note that now, multiple stacktraces may appear in the output, since e.g. a panic in the MIR builtin encoder leads to an `Err` result, leading to a panic within the method encoder etc.

Future PRs will improve common errors, e.g. by making them more explicit.

