### PR TITLE
Fix old expressions within pledges

### DIFF
--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -382,7 +382,7 @@ impl TaskEncoder for ConstEnc {
                         let args = Default::default();
                         Ok((
                             Vec::new(),
-                            expr.reify(vcx, (uneval.def, vcx.alloc(args))).downcast_ty(),
+                            expr.reify(vcx, (uneval.def, vcx.alloc(args), vir::OldLabel::None)).downcast_ty(),
                         ))
                     } else {
                         todo!("const too generic")

--- a/prusti-encoder/src/encoders/impure/fn_wand.rs
+++ b/prusti-encoder/src/encoders/impure/fn_wand.rs
@@ -47,7 +47,7 @@ impl<'vir, E: TaskEncoder> ImpureEncVisitor<'vir, '_, E> {
         for wand_data in self.wands.viper_wands() {
             let Some(wand) = self
                 .wands
-                .mk_wand(&wand_data, args, None, self.vcx, self.deps)
+                .mk_wand(&wand_data, args, None, None, self.vcx, self.deps)
             else {
                 continue;
             };
@@ -245,7 +245,7 @@ impl<'vir> WandEncOutput<'vir> {
 
         // TODO: wands for late-bound regions
         self.viper_wands().into_iter().filter_map(move |wand_data| {
-            let wand = self.mk_wand(&wand_data, args, None, vcx, deps)?;
+            let wand = self.mk_wand(&wand_data, args, None, None, vcx, deps)?;
             Some(vcx.mk_let_expr(
                 wand_result,
                 local_defs[mir::RETURN_PLACE].impure_snap,
@@ -273,7 +273,7 @@ impl<'vir> WandEncOutput<'vir> {
         let args = PledgeExpr::pledge_args(result, args);
         for wand_data in self.viper_wands() {
             let Some(wand) =
-                self.mk_wand(&wand_data, args, Some(call_ctx), visitor.vcx, visitor.deps)
+                self.mk_wand(&wand_data, args, Some(label_pre), Some(call_ctx), visitor.vcx, visitor.deps)
             else {
                 continue;
             };
@@ -285,10 +285,21 @@ impl<'vir> WandEncOutput<'vir> {
         &self,
         wand_data: &WandData<'vir>,
         pledge_args: PledgeArgs<'vir>,
+        pledge_old_label: Option<&'vir str>,
         call_ctx: WandCallContext<'vir>,
         vcx: &'vir vir::VirCtxt<'vir>,
         deps: &mut TaskEncoderDependencies<'vir, E>,
     ) -> Option<vir::Wand<'vir>> {
+        let pledge_expr = |p: &EncodedPledge<'vir>| match pledge_old_label {
+            Some(label) => p.expiry_postcondition.expr_at_label(pledge_args, label),
+            None => p.expiry_postcondition.expr(pledge_args),
+        };
+        let obligation_expr = |p: &EncodedPledge<'vir>| match pledge_old_label {
+            Some(label) => p
+                .expiry_obligation
+                .map(|o| o.expr_at_label(pledge_args, label)),
+            None => p.expiry_obligation.map(|o| o.expr(pledge_args)),
+        };
         debug_assert!(!wand_data.lhs.is_empty());
         let rhs = wand_data.rhs.iter().filter_map(|g| {
             self.encode_predicates_for_function_shape_node(vcx, deps, *g, call_ctx, |i| {
@@ -296,12 +307,7 @@ impl<'vir> WandEncOutput<'vir> {
             })
         });
         let rhs = rhs
-            .chain(
-                wand_data
-                    .pledges
-                    .iter()
-                    .map(|pledge| pledge.expiry_postcondition.expr(pledge_args)),
-            )
+            .chain(wand_data.pledges.iter().map(pledge_expr))
             .collect::<Vec<_>>();
         if rhs.is_empty() {
             // We skip emitting the wand when there is nothing on the RHS, i.e.,
@@ -316,13 +322,7 @@ impl<'vir> WandEncOutput<'vir> {
             })
         });
         let lhs = lhs
-            .chain(
-                wand_data
-                    .pledges
-                    .iter()
-                    .filter_map(|pledge| pledge.expiry_obligation)
-                    .map(|expr| expr.expr(pledge_args)),
-            )
+            .chain(wand_data.pledges.iter().filter_map(obligation_expr))
             .collect::<Vec<_>>();
         let lhs = vcx.mk_conj(&lhs);
         Some(vcx.mk_wand(lhs, rhs))

--- a/prusti-encoder/src/encoders/mir_fn/function.rs
+++ b/prusti-encoder/src/encoders/mir_fn/function.rs
@@ -198,7 +198,7 @@ impl TaskEncoder for FunctionEnc {
                     gargs: params.identity_args(),
                 }) {
                     Ok(out) => {
-                        let expr = out.expr.reify(vcx, (def_id, spec.pre_args));
+                        let expr = out.expr.reify(vcx, (def_id, spec.pre_args, vir::OldLabel::None));
                         assert!(
                             expr.ty() == return_type,
                             "expected {:?}, got {:?}",

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -1577,7 +1577,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             .collect();
         let expr = enc_output
             .expr
-            .reify(self.vcx, (self.def_id, self.vcx.alloc(locals)))
+            .reify(self.vcx, (self.def_id, self.vcx.alloc(locals), vir::OldLabel::None))
             .downcast_ty();
         Ok(expr)
     }

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -34,7 +34,7 @@ pub enum MirPureEncError {
     // UnsupportedTerminator,
 }
 
-pub type ExprInput<'vir> = (DefId, &'vir FxHashMap<mir::Local, vir::ExprSnap<'vir>>);
+pub type ExprInput<'vir> = (DefId, &'vir FxHashMap<mir::Local, vir::ExprSnap<'vir>>, vir::OldLabel<'vir>);
 type ExprRet<'vir> = vir::ExprGenSnap<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>;
 type ExprRetRef<'vir> = vir::ExprGenRef<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>;
 type ExprRetAny<'vir, T> = vir::ExprGen<'vir, ExprInput<'vir>, vir::ExprKind<'vir>, T>;
@@ -1199,7 +1199,16 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
 
         if should_wrap {
             if self.old_mode {
-                encoded_place.snap = self.vcx.mk_old_expr(encoded_place.snap);
+                let inner = encoded_place.snap;
+                encoded_place.snap = self.vcx.mk_lazy_expr(
+                    vir::vir_format!(self.vcx, "old_mode_wrap"),
+                    inner.ty(),
+                    Box::new(move |vcx, lctx: ExprInput<'vir>| {
+                        use vir::Reify;
+                        let reified = inner.reify(vcx, lctx);
+                        vcx.mk_old(reified, lctx.2).kind
+                    }),
+                );
             }
             if self.rel0_mode {
                 encoded_place.snap = self.vcx.mk_rel_expr(encoded_place.snap, 0);
@@ -1289,7 +1298,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
                 gargs: GParams::from(cl_def_id).identity_args(),
             })?
             .expr
-            .reify(self.vcx, (cl_def_id, self.vcx.alloc(reify_args)))
+            .reify(self.vcx, (cl_def_id, self.vcx.alloc(reify_args), vir::OldLabel::None))
             .lift();
         Ok((qvars, body.downcast_ty::<vir::Bool>()))
     }

--- a/prusti-encoder/src/encoders/pure/spec.rs
+++ b/prusti-encoder/src/encoders/pure/spec.rs
@@ -70,7 +70,17 @@ impl<'vir> PledgeExpr<'vir> {
     }
 
     pub fn expr(&self, args: PledgeArgs<'vir>) -> vir::ExprBool<'vir> {
-        vir::with_vcx(|vcx| self.expr.reify(vcx, (self.did, args.0)))
+        vir::with_vcx(|vcx| {
+            self.expr
+                .reify(vcx, (self.did, args.0, vir::OldLabel::None))
+        })
+    }
+
+    pub fn expr_at_label(&self, args: PledgeArgs<'vir>, label: &'vir str) -> vir::ExprBool<'vir> {
+        vir::with_vcx(|vcx| {
+            self.expr
+                .reify(vcx, (self.did, args.0, vir::OldLabel::Label(label)))
+        })
     }
 
     pub fn span(&self) -> Span {
@@ -227,7 +237,7 @@ impl TaskEncoder for MirSpecEnc {
                 .filter_map(|spec_def_id| {
                     let spec = Self::encode_pure(vcx, deps, ctx, *spec_def_id, "precondition")?;
                     let expr = spec.expr.downcast_ty::<vir::Bool>();
-                    let expr = expr.reify(vcx, (*spec_def_id, pre_args));
+                    let expr = expr.reify(vcx, (*spec_def_id, pre_args, vir::OldLabel::None));
                     let span = vcx.tcx().def_span(*spec_def_id);
                     Some((vcx.with_span(span, |_| expr), span))
                 })
@@ -262,7 +272,7 @@ impl TaskEncoder for MirSpecEnc {
                             )])
                         });
                         let expr = spec.expr.downcast_ty::<vir::Bool>();
-                        let expr = expr.reify(vcx, (*spec_def_id, post_args));
+                        let expr = expr.reify(vcx, (*spec_def_id, post_args, vir::OldLabel::None));
                         Some((expr, span))
                     })
                 })

