### PR TITLE
Do not panic on failed backtranslation

### DIFF
--- a/prusti-encoder/src/lib.rs
+++ b/prusti-encoder/src/lib.rs
@@ -140,6 +140,6 @@ pub fn backtranslate_error(
     error_kind: &str,
     offending_pos_id: usize,
     reason_pos_id: Option<usize>,
-) -> Option<Vec<PrustiError>> {
+) -> Vec<PrustiError> {
     vir::with_vcx(|vcx| vcx.backtranslate(error_kind, offending_pos_id, reason_pos_id))
 }

--- a/prusti-server/src/lib.rs
+++ b/prusti-server/src/lib.rs
@@ -225,7 +225,6 @@ fn handle_result(
                             .unwrap(),
                         error.reason_pos_id.and_then(|id| id.parse::<usize>().ok()),
                     )
-                    .expect("verification error could not be backtranslated")
                     .into_iter()
                 })
                 .for_each(|prusti_error| {

--- a/vir/src/spans.rs
+++ b/vir/src/spans.rs
@@ -176,7 +176,13 @@ impl<'tcx> VirCtxt<'tcx> {
             }
             span_opt = span.parent.as_ref();
         }
-        vec![PrustiError::internal(format!("A verification error occurred, but it could not be backtranslated: no handler found for error kind: {error_kind}."), DUMMY_SP.into())]
+        // No handler found for the error, this must be a bug. We'll try to provide a span at least.
+        let span = manager
+            .all
+            .get(offending_pos_id)
+            .map(|vir_span| vir_span.span)
+            .unwrap_or(DUMMY_SP);
+        vec![PrustiError::internal(format!("A verification error occurred, but it could not be backtranslated: no handler found for error kind: {error_kind}."), span.into())]
     }
 
     /// Attempt to backtranslate a position id to a rust span

--- a/vir/src/spans.rs
+++ b/vir/src/spans.rs
@@ -158,7 +158,7 @@ impl<'tcx> VirCtxt<'tcx> {
         error_kind: &str,
         offending_pos_id: usize,
         reason_pos_id: Option<usize>,
-    ) -> Option<Vec<PrustiError>> {
+    ) -> Vec<PrustiError> {
         let manager = self.spans.borrow();
         let reason_span_opt = reason_pos_id
             .and_then(|id| manager.all.get(id))
@@ -169,15 +169,14 @@ impl<'tcx> VirCtxt<'tcx> {
             while let Some(handler) = handler_opt {
                 if handler.error_kind == error_kind {
                     if let Some(errors) = (handler.handler)(reason_span_opt) {
-                        return Some(errors);
+                        return errors;
                     }
                 }
                 handler_opt = handler.next.as_deref();
             }
             span_opt = span.parent.as_ref();
         }
-        eprintln!("no handler found for error kind: {error_kind}");
-        None
+        vec![PrustiError::internal(format!("A verification error occurred, but it could not be backtranslated: no handler found for error kind: {error_kind}."), DUMMY_SP.into())]
     }
 
     /// Attempt to backtranslate a position id to a rust span


