### PR TITLE
Change the encoding of the closure macro

### DIFF
--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -455,26 +455,24 @@ mod private {
 
     pub struct PrustiClosure<F, T>(pub F, pub PhantomData<T>);
 
-    pub trait ClosureSpec<Args> {
-        type Output;
+    pub trait ClosureSpec<Args, Output> {
         #[pure]
         fn requires(args: Args) -> bool;
         #[pure]
-        fn ensures(args: Args, result: Self::Output) -> bool;
+        fn ensures(args: Args, result: Output) -> bool;
     }
 
-    impl<Args, F, T> ClosureSpec<Args> for PrustiClosure<F, T>
+    impl<Args, Output, F, T> ClosureSpec<Args, Output> for PrustiClosure<F, T>
     where
         Args: core::marker::Tuple,
-        T: ClosureSpec<Args>,
+        T: ClosureSpec<Args, Output>,
     {
-        type Output = T::Output;
         #[pure]
         fn requires(args: Args) -> bool {
             T::requires(args)
         }
         #[pure]
-        fn ensures(args: Args, result: Self::Output) -> bool {
+        fn ensures(args: Args, result: Output) -> bool {
             T::ensures(args, result)
         }
     }

--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -8,6 +8,7 @@
 #![feature(f128)]
 #![feature(f16)]
 #![feature(panic_internals)]
+#![feature(fn_traits)]
 
 // Even alloc can be disabled for consistency with std, and in preparation for future specs for other, possibly no_std, crates.
 #[cfg(feature = "alloc")]
@@ -449,6 +450,63 @@ mod private {
 
         fn ge(&self, _: &Self) -> bool {
             panic!()
+        }
+    }
+
+    pub struct PrustiClosure<F, T>(pub F, pub PhantomData<T>);
+
+    pub trait ClosureSpec<Args> {
+        type Output;
+        #[pure]
+        fn requires(args: Args) -> bool;
+        #[pure]
+        fn ensures(args: Args, result: Self::Output) -> bool;
+    }
+
+    impl<Args, F, T> ClosureSpec<Args> for PrustiClosure<F, T>
+    where
+        Args: core::marker::Tuple,
+        T: ClosureSpec<Args>,
+    {
+        type Output = T::Output;
+        #[pure]
+        fn requires(args: Args) -> bool {
+            T::requires(args)
+        }
+        #[pure]
+        fn ensures(args: Args, result: Self::Output) -> bool {
+            T::ensures(args, result)
+        }
+    }
+
+    impl<Args, F, T> FnOnce<Args> for PrustiClosure<F, T>
+    where
+        Args: core::marker::Tuple,
+        F: FnOnce<Args>,
+    {
+        type Output = F::Output;
+        extern "rust-call" fn call_once(self, args: Args) -> Self::Output {
+            self.0.call_once(args)
+        }
+    }
+
+    impl<Args, F, T> FnMut<Args> for PrustiClosure<F, T>
+    where
+        Args: core::marker::Tuple,
+        F: FnMut<Args>,
+    {
+        extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output {
+            self.0.call_mut(args)
+        }
+    }
+
+    impl<Args, F, T> Fn<Args> for PrustiClosure<F, T>
+    where
+        Args: core::marker::Tuple,
+        F: Fn<Args>,
+    {
+        extern "rust-call" fn call(&self, args: Args) -> Self::Output {
+            self.0.call(args)
         }
     }
 }

--- a/prusti-contracts/prusti-specs/src/lib.rs
+++ b/prusti-contracts/prusti-specs/src/lib.rs
@@ -502,8 +502,7 @@ pub fn closure(tokens: TokenStream) -> TokenStream {
         {
             struct #spec_struct_name;
 
-            impl ::prusti_contracts::ClosureSpec<#input_types_tuple> for #spec_struct_name {
-                type Output = #output_type;
+            impl ::prusti_contracts::ClosureSpec<#input_types_tuple, #output_type> for #spec_struct_name {
 
                 #[allow(unused_variables, unused_braces, unused_parens, unused_must_use)]
                 #[pure]

--- a/prusti-contracts/prusti-specs/src/lib.rs
+++ b/prusti-contracts/prusti-specs/src/lib.rs
@@ -455,88 +455,73 @@ fn generate_expression_closure(
 }
 
 pub fn closure(tokens: TokenStream) -> TokenStream {
-    let cl_spec: ClosureWithSpec = handle_result!(syn::parse(tokens.into()));
+    let ClosureWithSpec { cl, pres, posts } = handle_result!(syn::parse(tokens.into()));
     let callsite_span = Span::call_site();
 
-    let mut rewriter = rewriter::AstRewriter::new();
-
-    let mut preconds: Vec<(SpecificationId, syn::Expr)> = vec![];
-    let mut postconds: Vec<(SpecificationId, syn::Expr)> = vec![];
-
-    let mut cl_annotations = TokenStream::new();
-
-    for r in cl_spec.pres {
-        let spec_id = rewriter.generate_spec_id();
-        let precond =
-            handle_result!(rewriter.process_closure_assertion(spec_id, r.to_token_stream(),));
-        preconds.push((spec_id, precond));
-        let spec_id_str = spec_id.to_string();
-        cl_annotations.extend(quote_spanned! {callsite_span=>
-            #[prusti::pre_spec_id_ref = #spec_id_str]
-        });
-    }
-
-    for e in cl_spec.posts {
-        let spec_id = rewriter.generate_spec_id();
-        let postcond =
-            handle_result!(rewriter.process_closure_assertion(spec_id, e.to_token_stream(),));
-        postconds.push((spec_id, postcond));
-        let spec_id_str = spec_id.to_string();
-        cl_annotations.extend(quote_spanned! {callsite_span=>
-            #[prusti::post_spec_id_ref = #spec_id_str]
-        });
-    }
-
-    let syn::ExprClosure {
-        attrs,
-        asyncness,
-        movability,
-        capture,
-        or1_token,
-        inputs,
-        or2_token,
-        output,
-        body,
-    } = cl_spec.cl;
-
-    let output_type: syn::Type = match output {
+    let output_type: syn::Type = match cl.output {
         syn::ReturnType::Default => {
-            return syn::Error::new(output.span(), "closure must specify return type")
+            return syn::Error::new(cl.output.span(), "closure must specify return type")
                 .to_compile_error();
         }
         syn::ReturnType::Type(_, ref ty) => (**ty).clone(),
     };
 
-    let (spec_toks_pre, spec_toks_post) =
-        handle_result!(rewriter.process_closure(inputs.clone(), output_type, preconds, postconds,));
+    let mut input_names = Vec::new();
+    let mut input_types = Vec::new();
 
-    let mut attrs_ts = TokenStream::new();
-    for a in attrs {
-        attrs_ts.extend(a.into_token_stream());
+    for arg in &cl.inputs {
+        if let syn::Pat::Type(pt) = arg {
+            input_names.push((*pt.pat).clone());
+            input_types.push((*pt.ty).clone());
+        } else {
+            return syn::Error::new(
+                arg.span(),
+                "closure parameters must be typed patterns (e.g., |x: i32|)",
+            )
+            .to_compile_error();
+        }
     }
+
+    let spec_struct_name = quote::format_ident!("PrustiClosureSpec");
+    let input_types_tuple = quote! { (#(#input_types, )* ) };
+    let input_names_tuple = quote! { (#(#input_names, )* ) };
+
+    let conjoin_specs = |items: Vec<syn::Expr>| {
+        if items.is_empty() {
+            quote! {true}
+        } else {
+            let mut iter = items.iter();
+            let first = iter.next().unwrap();
+            iter.fold(quote! {#first}, |acc, item| quote! {#acc && #item})
+        }
+    };
+    let pres = conjoin_specs(pres);
+    let posts = conjoin_specs(posts);
 
     quote_spanned! {callsite_span=>
         {
-            #[allow(unused_variables, unused_braces, unused_parens)]
-            #[prusti::closure]
-            #[prusti::specs_version = #SPECS_VERSION]
-            #cl_annotations #attrs_ts
-            let _prusti_closure =
-                #asyncness #movability #capture
-                #or1_token #inputs #or2_token #output
-                {
-                    #[allow(unused_must_use, unused_braces, unused_parens)]
-                    if false {
-                        #spec_toks_pre
-                    }
-                    let result = #body ;
-                    #[allow(unused_must_use, unused_braces, unused_parens)]
-                    if false {
-                        #spec_toks_post
-                    }
-                    result
-                };
-            _prusti_closure
+            struct #spec_struct_name;
+
+            impl ::prusti_contracts::ClosureSpec<#input_types_tuple> for #spec_struct_name {
+                type Output = #output_type;
+
+                #[allow(unused_variables, unused_braces, unused_parens, unused_must_use)]
+                #[pure]
+                fn requires(#input_names_tuple: #input_types_tuple) -> bool {
+                    #pres
+                }
+
+                #[allow(unused_variables, unused_braces, unused_parens, unused_must_use)]
+                #[pure]
+                fn ensures(#input_names_tuple: #input_types_tuple, result: #output_type) -> bool {
+                    #posts
+                }
+            }
+
+            ::prusti_contracts::PrustiClosure(
+                #cl,
+                ::core::marker::PhantomData::<#spec_struct_name>
+            )
         }
     }
 }

--- a/prusti-contracts/prusti-specs/src/rewriter.rs
+++ b/prusti-contracts/prusti-specs/src/rewriter.rs
@@ -8,8 +8,8 @@ use crate::{
     },
 };
 use proc_macro2::{Span, TokenStream};
-use quote::{format_ident, quote, quote_spanned};
-use syn::{parse_quote_spanned, punctuated::Punctuated, spanned::Spanned, Pat, Token, Type};
+use quote::{quote, quote_spanned};
+use syn::{parse_quote_spanned, spanned::Spanned};
 
 pub(crate) struct AstRewriter {
     spec_id_generator: SpecificationIdGenerator,
@@ -287,74 +287,6 @@ impl AstRewriter {
             {
                 #[prusti::spec_only]
                 #[prusti::#kind]
-                #[prusti::spec_id = #spec_id_str]
-                || -> bool {
-                    #expr
-                };
-            }
-        })
-    }
-
-    /// Parse a closure with specifications into a Rust expression
-    /// TODO: arguments, result (types are typically not known yet after parsing...)
-    pub fn process_closure(
-        &mut self,
-        inputs: Punctuated<Pat, Token![,]>,
-        output: Type,
-        preconds: Vec<(SpecificationId, syn::Expr)>,
-        postconds: Vec<(SpecificationId, syn::Expr)>,
-    ) -> syn::Result<(TokenStream, TokenStream)> {
-        let process_cond =
-            |is_post: bool, id: &SpecificationId, assertion: &syn::Expr| -> TokenStream {
-                let spec_id_str = id.to_string();
-                let name = format_ident!(
-                    "prusti_{}_closure_{}",
-                    if is_post { "post" } else { "pre" },
-                    spec_id_str
-                );
-                let callsite_span = Span::call_site();
-                let result = if is_post && !inputs.empty_or_trailing() {
-                    quote_spanned! {callsite_span=> , result: #output }
-                } else if is_post {
-                    quote_spanned! {callsite_span=> result: #output }
-                } else {
-                    TokenStream::new()
-                };
-                quote_spanned! {callsite_span=>
-                    #[prusti::spec_only]
-                    #[prusti::spec_id = #spec_id_str]
-                    fn #name(#inputs #result) {
-                        #assertion
-                    }
-                }
-            };
-
-        let mut pre_ts = TokenStream::new();
-        for (id, precond) in preconds {
-            pre_ts.extend(process_cond(false, &id, &precond));
-        }
-
-        let mut post_ts = TokenStream::new();
-        for (id, postcond) in postconds {
-            post_ts.extend(process_cond(true, &id, &postcond));
-        }
-
-        Ok((pre_ts, post_ts))
-    }
-
-    /// Parse an assertion into a Rust expression
-    pub fn process_closure_assertion(
-        &mut self,
-        spec_id: SpecificationId,
-        tokens: TokenStream,
-    ) -> syn::Result<syn::Expr> {
-        let expr = parse_prusti(tokens)?;
-        let spec_id_str = spec_id.to_string();
-        let callsite_span = Span::call_site();
-        Ok(parse_quote_spanned! {callsite_span=>
-            #[allow(unused_must_use, unused_variables)]
-            {
-                #[prusti::spec_only]
                 #[prusti::spec_id = #spec_id_str]
                 || -> bool {
                     #expr

--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -567,6 +567,7 @@ impl<'tcx> TySpecifics<'tcx, RustTyDatas> {
             match adt.non_enum_variant().name.to_string().as_str() {
                 "Real" => Self::Builtin(RustBuiltinData::BuiltinReal),
                 "Ghost" => Self::Builtin(RustBuiltinData::BuiltinGhost),
+                "PrustiClosure" => Self::StructLike(Self::from_struct(adt.non_enum_variant())),
                 s => panic!("Found unrecognized builtin {s}"),
             }
         } else {


### PR DESCRIPTION
Change the encoding of the closure macro to reflect the changes in how we plan to encode closure specification.