--- a/prusti-tests/tests/verify/pass/magic-wands/old-in-pledge.rs
+++ b/prusti-tests/tests/verify/pass/magic-wands/old-in-pledge.rs
@@ -1,0 +1,27 @@
+use prusti_contracts::*;
+
+fn main() {
+    let mut x = 6;
+    let mut y = 3;
+    let a = return_larger(&mut x, &mut y);
+    *a = 8;
+    assert!(x == 8);
+    //assert!(y == 3);
+
+    let mut x = 6;
+    let mut y = 10;
+    let a = return_larger(&mut x, &mut y);
+    *a = 8;
+    //assert!(x == 6);
+    assert!(y == 8);
+}
+
+#[after_expiry(old(*x) > old(*y) ==> before_expiry(*result) == *x /* && old(*y) == *y */)]
+#[after_expiry(old(*x) <= old(*y) ==> before_expiry(*result) == *y /* && old(*x) == *x */)]
+fn return_larger<'a>(x: &'a mut i32, y: &'a mut i32) -> &'a mut i32 {
+    if *x > *y {
+        &mut (*x)
+    } else {
+        &mut (*y)
+    }
+}


### PR DESCRIPTION
This PR fixes the use of old expressions within pledges. 

The following test case now verifies:

```rust
fn exampleu6() {
    let mut x = 6;
    let mut y = 3;
    let a = return_larger(&mut x, &mut y);
    *a = 8;
    assert!(x == 8);
    //assert!(y == 3);

    let mut x = 6;
    let mut y = 10;
    let a = return_larger(&mut x, &mut y);
    *a = 8;
    //assert!(x == 6);
    assert!(y == 8);
}

#[after_expiry(old(*x) > old(*y) ==> before_expiry(*result) == *x /* && old(*y) == *y */)]
#[after_expiry(old(*x) <= old(*y) ==> before_expiry(*result) == *y /* && old(*x) == *x */)]
fn return_larger<'a>(x: &'a mut i32, y: &'a mut i32) -> &'a mut i32 {
    if *x > *y {
        &mut (*x)
    } else {
        &mut (*y)
    }
}
```

The previously unsupported parts are the `old(*x) > old(*y)` and `old(*x) <= old(*y)` parts within the `after_expiry`. Note that the commented out parts still do not work because of some permission error and require another PR.