### PR TITLE
Insert a `p_Ref_mutable assign` before an `undo_unsize` for mutable references

### DIFF
--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -681,11 +681,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                     .expect_mutref()
                     .prim_to_snap_assign(deref)
                     .upcast_ty();
-                let assign_stmt = dst_ty_impure.apply_method_assign(
-                    self.vcx,
-                    dst_enc,
-                    assigned,
-                );
+                let assign_stmt = dst_ty_impure.apply_method_assign(self.vcx, dst_enc, assigned);
                 self.stmt(assign_stmt);
 
                 let def_id = self.def_id();

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -663,9 +663,31 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                     label.map(vir::OldLabel::Label)
                 };
                 let src_enc = self.encode_place(src_place).expr.expect_predicate();
-                let src_enc = self.vcx.maybe_apply_label(src_enc, src_label);
+                let src_enc_old = self.vcx.maybe_apply_label(src_enc, src_label);
                 let dst_enc = self.encode_place(dst_place).expr.expect_predicate();
-                let dst_enc = self.vcx.maybe_apply_label(dst_enc, dst_label);
+                let dst_enc_old = self.vcx.maybe_apply_label(dst_enc, dst_label);
+
+                // The permission p_Ref_mutable may have been lost, e.g. if a mutable borrow occured before.
+                // In that case, we still have permission to access the data (e.g. acc(p_Param(p_Ref_mutable_snap(...)))
+                // but we need to do a p_Ref_mutable_assign to get the mutable ref from the old heap
+                let dst_ty_impure = self.ty_use_impure(dst_ty);
+                let ref_to_snap = dst_ty_impure.ref_to_snap(dst_enc);
+                let ref_to_snap = self.vcx.maybe_apply_label(ref_to_snap, dst_label);
+                let deref = self
+                    .ty_use_pure(dst_ty)
+                    .expect_mutref()
+                    .deref_access(ref_to_snap.downcast_ty());
+                let assigned = dst_ty_impure
+                    .expect_mutref()
+                    .prim_to_snap_assign(deref)
+                    .upcast_ty();
+                let assign_stmt = dst_ty_impure.apply_method_assign(
+                    self.vcx,
+                    dst_enc,
+                    assigned,
+                );
+                self.stmt(assign_stmt);
+
                 let def_id = self.def_id();
                 let unsize = self
                     .deps()