### PR DESCRIPTION
Currently, Prusti panics when encountering a Viper error which it can't backtranslate.
Even though these are generally bugs in Prusti, this is not particularly user-friendly. It also limits partial verification of a file:
If we have one such Viper error, we will not get results for anything else in the file.
"verification error could not be backtranslated" is the largest category of errors in the doctest pipeline (<https://prusti-stdlib-support.rgwohlbold.de/>), responsible for ~400/1600 failing test cases. It seems to be due to multiple issues, so a general fix for the panic seems to be warranted, before fixing the underlying issues.

This PR removes this panic and returns a proper internal Prusti error instead. To be helpful with debugging, it also provides the span for the error.

Consider the following file, triggering such an error:

```rust
use prusti_contracts::*;

fn main() {
    let _ = [1, 2, 3].into_iter();
}


#[ensures(result == 42)]
fn abc() -> i32 {
    0
}
```

Before the PR, we get the following output (note that we don't see any results for function `abc`):

```txt
Verification of 2 items...
no handler found for error kind: call.precondition:insufficient.permission

thread 'rustc' (1441696) panicked at prusti-server/src/lib.rs:228:22:
verification error could not be backtranslated
stack backtrace:
   0:     0x7f7ab55adb93 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::hf3fc14c10e517ebe
   1:     0x7f7ab5c01998 - core::fmt::write::h60a8fe1fb572c912
   2:     0x7f7ab55628f1 - std::io::Write::write_fmt::h04f6f73f48cbbad0
   3:     0x7f7ab5573a72 - std::sys::backtrace::BacktraceLock::print::h90e3d87c9a5140eb
   4:     0x7f7ab55799f9 - std::panicking::default_hook::{{closure}}::h5fd5162b51244d27
   5:     0x7f7ab5579523 - std::panicking::default_hook::h72c168565d86eae1
   6:     0x7f7ab45dc125 - std[57c1393ad41bbbfd]::panicking::update_hook::<alloc[7d9612ffe8b8ee55]::boxed::Box<rustc_driver_impl[902c67247d8c741]::install_ice_hook::{closure#1}>>::{closure#0}
   7:     0x7f7ab5579e1f - std::panicking::panic_with_hook::ha6b5140b25841651
   8:     0x7f7ab5579bda - std::panicking::panic_handler::{{closure}}::h0dee07c74bc57a6d
   9:     0x7f7ab5573bb9 - std::sys::backtrace::__rust_end_short_backtrace::hf5c7a0ee0072f6ae
  10:     0x7f7ab555445d - __rustc[4dd267c369f14767]::rust_begin_unwind
  11:     0x7f7ab1ccae30 - core::panicking::panic_fmt::h61140a6577667985
  12:     0x7f7ab30a634b - core::option::expect_failed::hfec0819f08969c51
  13:     0x55e662c25821 - core::option::Option<T>::expect::h4371774fb9a1d747
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/option.rs:964:21
  14:     0x55e6629f970d - prusti_server::handle_result::{{closure}}::h14ca810672e801c8
                               at /home/richard/progs/prusti-dev/prusti-server/src/lib.rs:228:22
  15:     0x55e66298df89 - core::iter::adapters::map::map_fold::{{closure}}::h1505c951a5be5ea3
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/map.rs:88:28
  16:     0x55e6629926fb - <alloc::vec::into_iter::IntoIter<T,A> as core::iter::traits::iterator::Iterator>::fold::h90a2c563579edb3e
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/into_iter.rs:323:25
  17:     0x55e662985bf2 - <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::fold::hbf3600a9c6dcddc9
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/map.rs:128:19
  18:     0x55e6629c476c - <core::iter::adapters::fuse::Fuse<I> as core::iter::traits::iterator::Iterator>::fold::hbaa21c6238785c62
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/fuse.rs:98:24
  19:     0x55e6629c476c - core::iter::adapters::flatten::FlattenCompat<I,U>::iter_fold::hcc64c54db7577666
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/flatten.rs:395:25
  20:     0x55e6629c4067 - <core::iter::adapters::flatten::FlattenCompat<I,U> as core::iter::traits::iterator::Iterator>::fold::h234e01a1d1f8a398
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/flatten.rs:581:14
  21:     0x55e6629c4048 - <core::iter::adapters::flatten::FlatMap<I,U,F> as core::iter::traits::iterator::Iterator>::fold::h308dff9480b53ed3
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/flatten.rs:87:20
  22:     0x55e6629c4147 - core::iter::traits::iterator::Iterator::for_each::h9df64723eb06205e
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:827:14
  23:     0x55e662983795 - prusti_server::handle_result::h6e89841766cb09d9
                               at /home/richard/progs/prusti-dev/prusti-server/src/lib.rs:231:18
  24:     0x55e662984761 - prusti_server::handle_termination_message::hd250af2406df3fc7
                               at /home/richard/progs/prusti-dev/prusti-server/src/lib.rs:303:5
  25:     0x55e6629fb082 - prusti_server::handle_stream::{{closure}}::h5c9d2d542025e7fa
                               at /home/richard/progs/prusti-dev/prusti-server/src/lib.rs:112:51
  26:     0x55e6629fc237 - prusti_server::verify_programs::{{closure}}::hceab232c962b03eb
                               at /home/richard/progs/prusti-dev/prusti-server/src/lib.rs:86:66
  27:     0x55e662a90b77 - <core::pin::Pin<P> as core::future::future::Future>::poll::h68f6715806798703
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
  28:     0x55e662a90bd8 - <core::pin::Pin<P> as core::future::future::Future>::poll::hbe3c6e0ccbacdbad
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
  29:     0x55e662a8eec8 - tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}::{{closure}}::hfb32635bccec209f
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:742:70
  30:     0x55e662a8eb3c - tokio::task::coop::with_budget::h85dd91c882f1a8ee
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/task/coop/mod.rs:167:5
  31:     0x55e662a8eb3c - tokio::task::coop::budget::h0c22861b5b863613
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/task/coop/mod.rs:133:5
  32:     0x55e662a8eb3c - tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}::ha3fe70ea7b3a3bfe
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:742:25
  33:     0x55e662a89a24 - tokio::runtime::scheduler::current_thread::Context::enter::h8ac59ac3905b7897
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:432:19
  34:     0x55e662a8c181 - tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::h0960c506faa882fd
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:741:44
  35:     0x55e662a8bdc8 - tokio::runtime::scheduler::current_thread::CoreGuard::enter::{{closure}}::hfe8d20cc894ab2c0
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:829:68
  36:     0x55e662bf6055 - tokio::runtime::context::scoped::Scoped<T>::set::h5c75b10c57e6497e
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context/scoped.rs:40:9
  37:     0x55e662bc4418 - tokio::runtime::context::set_scheduler::{{closure}}::h19cda6d696916a78
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context.rs:176:38
  38:     0x55e662c7d83f - std::thread::local::LocalKey<T>::try_with::he732535b9feb4808
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:315:12
  39:     0x55e662c65f4a - std::thread::local::LocalKey<T>::with::h9731de2f058e7e05
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:279:20
  40:     0x55e662bc43cf - tokio::runtime::context::set_scheduler::hd4d200f7206dd2dd
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context.rs:176:17
  41:     0x55e662a8af58 - tokio::runtime::scheduler::current_thread::CoreGuard::enter::h11882bc8af036385
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:829:27
  42:     0x55e662a8bddf - tokio::runtime::scheduler::current_thread::CoreGuard::block_on::h0aa5cc991cefed43
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:729:24
  43:     0x55e662a86f3d - tokio::runtime::scheduler::current_thread::CurrentThread::block_on::{{closure}}::hc1b3b81c4f52277e
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:200:33
  44:     0x55e662a9db42 - tokio::runtime::context::runtime::enter_runtime::h056332c3d8a3e026
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context/runtime.rs:65:16
  45:     0x55e662a8651d - tokio::runtime::scheduler::current_thread::CurrentThread::block_on::h6abecd0e14cb381b
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:188:9
  46:     0x55e662ac860a - tokio::runtime::runtime::Runtime::block_on_inner::h57cf98d38d9bbd93
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/runtime.rs:356:52
  47:     0x55e662ac8a27 - tokio::runtime::runtime::Runtime::block_on::h384db73f30cd64ba
                               at /home/richard/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/runtime.rs:328:18
  48:     0x55e662983ff4 - prusti_server::verify_programs::h2429b3a1abf3e69c
                               at /home/richard/progs/prusti-dev/prusti-server/src/lib.rs:73:29
  49:     0x55e66295b4f0 - prusti_driver::verifier::verify::h6c2e0e0cc3e1543c
                               at /home/richard/progs/prusti-dev/prusti/src/verifier.rs:58:9
  50:     0x55e6629339b6 - <prusti_driver::callbacks::PrustiCompilerCalls as rustc_driver_impl::Callbacks>::after_analysis::h22d8576928ef3e3e
                               at /home/richard/progs/prusti-dev/prusti/src/callbacks.rs:258:17
  51:     0x7f7ab6e15aff - rustc_interface[afaa10d6c1afcef4]::passes::create_and_enter_global_ctxt::<core[b6b5f5c4688e0f5a]::option::Option<rustc_interface[afaa10d6c1afcef4]::queries::Linker>, rustc_driver_impl[902c67247d8c741]::run_compiler::{closure#0}::{closure#2}>::{closure#2}::{closure#0}
  52:     0x7f7ab6dc313e - rustc_interface[afaa10d6c1afcef4]::interface::run_compiler::<(), rustc_driver_impl[902c67247d8c741]::run_compiler::{closure#0}>::{closure#1}
  53:     0x7f7ab6d14b78 - std[57c1393ad41bbbfd]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[afaa10d6c1afcef4]::util::run_in_thread_with_globals<rustc_interface[afaa10d6c1afcef4]::util::run_in_thread_pool_with_globals<rustc_interface[afaa10d6c1afcef4]::interface::run_compiler<(), rustc_driver_impl[902c67247d8c741]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
  54:     0x7f7ab6d1485c - <<std[57c1393ad41bbbfd]::thread::Builder>::spawn_unchecked_<rustc_interface[afaa10d6c1afcef4]::util::run_in_thread_with_globals<rustc_interface[afaa10d6c1afcef4]::util::run_in_thread_pool_with_globals<rustc_interface[afaa10d6c1afcef4]::interface::run_compiler<(), rustc_driver_impl[902c67247d8c741]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[b6b5f5c4688e0f5a]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
  55:     0x7f7ab6d1a5cd - std::sys::pal::unix::thread::Thread::new::thread_start::h45368d2ed0fa04a8
  56:     0x7f7aaf4a598b - <unknown>
  57:     0x7f7aaf529a0c - <unknown>
  58:                0x0 - <unknown>

error: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/viperproject/prusti-dev/issues/new

note: please make sure that you have updated to the latest nightly

note: please attach the file at `/home/richard/progs/prusti-dev/rustc-ice-2026-04-30T09_22_20-1441695.txt` to your bug report

note: compiler flags: --crate-type lib

query stack during panic:
end of query stack
note: Prusti version: 0.3.0, commit 52e9f08d2 2026-03-30 12:21:43 UTC, built on 2026-03-31 12:37:51 UTC

warning: 2 warnings emitted
```

With the PR, we get the following output:

```txt
Verification of 2 items...
error: [Prusti internal error] Prusti encountered an unexpected internal error
 --> abc.rs:4:13
  |
4 |     let _ = [1, 2, 3].into_iter();
  |             ^^^^^^^^^^^^^^^^^^^^^
  |
  = note: We would appreciate a bug report: https://github.com/viperproject/prusti-dev/issues/new
  = note: A verification error occurred, but it could not be backtranslated: no handler found for error kind: call.precondition:insufficient.permission.

error: [Prusti: verification error] postcondition might not hold
 --> abc.rs:8:11
  |
8 | #[ensures(result == 42)]
  |           ^^^^^^^^^^^^

error: aborting due to 2 previous errors; 2 warnings emitted
```