### PR TITLE
Fix missing caller substitution in `apply_wands`

### DIFF
--- a/prusti-encoder/src/encoders/impure/fn_wand.rs
+++ b/prusti-encoder/src/encoders/impure/fn_wand.rs
@@ -45,7 +45,9 @@ impl<'vir, E: TaskEncoder> ImpureEncVisitor<'vir, '_, E> {
         let args = PledgeExpr::pledge_args(result, args);
 
         for wand_data in self.wands.viper_wands() {
-            let Some(wand) = self.wands.mk_wand(&wand_data, args, None, self.vcx, self.deps)
+            let Some(wand) = self
+                .wands
+                .mk_wand(&wand_data, args, None, self.vcx, self.deps)
             else {
                 continue;
             };
@@ -271,13 +273,9 @@ impl<'vir> WandEncOutput<'vir> {
         });
         let args = PledgeExpr::pledge_args(result, args);
         for wand_data in self.viper_wands() {
-            let Some(wand) = self.mk_wand(
-                &wand_data,
-                args,
-                Some(call_ctx),
-                visitor.vcx,
-                visitor.deps,
-            ) else {
+            let Some(wand) =
+                self.mk_wand(&wand_data, args, Some(call_ctx), visitor.vcx, visitor.deps)
+            else {
                 continue;
             };
             visitor.stmt(visitor.vcx.mk_apply_stmt(wand));
@@ -294,13 +292,9 @@ impl<'vir> WandEncOutput<'vir> {
     ) -> Option<vir::Wand<'vir>> {
         debug_assert!(!wand_data.lhs.is_empty());
         let rhs = wand_data.rhs.iter().filter_map(|g| {
-            self.encode_predicates_for_function_shape_node(
-                vcx,
-                deps,
-                *g,
-                call_ctx,
-                |i| pledge_args[i],
-            )
+            self.encode_predicates_for_function_shape_node(vcx, deps, *g, call_ctx, |i| {
+                pledge_args[i]
+            })
         });
         let rhs = rhs
             .chain(
@@ -318,13 +312,9 @@ impl<'vir> WandEncOutput<'vir> {
         }
         let rhs = vcx.mk_conj(&rhs);
         let lhs = wand_data.lhs.iter().filter_map(|g| {
-            self.encode_predicates_for_function_shape_node(
-                vcx,
-                deps,
-                *g,
-                call_ctx,
-                |i| pledge_args[i],
-            )
+            self.encode_predicates_for_function_shape_node(vcx, deps, *g, call_ctx, |i| {
+                pledge_args[i]
+            })
         });
         let lhs = lhs
             .chain(

--- a/prusti-encoder/src/encoders/impure/fn_wand.rs
+++ b/prusti-encoder/src/encoders/impure/fn_wand.rs
@@ -45,7 +45,8 @@ impl<'vir, E: TaskEncoder> ImpureEncVisitor<'vir, '_, E> {
         let args = PledgeExpr::pledge_args(result, args);
 
         for wand_data in self.wands.viper_wands() {
-            let Some(wand) = self.wands.mk_wand(&wand_data, args, self.vcx, self.deps) else {
+            let Some(wand) = self.wands.mk_wand(&wand_data, args, None, self.vcx, self.deps)
+            else {
                 continue;
             };
             let mut package_script = Vec::new();
@@ -89,6 +90,10 @@ impl<'vir, E: TaskEncoder> ImpureEncVisitor<'vir, '_, E> {
 
 type EncodedPledges<'vir> = Vec<EncodedPledge<'vir>>;
 
+/// Not tied to a caller or callee context. `indirect_pres`, `indirect_posts`,
+/// `wand_posts`, and `package_wands` are identity-substituted and intended for
+/// use in the callee's own contract; `apply_wands` is for caller use and
+/// re-substitutes via a [`WandCallContext`].
 #[derive(Clone)]
 pub struct WandEncOutput<'vir> {
     /// Information about the corresponding function.
@@ -106,17 +111,43 @@ pub struct WandEncOutput<'vir> {
     wands: Vec<WandData<'vir>>,
 }
 
+/// Substitution context for instantiating a wand at a call site. When `None`,
+/// the wand is encoded using the callee's identity substitution (appropriate
+/// when emitting wands inside the function being defined). When `Some`, the
+/// wand is re-encoded with the call-site substitutions and the caller's
+/// generic parameters, so that placeholders like `Self` or other callee
+/// generics are replaced by concrete types from the caller's perspective.
+#[derive(Clone, Copy)]
+pub struct WandCallContext<'vir> {
+    pub caller_substs: ty::GenericArgsRef<'vir>,
+    pub caller_g_params: GParams<'vir>,
+}
+
 impl<'vir> WandEncOutput<'vir> {
-    pub(crate) fn fn_sig(&self, vcx: &'vir vir::VirCtxt<'vir>) -> ty::FnSig<'vir> {
-        self.function_data.identity_fn_sig(vcx.tcx())
+    pub(crate) fn fn_sig(
+        &self,
+        vcx: &'vir vir::VirCtxt<'vir>,
+        call_ctx: Option<WandCallContext<'vir>>,
+    ) -> ty::FnSig<'vir> {
+        match call_ctx {
+            Some(ctx) => self.function_data.fn_sig(vcx.tcx(), ctx.caller_substs),
+            None => self.function_data.identity_fn_sig(vcx.tcx()),
+        }
     }
 
-    pub(crate) fn g_params(&self, vcx: &'vir vir::VirCtxt<'vir>) -> GParams<'vir> {
-        GParams::new(
-            self.function_data.identity_substs(vcx.tcx()),
-            self.function_data.param_env(vcx.tcx()),
-            false,
-        )
+    pub(crate) fn g_params(
+        &self,
+        vcx: &'vir vir::VirCtxt<'vir>,
+        call_ctx: Option<WandCallContext<'vir>>,
+    ) -> GParams<'vir> {
+        match call_ctx {
+            Some(ctx) => ctx.caller_g_params,
+            None => GParams::new(
+                self.function_data.identity_substs(vcx.tcx()),
+                self.function_data.param_env(vcx.tcx()),
+                false,
+            ),
+        }
     }
 
     fn encode_predicates_for_function_shape_node(
@@ -124,13 +155,13 @@ impl<'vir> WandEncOutput<'vir> {
         vcx: &'vir vir::VirCtxt<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, impl TaskEncoder>,
         g: impl Into<FunctionShapeNode<Generalized>>,
+        call_ctx: Option<WandCallContext<'vir>>,
         mut snap: impl FnMut(mir::Local) -> vir::ExprSnap<'vir>,
     ) -> Option<vir::ExprBool<'vir>> {
         use vir::Reify;
         let g = g.into();
-        let fn_sig = self.fn_sig(vcx);
-        let arg_ty = g.ty(fn_sig);
-        let decomp = RustTyDecomposition::from_ty(arg_ty, self.g_params(vcx));
+        let arg_ty = g.ty(self.fn_sig(vcx, call_ctx));
+        let decomp = RustTyDecomposition::from_ty(arg_ty, self.g_params(vcx, call_ctx));
         let region_proj =
             projection_for_generalized_idx(arg_ty, g.region_idx(), decomp, vcx.tcx())?;
         let predicates = deps
@@ -161,7 +192,7 @@ impl<'vir> WandEncOutput<'vir> {
         deps: &'a mut TaskEncoderDependencies<'vir, E>,
     ) -> impl Iterator<Item = vir::ExprBool<'vir>> + 'a {
         self.inputs().filter_map(|g| {
-            self.encode_predicates_for_function_shape_node(vcx, deps, g, |i| {
+            self.encode_predicates_for_function_shape_node(vcx, deps, g, None, |i| {
                 local_defs[i].impure_snap
             })
         })
@@ -182,7 +213,7 @@ impl<'vir> WandEncOutput<'vir> {
             .inputs()
             .filter(|i| !self.blocked_inputs().contains(i))
             .filter_map(|lp| {
-                self.encode_predicates_for_function_shape_node(vcx, deps, lp, |i| {
+                self.encode_predicates_for_function_shape_node(vcx, deps, lp, None, |i| {
                     vcx.mk_old_expr(local_defs[i].impure_snap)
                 })
             })
@@ -190,7 +221,7 @@ impl<'vir> WandEncOutput<'vir> {
             .into_iter();
 
         let output_posts = self.outputs().filter_map(|g| {
-            self.encode_predicates_for_function_shape_node(vcx, deps, g, |i| {
+            self.encode_predicates_for_function_shape_node(vcx, deps, g, None, |i| {
                 local_defs[i].impure_snap
             })
         });
@@ -213,7 +244,7 @@ impl<'vir> WandEncOutput<'vir> {
 
         // TODO: wands for late-bound regions
         self.viper_wands().into_iter().filter_map(move |wand_data| {
-            let wand = self.mk_wand(&wand_data, args, vcx, deps)?;
+            let wand = self.mk_wand(&wand_data, args, None, vcx, deps)?;
             Some(vcx.mk_let_expr(
                 wand_result,
                 local_defs[mir::RETURN_PLACE].impure_snap,
@@ -227,6 +258,7 @@ impl<'vir> WandEncOutput<'vir> {
         arguments: &[vir::ExprSnap<'vir>],
         label_pre: &'vir str,
         label_post: &'vir str,
+        call_ctx: WandCallContext<'vir>,
         visitor: &mut ImpureEncVisitor<'vir, '_, E>,
     ) {
         let result = visitor
@@ -239,7 +271,13 @@ impl<'vir> WandEncOutput<'vir> {
         });
         let args = PledgeExpr::pledge_args(result, args);
         for wand_data in self.viper_wands() {
-            let Some(wand) = self.mk_wand(&wand_data, args, visitor.vcx, visitor.deps) else {
+            let Some(wand) = self.mk_wand(
+                &wand_data,
+                args,
+                Some(call_ctx),
+                visitor.vcx,
+                visitor.deps,
+            ) else {
                 continue;
             };
             visitor.stmt(visitor.vcx.mk_apply_stmt(wand));
@@ -250,12 +288,19 @@ impl<'vir> WandEncOutput<'vir> {
         &'a self,
         wand_data: &WandData<'vir>,
         pledge_args: PledgeArgs<'vir>,
+        call_ctx: Option<WandCallContext<'vir>>,
         vcx: &'vir vir::VirCtxt<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, E>,
     ) -> Option<vir::Wand<'vir>> {
         debug_assert!(!wand_data.lhs.is_empty());
         let rhs = wand_data.rhs.iter().filter_map(|g| {
-            self.encode_predicates_for_function_shape_node(vcx, deps, *g, |i| pledge_args[i])
+            self.encode_predicates_for_function_shape_node(
+                vcx,
+                deps,
+                *g,
+                call_ctx,
+                |i| pledge_args[i],
+            )
         });
         let rhs = rhs
             .chain(
@@ -273,7 +318,13 @@ impl<'vir> WandEncOutput<'vir> {
         }
         let rhs = vcx.mk_conj(&rhs);
         let lhs = wand_data.lhs.iter().filter_map(|g| {
-            self.encode_predicates_for_function_shape_node(vcx, deps, *g, |i| pledge_args[i])
+            self.encode_predicates_for_function_shape_node(
+                vcx,
+                deps,
+                *g,
+                call_ctx,
+                |i| pledge_args[i],
+            )
         });
         let lhs = lhs
             .chain(

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -56,7 +56,7 @@ use crate::encoders::{
     },
 };
 
-use super::WandEncOutput;
+use super::{WandCallContext, WandEncOutput};
 
 #[derive(Clone, Copy)]
 struct FromToVar<'vir> {
@@ -777,7 +777,10 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 let terminator = bb.terminator.as_ref().unwrap();
                 match &terminator.kind {
                     mir::TerminatorKind::Call {
-                        args, destination, ..
+                        func,
+                        args,
+                        destination,
+                        ..
                     } => {
                         let (_, dest_snap, _, _) =
                             self.encode_place_with_snap((*destination).into());
@@ -788,7 +791,14 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                                 }))
                                 .collect::<Result<Vec<_>, EncodeFullError<'vir, E>>>()?;
                         let (label_pre, label_post) = self.call_labels[&call.location().block];
-                        wands.apply_wands(&wand_args, label_pre, label_post, self);
+                        let func_ty = func.ty(self.body, self.vcx.tcx());
+                        let (_, caller_substs) =
+                            RustSignature::get_def_id_and_caller_substs(func_ty);
+                        let call_ctx = WandCallContext {
+                            caller_substs,
+                            caller_g_params: GParams::from(self.def_id),
+                        };
+                        wands.apply_wands(&wand_args, label_pre, label_post, call_ctx, self);
                     }
                     _ => unreachable!(),
                 }

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -51,7 +51,7 @@ use crate::encoders::{
     },
 };
 
-use super::WandEncOutput;
+use super::{WandCallContext, WandEncOutput};
 
 #[derive(Clone, Copy)]
 struct FromToVar<'vir> {
@@ -769,7 +769,10 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 let terminator = bb.terminator.as_ref().unwrap();
                 match &terminator.kind {
                     mir::TerminatorKind::Call {
-                        args, destination, ..
+                        func,
+                        args,
+                        destination,
+                        ..
                     } => {
                         let (_, dest_snap, _, _) =
                             self.encode_place_with_snap((*destination).into());
@@ -780,7 +783,14 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                                 }))
                                 .collect::<Result<Vec<_>, EncodeFullError<'vir, E>>>()?;
                         let (label_pre, label_post) = self.call_labels[&call.location().block];
-                        wands.apply_wands(&wand_args, label_pre, label_post, self);
+                        let func_ty = func.ty(self.body, self.vcx.tcx());
+                        let (_, caller_substs) =
+                            RustSignature::get_def_id_and_caller_substs(func_ty);
+                        let call_ctx = WandCallContext {
+                            caller_substs,
+                            caller_g_params: GParams::from(self.def_id),
+                        };
+                        wands.apply_wands(&wand_args, label_pre, label_post, call_ctx, self);
                     }
                     _ => unreachable!(),
                 }

--- a/prusti-encoder/src/encoders/mod.rs
+++ b/prusti-encoder/src/encoders/mod.rs
@@ -15,7 +15,7 @@ pub mod custom;
 pub mod addr;
 
 pub use r#const::ConstEnc;
-pub use impure::fn_wand::{WandEnc, WandEncOutput, WandEncTask};
+pub use impure::fn_wand::{WandCallContext, WandEnc, WandEncOutput, WandEncTask};
 pub use local_def::*;
 pub use mir_builtin::{MirBuiltinEnc, MirBuiltinEncTask};
 pub use mir_fn::{FunctionCallEnc, MethodCallEnc, encode_all_in_crate};

--- a/prusti-tests/tests/v2/pass/borrows/generic_reborrow_callsite.rs
+++ b/prusti-tests/tests/v2/pass/borrows/generic_reborrow_callsite.rs
@@ -1,0 +1,7 @@
+fn reborrow<U>(x: &mut U) -> &mut U {
+    x
+}
+
+fn caller<T>(mut v: T) {
+    let _ = reborrow(&mut v);
+}


### PR DESCRIPTION
When applying a magic wand containing generic arguments, generic parameters were identity-substituted, leading to a "local variable not found in consistency check" error. Consider the following code snippet:

```rust
fn reborrow<U>(x: &mut U) -> &mut U {
    x
}

fn caller<T>(mut v: T) {
    let _ = reborrow(&mut v);
}
```

When the borrow expires, the following wand is applied in the caller:

```vpr
  apply acc(p_Param(old[post1](p_Ref_mutable_snap(_2p, T$0)).s_Ref_mutable_0,
    U$0), write) --*
    acc(p_Param(old[pre0](p_Ref_mutable_snap(_3p, T$0)).s_Ref_mutable_0, U$0), write)
```

Notice the `U$0` which has not been substituted.
This PR introduces caller substitution for `apply_wand`.
Running the doctests shows that this change eliminates this error category, see <https://prusti-stdlib-support.rgwohlbold.de/>.