@@ -678,8 +700,8 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 self.stmt(
                     self.vcx
                         .alloc(vir::StmtData::new(self.vcx.alloc((unsize.undo)(
-                            src_enc,
-                            dst_enc,
+                            src_enc_old,
+                            dst_enc_old,
                             generics.ty_exprs(),
                             generics.const_exprs(),
                         )))),


### PR DESCRIPTION
Currently, unsizing mutable references works as follows: On a `PointerCoercion(Unsizing)`, Prusti emits a `mir_unsize_{...}`. For example, when unsizing `&[i32; 3] -> &[i32]`, this has the following contract (ignoring array/slice specifics):

```
requires acc(p_Ref_mutable(src, s_Array_type(s_Int_i32_type(), s_UInt_usize_cons(3))), write)
requires acc(p_Param(p_Ref_mutable_snap(src, s_Array_type(s_Int_i32_type(), s_UInt_usize_cons(3))).s_Ref_mutable_0, s_Array_type(s_Int_i32_type(), s_UInt_usize_cons(3))), write)
ensures acc(p_Ref_mutable(dst, s_Slice_type(s_Int_i32_type())), write)
ensures acc(p_Param(p_Ref_mutable_snap(dst, s_Slice_type(s_Int_i32_type())).s_Ref_mutable_0, s_Slice_type(s_Int_i32_type())), write)
ensures old(p_Ref_mutable_snap(src, s_Array_type(s_Int_i32_type(), s_UInt_usize_cons(3))).s_Ref_mutable_0) ==
    p_Ref_mutable_snap(dst, s_Slice_type(s_Int_i32_type())).s_Ref_mutable_0
``` 

In summary: hand in a Ref to `[i32; 3]`, get back a Ref to `[i32]` while not changing the address the Ref points to. This corresponds to the fact then when borrowing mutably, we can't use the original array while being borrowed. However, after the borrow expires, we have to undo the unsizing and convert `&[i32] -> &[i32; 3]`. This is done via the `undo_unsize` method on `StorageDead`. For our example, this emits the following contract (again ignoring specifics for slices/arrays):

```
requires acc(p_Ref_mutable(dst, s_Slice_type(s_Int_i32_type())), write)
requires acc(p_Param(p_Ref_mutable_snap(dst, s_Slice_type(s_Int_i32_type())).s_Ref_mutable_0,
  s_Slice_type(s_Int_i32_type())), write)
ensures acc(p_Ref_mutable(src, s_Array_type(s_Int_i32_type(), s_UInt_usize_cons(3))), write)
ensures acc(p_Param(p_Ref_mutable_snap(src, s_Array_type(s_Int_i32_type(), s_UInt_usize_cons(3))).s_Ref_mutable_0,
  s_Array_type(s_Int_i32_type(), s_UInt_usize_cons(3))), write)
ensures p_Ref_mutable_snap(src, s_Array_type(s_Int_i32_type(), s_UInt_usize_cons(3))).s_Ref_mutable_0 ==
  old(p_Ref_mutable_snap(dst, s_Slice_type(s_Int_i32_type())).s_Ref_mutable_0)
``` 

This is basically the inverse of the contract for `unsize`.

However, code between these method calls could do arbitrary things with the reference. For example, it could pass it into a function:

```rust
fn consume(v: &mut [i32]) {
}

fn main() {
    let mut arr = [1, 2, 3];
    consume(&mut arr);
}
```

In this case, `consume` has the following contract:

```txt
requires acc(p_Ref_mutable(_1p, s_Slice_type(s_Int_i32_type())), write)
requires acc(p_Param(p_Ref_mutable_snap(_1p, s_Slice_type(s_Int_i32_type())).s_Ref_mutable_0,
  s_Slice_type(s_Int_i32_type())), write)
ensures acc(p_0_Tuple(_0p), write)
ensures acc(p_Param(old(p_Ref_mutable_snap(_1p, s_Slice_type(s_Int_i32_type()))).s_Ref_mutable_0,
  s_Slice_type(s_Int_i32_type())), write)
```

Note that it takes in a `Ref_mutable`, but does not return it. However, when attempting to undo the unsizing, `main` doesn't have the permission `p_Ref_mutable(...)` anymore, leading to a verification failure (and a `verification error could not be backtranslated` issue).

This PR wants to solve the issue. We note that we do get the permission `acc(p_Param(old(p_Ref_mutable_snap(_1p, s_Slice_type(s_Int_i32_type()))).s_Ref_mutable_0, s_Slice_type(s_Int_i32_type())), write)` back from `consume`. Therefore, we can construct a mutable Ref using the old heap, and use the `p_Param` permission from before.

Overall, an `undo_unsize` call now looks like the following:

```
p_Ref_mutable_assign(_3p, s_Slice_type(s_Int_i32_type()), p_Ref_mutable_arbitrary_value(old[_before_0_11](p_Ref_mutable_snap(_3p,
      s_Slice_type(s_Int_i32_type()))).s_Ref_mutable_0))
mir_undo_unsize_$amp$$sq$$qm$6$sp$mut$sp$$lb$i32$sc$$sp$3_usize$rb$_to_$amp$$sq$$qm$5$sp$mut$sp$$lb$i32$rb$(old[_before_0_9](_4p),
      old[_before_0_11](_3p))
``` 

I tested various examples, e.g. a local unsize, calling one or more functions with the unsized reference, all of which now pass verification.