### PR TITLE
Fix `AlreadyEncoded` crash for mutually recursive struct types

### DIFF
--- a/prusti-encoder/src/encoders/ty/generics/args_ty.rs
+++ b/prusti-encoder/src/encoders/ty/generics/args_ty.rs
@@ -53,7 +53,7 @@ impl TaskEncoder for GArgsTyEnc {
                 let decomp = RustTyDecomposition::from_ty(arg, task_key.context);
                 params.ty_expr(deps, decomp)
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, _>>()?;
         let const_args = task_key
             .args
             .iter()

--- a/prusti-encoder/src/encoders/ty/generics/params.rs
+++ b/prusti-encoder/src/encoders/ty/generics/params.rs
@@ -272,9 +272,7 @@ impl<'vir> GenericParams<'vir> {
                 }),
             });
         }
-        let ty_constructor = deps
-            .require_ref::<TyConstructorEnc>(ty.ty)?
-            .ty_constructor;
+        let ty_constructor = deps.require_ref::<TyConstructorEnc>(ty.ty)?.ty_constructor;
         let args = deps.require_dep::<GArgsTyEnc>(ty.args)?;
         Ok(ty_constructor(args.get_ty(), args.get_const()))
     }

--- a/prusti-encoder/src/encoders/ty/generics/params.rs
+++ b/prusti-encoder/src/encoders/ty/generics/params.rs
@@ -3,7 +3,7 @@ use prusti_rustc_interface::{
     middle::ty,
     span::{def_id::DefId, symbol},
 };
-use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 use vir::{CastType, HasType};
 
 use crate::encoders::{
@@ -257,10 +257,10 @@ impl<'vir> GenericParams<'vir> {
         &self,
         deps: &mut TaskEncoderDependencies<'vir, E>,
         ty: RustTyDecomposition<'vir>,
-    ) -> vir::ExprTyVal<'vir> {
+    ) -> Result<vir::ExprTyVal<'vir>, EncodeFullError<'vir, E>> {
         if let TySpecifics::Param(RustParamData::Generic) = &ty.ty.specifics {
             let param = ty.args.expect_param();
-            return match param {
+            return Ok(match param {
                 GParamVariant::Param(p) => self.ty_exprs[self.map_idx(p.index).unwrap()],
                 GParamVariant::Alias(alias) => vir::with_vcx(|vcx| {
                     let tcx = vcx.tcx();
@@ -270,14 +270,13 @@ impl<'vir> GenericParams<'vir> {
                     let args = deps.require_dep::<GArgsTyEnc>(args).unwrap();
                     (trait_data.assoc_types[&alias.def_id])(args.get_ty(), args.get_const())
                 }),
-            };
+            });
         }
         let ty_constructor = deps
-            .require_ref::<TyConstructorEnc>(ty.ty)
-            .unwrap()
+            .require_ref::<TyConstructorEnc>(ty.ty)?
             .ty_constructor;
-        let args = deps.require_dep::<GArgsTyEnc>(ty.args).unwrap();
-        ty_constructor(args.get_ty(), args.get_const())
+        let args = deps.require_dep::<GArgsTyEnc>(ty.args)?;
+        Ok(ty_constructor(args.get_ty(), args.get_const()))
     }
 }
 

--- a/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
@@ -146,7 +146,7 @@ impl TaskEncoder for TraitImplEnc {
                                 tcx.type_of(impl_item_def_id).instantiate_identity(),
                                 impl_item_context,
                             ),
-                        );
+                        )?;
                         axioms.push(vcx.mk_domain_axiom(
                             vir_format_identifier!(vcx, "{trait_name}_impl_{implementing_ty}_{idx}_assoc_type_{item_name}"),
                             vir::expr! {forall ..[trait_ty_decls], ..[trait_const_decls] :: {[assoc_type(trait_tys, trait_consts)]} ([assoc_type(trait_tys, trait_consts)]) == (assoc_type_expr)},

--- a/prusti-tests/tests/verify/pass/no-annotations/recursive-structs.rs
+++ b/prusti-tests/tests/verify/pass/no-annotations/recursive-structs.rs
@@ -1,0 +1,11 @@
+struct A<K, V> {
+    k: K,
+    v: V,
+    link: Option<*const B<K, V>>,
+}
+struct B<K, V> {
+    data: A<K, V>,
+}
+fn main() {
+    let _: A<i32, bool> = A { k: 0, v: false, link: None };
+}

--- a/prusti-tests/tests/verify/pass/no-annotations/recursive-structs.rs
+++ b/prusti-tests/tests/verify/pass/no-annotations/recursive-structs.rs
@@ -1,11 +1,10 @@
-struct A<K, V> {
+struct A<K> {
     k: K,
-    v: V,
-    link: Option<*const B<K, V>>,
+    link: Option<Box<B<K>>>,
 }
-struct B<K, V> {
-    data: A<K, V>,
+struct B<K> {
+    data: A<K>,
 }
 fn main() {
-    let _: A<i32, bool> = A { k: 0, v: false, link: None };
+    let _: A<i32> = A { k: 0, link: None };
 }


### PR DESCRIPTION
- Fix encoding crash for types with mutually recursive struct fields
- Propagate `AlreadyEncoded` via `?` instead of panicking with `unwrap()` in `GenericParams::ty_expr`

`GenericParams::ty_expr` used `.unwrap()` on `require_ref` and `require_dep` calls, which panicked on `AlreadyEncoded` instead of propagating it. This caused crashes when encoding types like:

```rust
struct A<K> {                                                                                                                                
    k: K,       
    link: Option<Box<B<K>>>,
}                                                                                                                                               
struct B<K> {
    data: A<K>,
}                                                                                                                                               
fn main() {
    let _: A<i32> = A { k: 0, link: None };                                                                                     
}
```

The cycle occurs because `TyUsePureEnc::do_encode_full` calls `require_dep::<TyPureEnc>` which requests the full output of a type that may still be in `Started` state. This triggers re-entry that completes the task, and subsequent `check_cycle` calls correctly return `AlreadyEncoded` — but `.unwrap()` turned that into a panic.                                                                                        

Replacing `.unwrap()` with `?` lets `AlreadyEncoded` propagate through the encoder chain until `encode()` resolves it from cache.                       

This is a first step to fixing also fixes stdlib types like `BTreeMap`, where `InternalNode<K,V>` directly contains `LeafNode<K,V>` which references `InternalNode` through its `parent` field.

For example, the following code snippet doesn't trigger an error anymore:

```rust
fn main() {
    use std::collections::BTreeMap;
    let mut movie_reviews: BTreeMap<String, String> = BTreeMap::new();
}
```

However, operations on `BTreeMap`s still trigger errors due to PCG limitations, but this is out of scope for this PR. 