### PR TITLE
Normalize + and ! in identifiers

### DIFF
--- a/vir/src/viper_ident.rs
+++ b/vir/src/viper_ident.rs
@@ -52,6 +52,8 @@ fn sanitize_char(c: char) -> Option<String> {
         '/' => Some("$fs$".to_string()),
         '*' => Some("$as$".to_string()),
         '=' => Some("$eq$".to_string()),
+        '+' => Some("$pl$".to_string()),
+        '!' => Some("$ex$".to_string()),
         _ => None,
     }
 }


### PR DESCRIPTION
Currently, `+` and `!` are not normalized in identifiers, leading to invalid identifier consistency errors. 19/3349 doctests hit this problem.

## Example for `+`

```rust
use std::any::Any;
fn is_string(s: &dyn Any) -> bool {
    s.is::<String>()
}
```

leads to the invalid identifier `m_$lt$$lp$dyn$sp$std$col$$col$any$col$$col$Any$sp$+$sp$$sq$static$rp$$gt$$col$$col$is` representing `m_<(dyn std::any::Any + 'static)>::is`.

## Example for `!`

```rust
#![allow(dead_code, deprecated, unused_variables, unused_mut)]
#![feature(never_type)]
use std::fmt;
trait Debug {
    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result;
}
impl Debug for ! {
    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
        *self
    }
}
fn main() {}
```

leads to the identifier `m_$lt$!$sp$as$sp$Debug$gt$$col$$col$fmt` representing `m_<! as Debug>::fmt`.