### PR TITLE
Fix mismatched parameter indices in trait impl encoding

### DIFF
--- a/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
@@ -122,11 +122,16 @@ impl TaskEncoder for TraitImplEnc {
                 //     fn foo<'b, B>() {}
                 // }
                 // ```
-                // The `trait_item_context` of `foo` is `<Self, 'a, A, 'b, B>`
-                // and we combine the identity suffix of this with the args to
-                // the trait to get: `<MyType, 'static, (T, bool), 'b, B>`.
+                // The `impl_item_context` of `foo` is `<T, 'b, B>` and
+                // `impl_context` is `<T>`. We take the suffix of the impl
+                // item's params that are specific to the method (i.e. not
+                // inherited from the impl) and combine them with the trait
+                // args to get: `<MyType, 'static, (T, bool), 'b, B>`.
+                // We use `impl_item_context` rather than the trait item's
+                // context because the parameter indices must match the
+                // `impl_item_context` used in `GArgs::new` below.
                 let trait_item_context = GParams::from(trait_item_def_id);
-                let item_args = &trait_item_context.rust_params()[trait_ref.args.len()..];
+                let item_args = &impl_item_context.rust_params()[impl_context.rust_params().len()..];
                 let args = trait_ref.args.iter().chain(item_args.iter().copied());
                 let args = tcx.mk_args_from_iter(args);
                 let impl_item_args = GArgs::new(impl_item_context, args);

--- a/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
@@ -131,7 +131,8 @@ impl TaskEncoder for TraitImplEnc {
                 // context because the parameter indices must match the
                 // `impl_item_context` used in `GArgs::new` below.
                 let trait_item_context = GParams::from(trait_item_def_id);
-                let item_args = &impl_item_context.rust_params()[impl_context.rust_params().len()..];
+                let item_args =
+                    &impl_item_context.rust_params()[impl_context.rust_params().len()..];
                 let args = trait_ref.args.iter().chain(item_args.iter().copied());
                 let args = tcx.mk_args_from_iter(args);
                 let impl_item_args = GArgs::new(impl_item_context, args);


### PR DESCRIPTION
The trait impl encoder creates a `GArgs` for a given method implementation. However, if the method is generic, the encoder creates invalid `GArgs` that causes an index out of bounds error downstream.

Take the following code snippet:

```rust
trait MyTrait {
    fn foo<F>();
}

struct MyStruct {}
impl MyTrait for MyStruct {
    fn foo<F>() {}
}
```

This has the trait impl encoder create the `GArgs` `context = [F/#0], args = [MyStruct, F/#1]`. Later, while iterating over `args`, indexing into `context` results in an index out of bounds error:

```txt
thread 'rustc' (78920) panicked at prusti-encoder/src/encoders/ty/generics/params.rs:234:34:
index out of bounds: the len is 1 but the index is 1
stack backtrace:
   0:     0x7fb9045adb93 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::hf3fc14c10e517ebe
   1:     0x7fb904c01998 - core::fmt::write::h60a8fe1fb572c912
   2:     0x7fb9045628f1 - std::io::Write::write_fmt::h04f6f73f48cbbad0
   3:     0x7fb904573a72 - std::sys::backtrace::BacktraceLock::print::h90e3d87c9a5140eb
   4:     0x7fb9045799f9 - std::panicking::default_hook::{{closure}}::h5fd5162b51244d27
   5:     0x7fb904579523 - std::panicking::default_hook::h72c168565d86eae1
   6:     0x7fb9035dc125 - std[57c1393ad41bbbfd]::panicking::update_hook::<alloc[7d9612ffe8b8ee55]::boxed::Box<rustc_driver_impl[902c67247d8c741]::install_ice_hook::{closure#1}>>::{closure#0}
   7:     0x7fb904579e1f - std::panicking::panic_with_hook::ha6b5140b25841651
   8:     0x7fb904579bda - std::panicking::panic_handler::{{closure}}::h0dee07c74bc57a6d
   9:     0x7fb904573bb9 - std::sys::backtrace::__rust_end_short_backtrace::hf5c7a0ee0072f6ae
  10:     0x7fb90455445d - __rustc[4dd267c369f14767]::rust_begin_unwind
  11:     0x7fb900ccae30 - core::panicking::panic_fmt::h61140a6577667985
  12:     0x7fb902cf92a3 - core::panicking::panic_bounds_check::h179101727ed356ff
  13:     0x55fde22772c8 - <usize as core::slice::index::SliceIndex<[T]>>::index::h977e95f51fc0c952
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:265:10
  14:     0x55fde2331f6a - core::slice::index::<impl core::ops::index::Index<I> for [T]>::index::h7ddd8f9529803b5d
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:18:15
  15:     0x55fde2331f6a - <alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index::he2e1005d7ce1a366
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:3621:9
  16:     0x55fde275905f - prusti_encoder::encoders::ty::generics::params::GenericParams::map_idx::h3cb9eaeb83b775cd
                               at /home/richard/progs/prusti-dev/prusti-encoder/src/encoders/ty/generics/params.rs:234:34
  17:     0x55fde24cfd28 - prusti_encoder::encoders::ty::generics::params::GenericParams::ty_expr::h10e5bf205c28a29d
                               at /home/richard/progs/prusti-dev/prusti-encoder/src/encoders/ty/generics/params.rs:264:63
  18:     0x55fde25cba79 - <prusti_encoder::encoders::ty::generics::args_ty::GArgsTyEnc as task_encoder::TaskEncoder>::do_encode_full::{{closure}}::h991870726cb7e5f1
                               at /home/richard/progs/prusti-dev/prusti-encoder/src/encoders/ty/generics/args_ty.rs:54:24
  19:     0x55fde25b6cd2 - core::iter::adapters::map::map_try_fold::{{closure}}::h470566a1e9366fa3
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/map.rs:95:28
  20:     0x55fde22e65b3 - core::iter::adapters::filter_map::filter_map_try_fold::{{closure}}::had003e8ec42a6b9c
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/filter_map.rs:50:20
  21:     0x55fde23937fd - core::iter::adapters::copied::copy_try_fold::{{closure}}::h115705d721d68db7
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/copied.rs:34:22
  22:     0x55fde25779c8 - core::iter::traits::iterator::Iterator::try_fold::h726d2b968780ba4f
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2426:21
  23:     0x55fde2393070 - <core::iter::adapters::copied::Copied<I> as core::iter::traits::iterator::Iterator>::try_fold::he834bae6572431e5
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/copied.rs:68:17
  24:     0x55fde22e56ef - <core::iter::adapters::filter_map::FilterMap<I,F> as core::iter::traits::iterator::Iterator>::try_fold::h81b2abbb5685b6a0
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/filter_map.rs:138:19
  25:     0x55fde25ae215 - <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold::h96a9e02fc462fac7
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/map.rs:121:19
  26:     0x55fde2441cc6 - <core::iter::adapters::GenericShunt<I,R> as core::iter::traits::iterator::Iterator>::try_fold::h332108b7ec56c0a3
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/mod.rs:192:14
  27:     0x55fde244125a - core::iter::traits::iterator::Iterator::try_for_each::h0a69654814b08ce5
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2487:14
  28:     0x55fde244125a - <core::iter::adapters::GenericShunt<I,R> as core::iter::traits::iterator::Iterator>::next::h262b3ec1705243a6
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/mod.rs:174:14
  29:     0x55fde23293e4 - alloc::vec::Vec<T,A>::extend_desugared::hfb79990ed19f1c40
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:3791:44
  30:     0x55fde23383a7 - <alloc::vec::Vec<T,A> as alloc::vec::spec_extend::SpecExtend<T,I>>::spec_extend::h824f67dff20edb49
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/spec_extend.rs:19:14
  31:     0x55fde230bf30 - <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter::he9c52c8b1fec99be
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/spec_from_iter_nested.rs:42:9
  32:     0x55fde2339e9e - <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter::hb6662ed60b61514f
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/spec_from_iter.rs:34:9
  33:     0x55fde2337411 - <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter::hed602172b7885dea
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:3683:9
  34:     0x55fde244604b - core::iter::traits::iterator::Iterator::collect::h6c66ce9e1043d1bc
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2027:9
  35:     0x55fde22204e1 - <core::result::Result<V,E> as core::iter::traits::collect::FromIterator<core::result::Result<A,E>>>::from_iter::{{closure}}::h3a9e6a5b9ffa484e
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs:2143:51
  36:     0x55fde2447557 - core::iter::adapters::try_process::h804c6260ca47b48a
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/mod.rs:160:17
  37:     0x55fde22200f7 - <core::result::Result<V,E> as core::iter::traits::collect::FromIterator<core::result::Result<A,E>>>::from_iter::h3cb3163f92bac3d8
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs:2143:9
  38:     0x55fde25b4714 - core::iter::traits::iterator::Iterator::collect::heac11d78f9687627
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2027:9
  39:     0x55fde275d1ec - <prusti_encoder::encoders::ty::generics::args_ty::GArgsTyEnc as task_encoder::TaskEncoder>::do_encode_full::hf386052e77ec9846
                               at /home/richard/progs/prusti-dev/prusti-encoder/src/encoders/ty/generics/args_ty.rs:56:14
  40:     0x55fde2360a00 - task_encoder::TaskEncoder::encode::{{closure}}::h708c4a37198dcf1c
                               at /home/richard/progs/prusti-dev/task-encoder/src/lib.rs:279:33
  41:     0x55fde224acc5 - core::ops::function::FnOnce::call_once::h17960130c3ca98e5
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:253:5
  42:     0x55fde25a53ed - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h23c138b50dbfb3ff
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:274:9
  43:     0x55fde2744401 - std::panicking::catch_unwind::do_call::h067500b06cc64bf4
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:590:40
  44:     0x55fde27443ab - __rust_try
  45:     0x55fde2743c72 - std::panicking::catch_unwind::h223460a978a9c9f6
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:553:19
  46:     0x55fde2743c72 - std::panic::catch_unwind::ha6da8e14f9a2d8a6
                               at /home/richard/.rustup/toolchains/nightly-2025-09-04-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
  47:     0x55fde25cbe81 - task_encoder::TaskEncoder::encode::h3340f021499600ff
                               at /home/richard/progs/prusti-dev/task-encoder/src/lib.rs:277:28
  48:     0x55fde26abf50 - task_encoder::dependencies::TaskEncoderDependencies<E>::require_dep::hd2e8b5f28169b71b
                               at /home/richard/progs/prusti-dev/task-encoder/src/dependencies.rs:117:13
  49:     0x55fde25d2cb7 - <prusti_encoder::encoders::ty::generics::trait_impls::TraitImplEnc as task_encoder::TaskEncoder>::do_encode_full::{{closure}}::h8e4508345a3eb808
```

This PR fixes the issue by creating the `args` from the impl item context instead of the trait item context which has the correct indices.

## TODO

- [x] run on doctests