### PR TITLE
Int support

### DIFF
--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -167,7 +167,7 @@ mod private {
 
     #[pure]
     pub fn prusti_terminates_trusted() -> Int {
-        Int::new(1)
+        Int::from(1)
     }
 
     /// a mathematical (unbounded) integer type

--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -175,16 +175,6 @@ mod private {
     #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Int(());
 
-    impl Int {
-        pub fn new(_: i64) -> Self {
-            panic!()
-        }
-
-        pub fn new_usize(_: usize) -> Self {
-            panic!()
-        }
-    }
-
     macro_rules! __int_dummy_trait_impls__ {
         ($($trait:ident $fun:ident),*) => {$(
             impl core::ops::$trait for Int {

--- a/prusti-contracts/prusti-contracts/src/lib.rs
+++ b/prusti-contracts/prusti-contracts/src/lib.rs
@@ -212,6 +212,36 @@ mod private {
         };
     }
 
+    impl From<i16> for Int {
+        fn from(_: i16) -> Self {
+            panic!();
+        }
+    }
+
+    impl From<i32> for Int {
+        fn from(_: i32) -> Self {
+            panic!();
+        }
+    }
+
+    impl From<i64> for Int {
+        fn from(_: i64) -> Self {
+            panic!();
+        }
+    }
+
+    impl From<i128> for Int {
+        fn from(_: i128) -> Self {
+            panic!();
+        }
+    }
+
+    impl From<usize> for Int {
+        fn from(_: usize) -> Self {
+            panic!();
+        }
+    }
+
     impl Neg for Int {
         type Output = Self;
         fn neg(self) -> Self {
@@ -221,6 +251,22 @@ mod private {
 
     impl PartialOrd for Int {
         fn partial_cmp(&self, _other: &Self) -> Option<core::cmp::Ordering> {
+            panic!()
+        }
+
+        fn lt(&self, _: &Self) -> bool {
+            panic!()
+        }
+
+        fn le(&self, _: &Self) -> bool {
+            panic!()
+        }
+
+        fn gt(&self, _: &Self) -> bool {
+            panic!()
+        }
+
+        fn ge(&self, _: &Self) -> bool {
             panic!()
         }
     }

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -5,7 +5,6 @@ use crate::encoders::{
     ty::{
         RustTyDecomposition,
         generics::GParams,
-        interpretation::real::TyRealLocal,
         use_pure::{TyUsePure, TyUsePureEnc},
     },
 };
@@ -29,6 +28,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::fmt;
 use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 use vir::{CastType, CompType, add_debug_note};
+
+use super::ty::interpretation::TyPrimLocal;
 
 pub struct MirPureEnc;
 
@@ -374,7 +375,16 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         self.deps.require_dep::<TyUsePureEnc>(ty_task).unwrap()
     }
 
-    fn ty_use_real(&mut self) -> &'vir TyRealLocal<'vir> {
+    fn ty_use_int(&mut self) -> &'vir TyPrimLocal<'vir, vir::Int> {
+        let ty_task = RustTyDecomposition::from_int();
+        self.deps
+            .require_dep::<TyUsePureEnc>(ty_task)
+            .unwrap()
+            .expect_builtin()
+            .expect_int()
+    }
+
+    fn ty_use_real(&mut self) -> &'vir TyPrimLocal<'vir, vir::Perm> {
         let ty_task = RustTyDecomposition::from_real();
         self.deps
             .require_dep::<TyUsePureEnc>(ty_task)
@@ -1210,6 +1220,42 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         encoded_place
     }
 
+    fn encode_builtin_num_neg<T: CompType>(
+        &mut self,
+        num: &TyPrimLocal<'vir, T>,
+        args: &[Spanned<mir::Operand<'vir>>],
+        curr_ver: &FxHashMap<mir::Local, Version<'vir>>,
+    ) -> Result<
+        vir::ExprGenCSnap<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>,
+        EncodeFullError<'vir, MirPureEnc>,
+    >
+    where
+        vir::Prim: vir::TransmuteFrom<T>,
+    {
+        let num_val = num.snap_to_prim.call()(
+            self.encode_operand_snap(&args[0].node, curr_ver)?
+                .downcast_ty(),
+        );
+        Ok(num.prim_to_snap.call()(
+            self.vcx
+                .mk_unary_op_expr(vir::UnOpKind::Neg, num_val.upcast_ty())
+                .downcast_ty(),
+        ))
+    }
+
+    fn encode_int_op(
+        &mut self,
+        bin_op: vir::BinOpKind,
+        args: &[Spanned<mir::Operand<'vir>>],
+        curr_ver: &FxHashMap<mir::Local, Version<'vir>>,
+    ) -> Result<
+        vir::ExprGenCSnap<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>,
+        EncodeFullError<'vir, MirPureEnc>,
+    > {
+        let int = self.ty_use_int();
+        self.encode_builtin_num_op(int, bin_op, args, curr_ver)
+    }
+
     fn encode_real_op(
         &mut self,
         bin_op: vir::BinOpKind,
@@ -1220,17 +1266,46 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         EncodeFullError<'vir, MirPureEnc>,
     > {
         let real = self.ty_use_real();
-        let real1 = real.snap_to_perm.call()(
+        self.encode_builtin_num_op(real, bin_op, args, curr_ver)
+    }
+
+    fn encode_builtin_num_op<T: CompType>(
+        &mut self,
+        num: &TyPrimLocal<'vir, T>,
+        bin_op: vir::BinOpKind,
+        args: &[Spanned<mir::Operand<'vir>>],
+        curr_ver: &FxHashMap<mir::Local, Version<'vir>>,
+    ) -> Result<
+        vir::ExprGenCSnap<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>,
+        EncodeFullError<'vir, MirPureEnc>,
+    >
+    where
+        vir::Prim: vir::TransmuteFrom<T>,
+    {
+        let num1 = num.snap_to_prim.call()(
             self.encode_operand_snap(&args[0].node, curr_ver)?
                 .downcast_ty(),
         );
-        let real2 = real.snap_to_perm.call()(
+        let num2 = num.snap_to_prim.call()(
             self.encode_operand_snap(&args[1].node, curr_ver)?
                 .downcast_ty(),
         );
-        Ok(real.perm_to_snap.call()(
-            self.vcx.mk_bin_op_expr(bin_op, real1, real2).downcast_ty(),
+        Ok(num.prim_to_snap.call()(
+            self.vcx.mk_bin_op_expr(bin_op, num1, num2).downcast_ty(),
         ))
+    }
+
+    fn encode_int_cmp(
+        &mut self,
+        bin_op: vir::BinOpKind,
+        args: &[Spanned<mir::Operand<'vir>>],
+        curr_ver: &FxHashMap<mir::Local, Version<'vir>>,
+    ) -> Result<
+        vir::ExprGenCSnap<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>,
+        EncodeFullError<'vir, MirPureEnc>,
+    > {
+        let int = self.ty_use_int();
+        self.encode_builtin_num_cmp(int, bin_op, args, curr_ver)
     }
 
     fn encode_real_cmp(
@@ -1243,32 +1318,45 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         EncodeFullError<'vir, MirPureEnc>,
     > {
         let real = self.ty_use_real();
+        self.encode_builtin_num_cmp(real, bin_op, args, curr_ver)
+    }
+
+    fn encode_builtin_num_cmp<T: CompType>(
+        &mut self,
+        num: &TyPrimLocal<'vir, T>,
+        bin_op: vir::BinOpKind,
+        args: &[Spanned<mir::Operand<'vir>>],
+        curr_ver: &FxHashMap<mir::Local, Version<'vir>>,
+    ) -> Result<
+        vir::ExprGenCSnap<'vir, ExprInput<'vir>, vir::ExprKind<'vir>>,
+        EncodeFullError<'vir, MirPureEnc>,
+    > {
         let bool = self.ty_use(self.vcx.tcx().types.bool);
         let bool = bool.expect_primitive();
         let a0_ty = args[0].node.ty(self.body, self.vcx.tcx());
-        let real1 = self
+        let num1 = self
             .encode_operand_snap(&args[0].node, curr_ver)?
             .downcast_ty();
-        let real1_deref = real.snap_to_perm.call()(
+        let num1_deref = num.snap_to_prim.call()(
             self.ty_use(a0_ty)
                 .expect_immref()
-                .value_access(real1)
+                .value_access(num1)
                 .downcast_ty(),
         );
 
         let a1_ty = args[1].node.ty(self.body, self.vcx.tcx());
-        let real2 = self
+        let num2 = self
             .encode_operand_snap(&args[1].node, curr_ver)?
             .downcast_ty();
-        let real2_deref = real.snap_to_perm.call()(
+        let num2_deref = num.snap_to_prim.call()(
             self.ty_use(a1_ty)
                 .expect_immref()
-                .value_access(real2)
+                .value_access(num2)
                 .downcast_ty(),
         );
         Ok(bool.prim_to_snap.call()(
             self.vcx
-                .mk_bin_op_expr_inner(bin_op, real1_deref.as_dyn(), real2_deref.as_dyn())
+                .mk_bin_op_expr_inner(bin_op, num1_deref.as_dyn(), num2_deref.as_dyn())
                 .downcast_ty(),
         ))
     }
@@ -1292,6 +1380,18 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
             IsInfinite(ty::FloatTy),
             FlAbs(ty::FloatTy),
             FlToReal,
+            IntToInt,
+            IntMul,
+            IntEq,
+            IntSub,
+            IntAdd,
+            IntDiv,
+            IntRem,
+            IntNeg,
+            IntLt,
+            IntLe,
+            IntGt,
+            IntGe,
             RealMul,
             RealEq,
             RealSub,
@@ -1349,6 +1449,24 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
             (None, "f32_abs") => PrustiBuiltin::FlAbs(ty::FloatTy::F32),
             (None, "f64_abs") => PrustiBuiltin::FlAbs(ty::FloatTy::F64),
             (None, "f128_abs") => PrustiBuiltin::FlAbs(ty::FloatTy::F128),
+
+            // TODO deprecate these two
+            (Some("prusti_contracts::Int"), "new") => PrustiBuiltin::IntToInt,
+            (Some("prusti_contracts::Int"), "new_usize") => PrustiBuiltin::IntToInt,
+
+            (Some("prusti_contracts::Int"), "from") => PrustiBuiltin::IntToInt,
+            (Some("prusti_contracts::Int"), "mul") => PrustiBuiltin::IntMul,
+            (Some("prusti_contracts::Int"), "eq") => PrustiBuiltin::IntEq,
+            (Some("prusti_contracts::Int"), "sub") => PrustiBuiltin::IntSub,
+            (Some("prusti_contracts::Int"), "add") => PrustiBuiltin::IntAdd,
+            (Some("prusti_contracts::Int"), "div") => PrustiBuiltin::IntDiv,
+            (Some("prusti_contracts::Int"), "neg") => PrustiBuiltin::IntNeg,
+            (Some("prusti_contracts::Int"), "lt") => PrustiBuiltin::IntLt,
+            (Some("prusti_contracts::Int"), "le") => PrustiBuiltin::IntLe,
+            (Some("prusti_contracts::Int"), "gt") => PrustiBuiltin::IntGt,
+            (Some("prusti_contracts::Int"), "ge") => PrustiBuiltin::IntGe,
+            (Some("prusti_contracts::Int"), "rem") => PrustiBuiltin::IntRem,
+
             (Some("prusti_contracts::Real"), "from") => PrustiBuiltin::FlToReal,
             (Some("prusti_contracts::Real"), "mul") => PrustiBuiltin::RealMul,
             (Some("prusti_contracts::Real"), "eq") => PrustiBuiltin::RealEq,
@@ -1690,7 +1808,30 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
                     .encode_operand_snap(&args[0].node, curr_ver)?
                     .downcast_ty();
                 let res = fl_ty.fp_to_real.call()(fl);
-                self.ty_use_real().perm_to_snap.call()(res)
+                self.ty_use_real().prim_to_snap.call()(res)
+            }
+            PrustiBuiltin::IntToInt => {
+                let a_ty = args[0].node.ty(self.body, self.vcx.tcx());
+                let int_ty = self.ty_use(a_ty).expect_primitive();
+                let int = self
+                    .encode_operand_snap(&args[0].node, curr_ver)?
+                    .downcast_ty();
+                let res = int_ty.expect_native().snap_to_prim.call()(int).downcast_ty();
+                self.ty_use_int().prim_to_snap.call()(res)
+            }
+            PrustiBuiltin::IntMul => self.encode_int_op(vir::BinOpKind::Mul, args, curr_ver)?,
+            PrustiBuiltin::IntSub => self.encode_int_op(vir::BinOpKind::Sub, args, curr_ver)?,
+            PrustiBuiltin::IntAdd => self.encode_int_op(vir::BinOpKind::Add, args, curr_ver)?,
+            PrustiBuiltin::IntDiv => self.encode_int_op(vir::BinOpKind::Div, args, curr_ver)?,
+            PrustiBuiltin::IntRem => self.encode_int_op(vir::BinOpKind::Mod, args, curr_ver)?,
+            PrustiBuiltin::IntEq => self.encode_int_cmp(vir::BinOpKind::CmpEq, args, curr_ver)?,
+            PrustiBuiltin::IntLt => self.encode_int_cmp(vir::BinOpKind::CmpLt, args, curr_ver)?,
+            PrustiBuiltin::IntLe => self.encode_int_cmp(vir::BinOpKind::CmpLe, args, curr_ver)?,
+            PrustiBuiltin::IntGt => self.encode_int_cmp(vir::BinOpKind::CmpGt, args, curr_ver)?,
+            PrustiBuiltin::IntGe => self.encode_int_cmp(vir::BinOpKind::CmpGe, args, curr_ver)?,
+            PrustiBuiltin::IntNeg => {
+                let int = self.ty_use_int();
+                self.encode_builtin_num_neg(int, args, curr_ver)?
             }
             PrustiBuiltin::RealMul => self.encode_real_op(vir::BinOpKind::Mul, args, curr_ver)?,
             PrustiBuiltin::RealSub => self.encode_real_op(vir::BinOpKind::Sub, args, curr_ver)?,
@@ -1705,15 +1846,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
             PrustiBuiltin::RealGe => self.encode_real_cmp(vir::BinOpKind::CmpGe, args, curr_ver)?,
             PrustiBuiltin::RealNeg => {
                 let real = self.ty_use_real();
-                let real_val = real.snap_to_perm.call()(
-                    self.encode_operand_snap(&args[0].node, curr_ver)?
-                        .downcast_ty(),
-                );
-                real.perm_to_snap.call()(
-                    self.vcx
-                        .mk_unary_op_expr(vir::UnOpKind::Neg, real_val.upcast_ty())
-                        .downcast_ty(),
-                )
+                self.encode_builtin_num_neg(real, args, curr_ver)?
             }
         }
         .upcast_ty())

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -1220,7 +1220,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         encoded_place
     }
 
-    fn encode_builtin_num_neg<T: CompType>(
+    fn encode_prim_neg<T: CompType>(
         &mut self,
         num: &TyPrimLocal<'vir, T>,
         args: &[Spanned<mir::Operand<'vir>>],
@@ -1253,7 +1253,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         EncodeFullError<'vir, MirPureEnc>,
     > {
         let int = self.ty_use_int();
-        self.encode_builtin_num_op(int, bin_op, args, curr_ver)
+        self.encode_prim_op(int, bin_op, args, curr_ver)
     }
 
     fn encode_real_op(
@@ -1266,10 +1266,10 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         EncodeFullError<'vir, MirPureEnc>,
     > {
         let real = self.ty_use_real();
-        self.encode_builtin_num_op(real, bin_op, args, curr_ver)
+        self.encode_prim_op(real, bin_op, args, curr_ver)
     }
 
-    fn encode_builtin_num_op<T: CompType>(
+    fn encode_prim_op<T: CompType>(
         &mut self,
         num: &TyPrimLocal<'vir, T>,
         bin_op: vir::BinOpKind,
@@ -1305,7 +1305,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         EncodeFullError<'vir, MirPureEnc>,
     > {
         let int = self.ty_use_int();
-        self.encode_builtin_num_cmp(int, bin_op, args, curr_ver)
+        self.encode_prim_cmp(int, bin_op, args, curr_ver)
     }
 
     fn encode_real_cmp(
@@ -1318,10 +1318,10 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         EncodeFullError<'vir, MirPureEnc>,
     > {
         let real = self.ty_use_real();
-        self.encode_builtin_num_cmp(real, bin_op, args, curr_ver)
+        self.encode_prim_cmp(real, bin_op, args, curr_ver)
     }
 
-    fn encode_builtin_num_cmp<T: CompType>(
+    fn encode_prim_cmp<T: CompType>(
         &mut self,
         num: &TyPrimLocal<'vir, T>,
         bin_op: vir::BinOpKind,
@@ -1831,7 +1831,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
             PrustiBuiltin::IntGe => self.encode_int_cmp(vir::BinOpKind::CmpGe, args, curr_ver)?,
             PrustiBuiltin::IntNeg => {
                 let int = self.ty_use_int();
-                self.encode_builtin_num_neg(int, args, curr_ver)?
+                self.encode_prim_neg(int, args, curr_ver)?
             }
             PrustiBuiltin::RealMul => self.encode_real_op(vir::BinOpKind::Mul, args, curr_ver)?,
             PrustiBuiltin::RealSub => self.encode_real_op(vir::BinOpKind::Sub, args, curr_ver)?,
@@ -1846,7 +1846,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
             PrustiBuiltin::RealGe => self.encode_real_cmp(vir::BinOpKind::CmpGe, args, curr_ver)?,
             PrustiBuiltin::RealNeg => {
                 let real = self.ty_use_real();
-                self.encode_builtin_num_neg(real, args, curr_ver)?
+                self.encode_prim_neg(real, args, curr_ver)?
             }
         }
         .upcast_ty())

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -1222,7 +1222,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
 
     fn encode_prim_neg<T: CompType>(
         &mut self,
-        num: &TyPrimLocal<'vir, T>,
+        prim: &TyPrimLocal<'vir, T>,
         args: &[Spanned<mir::Operand<'vir>>],
         curr_ver: &FxHashMap<mir::Local, Version<'vir>>,
     ) -> Result<
@@ -1232,13 +1232,13 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
     where
         vir::Prim: vir::TransmuteFrom<T>,
     {
-        let num_val = num.snap_to_prim.call()(
+        let prim_val = prim.snap_to_prim.call()(
             self.encode_operand_snap(&args[0].node, curr_ver)?
                 .downcast_ty(),
         );
-        Ok(num.prim_to_snap.call()(
+        Ok(prim.prim_to_snap.call()(
             self.vcx
-                .mk_unary_op_expr(vir::UnOpKind::Neg, num_val.upcast_ty())
+                .mk_unary_op_expr(vir::UnOpKind::Neg, prim_val.upcast_ty())
                 .downcast_ty(),
         ))
     }
@@ -1271,7 +1271,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
 
     fn encode_prim_op<T: CompType>(
         &mut self,
-        num: &TyPrimLocal<'vir, T>,
+        prim: &TyPrimLocal<'vir, T>,
         bin_op: vir::BinOpKind,
         args: &[Spanned<mir::Operand<'vir>>],
         curr_ver: &FxHashMap<mir::Local, Version<'vir>>,
@@ -1282,16 +1282,16 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
     where
         vir::Prim: vir::TransmuteFrom<T>,
     {
-        let num1 = num.snap_to_prim.call()(
+        let prim1 = prim.snap_to_prim.call()(
             self.encode_operand_snap(&args[0].node, curr_ver)?
                 .downcast_ty(),
         );
-        let num2 = num.snap_to_prim.call()(
+        let prim2 = prim.snap_to_prim.call()(
             self.encode_operand_snap(&args[1].node, curr_ver)?
                 .downcast_ty(),
         );
-        Ok(num.prim_to_snap.call()(
-            self.vcx.mk_bin_op_expr(bin_op, num1, num2).downcast_ty(),
+        Ok(prim.prim_to_snap.call()(
+            self.vcx.mk_bin_op_expr(bin_op, prim1, prim2).downcast_ty(),
         ))
     }
 
@@ -1323,7 +1323,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
 
     fn encode_prim_cmp<T: CompType>(
         &mut self,
-        num: &TyPrimLocal<'vir, T>,
+        prim: &TyPrimLocal<'vir, T>,
         bin_op: vir::BinOpKind,
         args: &[Spanned<mir::Operand<'vir>>],
         curr_ver: &FxHashMap<mir::Local, Version<'vir>>,
@@ -1334,29 +1334,29 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         let bool = self.ty_use(self.vcx.tcx().types.bool);
         let bool = bool.expect_primitive();
         let a0_ty = args[0].node.ty(self.body, self.vcx.tcx());
-        let num1 = self
+        let prim1 = self
             .encode_operand_snap(&args[0].node, curr_ver)?
             .downcast_ty();
-        let num1_deref = num.snap_to_prim.call()(
+        let prim1_deref = prim.snap_to_prim.call()(
             self.ty_use(a0_ty)
                 .expect_immref()
-                .value_access(num1)
+                .value_access(prim1)
                 .downcast_ty(),
         );
 
         let a1_ty = args[1].node.ty(self.body, self.vcx.tcx());
-        let num2 = self
+        let prim2 = self
             .encode_operand_snap(&args[1].node, curr_ver)?
             .downcast_ty();
-        let num2_deref = num.snap_to_prim.call()(
+        let prim2_deref = prim.snap_to_prim.call()(
             self.ty_use(a1_ty)
                 .expect_immref()
-                .value_access(num2)
+                .value_access(prim2)
                 .downcast_ty(),
         );
         Ok(bool.prim_to_snap.call()(
             self.vcx
-                .mk_bin_op_expr_inner(bin_op, num1_deref.as_dyn(), num2_deref.as_dyn())
+                .mk_bin_op_expr_inner(bin_op, prim1_deref.as_dyn(), prim2_deref.as_dyn())
                 .downcast_ty(),
         ))
     }

--- a/prusti-encoder/src/encoders/ty/interpretation/int.rs
+++ b/prusti-encoder/src/encoders/ty/interpretation/int.rs
@@ -1,5 +1,5 @@
 use task_encoder::{EncodeFullError, TaskEncoderDependencies};
-use vir::{CastType, TYPE_PERM};
+use vir::{CastType, TYPE_INT};
 
 use crate::encoders::ty::{
     impure::{PredicateBuilder, TyImpureBuiltin, TyImpureEnc},
@@ -11,8 +11,8 @@ use super::TyPrimLocal;
 pub(crate) fn ty_pure<'vir>(
     builder: &mut AdtBuilder<'vir>,
 ) -> Result<TyPureBuiltinData<'vir>, EncodeFullError<'vir, TyPureEnc>> {
-    let (cons, vec) = builder.constructor("", TYPE_PERM, None);
-    Ok(TyPureBuiltinData::TyPureBuiltinReal(TyPrimLocal {
+    let (cons, vec) = builder.constructor("", TYPE_INT, None);
+    Ok(TyPureBuiltinData::TyPureBuiltinInt(TyPrimLocal {
         prim_to_snap: cons,
         snap_to_prim: vec.first().unwrap().downcast_ty(),
     }))

--- a/prusti-encoder/src/encoders/ty/interpretation/mod.rs
+++ b/prusti-encoder/src/encoders/ty/interpretation/mod.rs
@@ -1,3 +1,12 @@
+use vir::{AdtDestructorData, CompType, FunctionIdn};
+
 pub mod bitvec;
 pub mod float;
+pub mod int;
 pub mod real;
+
+#[derive(Debug, Clone, Copy)]
+pub struct TyPrimLocal<'vir, T: CompType> {
+    pub prim_to_snap: FunctionIdn<'vir, T, vir::CSnap>,
+    pub snap_to_prim: &'vir AdtDestructorData<'vir, vir::CSnap, T>,
+}

--- a/prusti-encoder/src/encoders/ty/kinds/builtin.rs
+++ b/prusti-encoder/src/encoders/ty/kinds/builtin.rs
@@ -2,7 +2,7 @@ use task_encoder::EncodeFullError;
 
 use crate::encoders::ty::{
     RustBuiltin, RustBuiltinData, impure,
-    interpretation::real,
+    interpretation::{int, real},
     pure::{AdtBuilder, TyPureBuiltin, TyPureEnc},
 };
 
@@ -11,6 +11,7 @@ pub(crate) fn ty_pure<'vir>(
     builder: &mut AdtBuilder<'vir>,
 ) -> Result<TyPureBuiltin<'vir>, EncodeFullError<'vir, TyPureEnc>> {
     match data {
+        RustBuiltinData::BuiltinInt => int::ty_pure(builder),
         RustBuiltinData::BuiltinReal => real::ty_pure(builder),
         RustBuiltinData::BuiltinGhost => {
             builder.constructor::<()>("", (), None);
@@ -25,6 +26,7 @@ pub(crate) fn ty_impure<'vir>(
     builder: &mut impure::PredicateBuilder<'vir>,
 ) -> Result<impure::TyImpureBuiltin<'vir>, EncodeFullError<'vir, impure::TyImpureEnc>> {
     match data.0 {
+        RustBuiltinData::BuiltinInt => int::ty_impure((), deps, builder),
         RustBuiltinData::BuiltinReal => real::ty_impure((), deps, builder),
         RustBuiltinData::BuiltinGhost => {
             super::opaque::set_opaque(builder);

--- a/prusti-encoder/src/encoders/ty/pure.rs
+++ b/prusti-encoder/src/encoders/ty/pure.rs
@@ -14,13 +14,13 @@ use vir::{
     DomainIdnSnap, FunctionIdn, Type,
 };
 
-use crate::encoders::{Pure, ty::interpretation::real};
+use crate::encoders::Pure;
 
 use super::{
     RustTy, ViperTyDatas,
     data::*,
     generics::{GenericParams, GenericParamsEnc},
-    interpretation::float::FloatDomain,
+    interpretation::{TyPrimLocal, float::FloatDomain},
 };
 
 pub(super) type PureTyDatas = ViperTyDatas<Pure>;
@@ -51,12 +51,20 @@ pub type TyPureBuiltin<'vir> = <PureTyDatas as TyDatas<'vir>>::BuiltinData;
 
 #[derive(Debug, Clone, Copy)]
 pub enum TyPureBuiltinData<'vir> {
-    TyPureBuiltinReal(real::TyRealLocal<'vir>),
+    TyPureBuiltinInt(TyPrimLocal<'vir, vir::Int>),
+    TyPureBuiltinReal(TyPrimLocal<'vir, vir::Perm>),
     TyPureBuiltinGhost,
 }
 
 impl<'vir> TyPureBuiltinData<'vir> {
-    pub fn expect_real(&'vir self) -> &'vir real::TyRealLocal<'vir> {
+    pub fn expect_int(&'vir self) -> &'vir TyPrimLocal<'vir, vir::Int> {
+        match &self {
+            TyPureBuiltinData::TyPureBuiltinInt(ty_int_local) => ty_int_local,
+            _ => panic!(),
+        }
+    }
+
+    pub fn expect_real(&'vir self) -> &'vir TyPrimLocal<'vir, vir::Perm> {
         match &self {
             TyPureBuiltinData::TyPureBuiltinReal(ty_real_local) => ty_real_local,
             _ => panic!(),

--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -62,6 +62,19 @@ impl<'tcx> RustTyDecomposition<'tcx> {
         TyData::<'tcx, RustTyDatas>::from_ty(ty, context.into())
     }
 
+    pub fn from_int() -> Self {
+        let data = RustTyData {
+            name: symbol::Symbol::intern("Int"),
+            params: GParams::empty(),
+        };
+        let specifics = TySpecifics::Builtin(RustBuiltinData::BuiltinInt);
+        Self::new(
+            TyData::<'tcx, RustTyDatas>::new(data, specifics).alloc(),
+            GArgs::new(GParams::empty(), &[]),
+            Some(true),
+        )
+    }
+
     pub fn from_real() -> Self {
         let data = RustTyData {
             name: symbol::Symbol::intern("Real"),
@@ -243,6 +256,9 @@ impl<'tcx> TyDatas<'tcx> for RustTyDatas {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RustBuiltinData {
+    // BuiltinSeq,
+    // BuiltinMap,
+    BuiltinInt,
     BuiltinReal,
     BuiltinGhost,
 }
@@ -679,6 +695,7 @@ impl<'tcx> TySpecifics<'tcx, RustTyDatas> {
             EnvQuery::new(vcx.tcx()).is_adt_in_crate(adt, "prusti_contracts")
         }) {
             match adt.non_enum_variant().name.to_string().as_str() {
+                "Int" => Self::Builtin(RustBuiltinData::BuiltinInt),
                 "Real" => Self::Builtin(RustBuiltinData::BuiltinReal),
                 "Ghost" => Self::Builtin(RustBuiltinData::BuiltinGhost),
                 s => panic!("Found unrecognized builtin {s}"),

--- a/prusti-encoder/src/encoders/ty/rust_ty.rs
+++ b/prusti-encoder/src/encoders/ty/rust_ty.rs
@@ -256,8 +256,6 @@ impl<'tcx> TyDatas<'tcx> for RustTyDatas {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RustBuiltinData {
-    // BuiltinSeq,
-    // BuiltinMap,
     BuiltinInt,
     BuiltinReal,
     BuiltinGhost,

--- a/prusti-tests/tests/verify/fail/termination3.rs
+++ b/prusti-tests/tests/verify/fail/termination3.rs
@@ -38,33 +38,33 @@ fn pure_fns_need_to_terminate() { //~ ERROR: Pure functions need to terminate
 #[terminates]
 fn valid_loop_variant(mut x: i64) {
     while x > 1 {
-        body_variant!(Int::new(x));
+        body_variant!(Int::from(x));
         x -= 1;
     }
 }
 
-#[terminates(Int::new(x))]
+#[terminates(Int::from(x))]
 fn valid_recursion(x: i64) {
     if x > 0 {
         valid_recursion(x - 1);
     }
 }
 
-#[terminates(Int::new(x))]
+#[terminates(Int::from(x))]
 fn valid_mutual_recursion1(x: i64) {
     if x > 0 {
         valid_mutual_recursion2(x - 1);
     }
 }
 
-#[terminates(Int::new(x))]
+#[terminates(Int::from(x))]
 fn valid_mutual_recursion2(x: i64) {
     if x > 0 {
         valid_mutual_recursion1(x - 1);
     }
 }
 
-#[terminates(Int::new(0))]
+#[terminates(Int::from(0))]
 fn may_have_acyclic_calls_with_increasing_termination_measure(x: i64) {
     valid_mutual_recursion1(x);
 }
@@ -72,10 +72,10 @@ fn may_have_acyclic_calls_with_increasing_termination_measure(x: i64) {
 #[terminates]
 fn valid_nested_loop(mut a: i64) {
     while a > 0 {
-        body_variant!(Int::new(a));
+        body_variant!(Int::from(a));
         let mut b = a;
         while b > 0 {
-            body_variant!(Int::new(b));
+            body_variant!(Int::from(b));
             b -= 1;
         }
         a -= 1;
@@ -85,7 +85,7 @@ fn valid_nested_loop(mut a: i64) {
 #[terminates]
 fn invalid_nested_inner_loop(mut a: i64) {
     while a > 0 {
-        body_variant!(Int::new(a));
+        body_variant!(Int::from(a));
         let mut b = a;
         while b > 0 { //~ ERROR: this loop might not terminate
             b -= 1;
@@ -99,7 +99,7 @@ fn invalid_nested_outer_loop(mut a: i64) {
     while a > 0 { //~ ERROR: this loop might not terminate
         let mut b = a;
         while b > 0 {
-            body_variant!(Int::new(b));
+            body_variant!(Int::from(b));
             b -= 1;
         }
         a -= 1;
@@ -109,7 +109,7 @@ fn invalid_nested_outer_loop(mut a: i64) {
 #[terminates]
 fn invalid_loop_variant(mut u: i64) {
     while u > 0 {
-        body_variant!(Int::new(u)); //~ ERROR: The loop variant might not have decreased
+        body_variant!(Int::from(u)); //~ ERROR: The loop variant might not have decreased
     }
 }
 
@@ -117,7 +117,7 @@ fn invalid_loop_variant(mut u: i64) {
 fn y(mut y: i64) {
     while y > 1 {
         body_invariant!(true);
-        body_variant!(Int::new(y));
+        body_variant!(Int::from(y));
         y -= 1;
     }
 }
@@ -130,7 +130,7 @@ fn fibi(x: i64) -> i64 {
     let mut a = 0;
     let mut b = 1;
     while i < x {
-        body_variant!(Int::new(x) - Int::new(i));
+        body_variant!(Int::from(x) - Int::from(i));
         body_invariant!(i < x);
         body_invariant!(i >= 0);
         body_invariant!(a == fib(i));
@@ -148,7 +148,7 @@ fn fibi(x: i64) -> i64 {
 
 #[pure]
 #[requires(x >= 0)]
-#[terminates(Int::new(x))]
+#[terminates(Int::from(x))]
 fn fib(x: i64) -> i64 {
     if x <= 1 {
         x

--- a/prusti-tests/tests/verify/pass/ints/ints.rs
+++ b/prusti-tests/tests/verify/pass/ints/ints.rs
@@ -1,0 +1,39 @@
+use prusti_contracts::*;
+
+#[ensures(Int::from(x) == Int::from(result))]
+pub fn foo16(x: i16) -> i16 {
+    x
+}
+
+#[ensures(Int::from(x) == Int::from(result))]
+pub fn foo32(x: i32) -> i32 {
+    x
+}
+
+#[ensures(Int::from(x) == Int::from(result))]
+pub fn foo64(x: i64) -> i64 {
+    x
+}
+
+#[ensures(Int::from(x) == Int::from(result))]
+pub fn foo128(x: i128) -> i128 {
+    x
+}
+
+#[ensures(Int::from(x) == Int::from(result))]
+pub fn foousize(x: usize) -> usize {
+    x
+}
+
+#[requires(x == usize::MAX)]
+#[requires(y < usize::MAX)]
+#[ensures(Int::from(y) < Int::from(x) + Int::from(100))]
+#[ensures(Int::from(y) <= Int::from(x) + Int::from(100))]
+#[ensures(Int::from(x) > Int::from(x) - Int::from(100))]
+#[ensures(Int::from(x) >= Int::from(x) - Int::from(100))]
+#[ensures(Int::from(x) % Int::from(100) < Int::from(100))]
+#[ensures(Int::from(x) / Int::from(100) < Int::from(x))]
+#[ensures(Int::from(x) * Int::from(100) > -Int::from(x))]
+pub fn foo_ops(x: usize, y: usize) -> usize {
+    x
+}

--- a/prusti-tests/tests/verify/pass/lemma.rs
+++ b/prusti-tests/tests/verify/pass/lemma.rs
@@ -3,7 +3,7 @@
 use prusti_contracts::*;
 
 #[pure]
-#[terminates(Int::new(x))]
+#[terminates(Int::from(x))]
 #[requires(x >= 0)]
 fn add_3(x: i64) -> i64 {
     if x == 0 {
@@ -15,7 +15,7 @@ fn add_3(x: i64) -> i64 {
 }
 
 #[pure]
-#[terminates(Int::new(x))]
+#[terminates(Int::from(x))]
 #[requires(x >= 0)]
 #[ensures((x % 2 == 0) == (add_3(x) % 2 == 0))]
 fn lemma(x: i64) -> bool {

--- a/prusti-tests/tests/verify_overflow/fail/core_proof/ghost/ints.rs
+++ b/prusti-tests/tests/verify_overflow/fail/core_proof/ghost/ints.rs
@@ -4,10 +4,10 @@
 
 use prusti_contracts::*;
 
-#[requires(a == Int::new(5))]
+#[requires(a == Int::from(5))]
 fn precond_test(a: Int) {}
 
-#[ensures(a == Int::new(5))] //~ ERROR: postcondition might not hold.
+#[ensures(a == Int::from(5))] //~ ERROR: postcondition might not hold.
 fn postcond_test(a: Int) {}
 
 fn int_equality(a: i64) {
@@ -71,18 +71,18 @@ fn negations(a: Int, b: Int) {
     prusti_assert!(-(a + b) == (-a) + (-b));
 }
 
-#[requires(a > Int::new(0) && b > Int::new(0))]
+#[requires(a > Int::from(0) && b > Int::from(0))]
 fn remainder1(a: Int, b: Int) {
     prusti_assert!(a % b >= Int::new(0));
 }
 
-#[requires(a > Int::new(0) && b > Int::new(0))]
+#[requires(a > Int::from(0) && b > Int::from(0))]
 fn remainder2(a: Int, b: Int) {
     let r = a % b;
     prusti_assert!(r >= Int::new(0));
 }
 
-#[requires(a > Int::new(0) && b > Int::new(0))]
+#[requires(a > Int::from(0) && b > Int::from(0))]
 fn divisions(a: Int, b: Int) {
     let c = a / b;
 }

--- a/prusti-tests/tests/verify_overflow/fail/core_proof/ghost/ints.rs
+++ b/prusti-tests/tests/verify_overflow/fail/core_proof/ghost/ints.rs
@@ -11,36 +11,36 @@ fn precond_test(a: Int) {}
 fn postcond_test(a: Int) {}
 
 fn int_equality(a: i64) {
-    prusti_assert!(Int::new(a) == Int::new(a));
-    prusti_assert!(Int::new(1) == Int::new(2)); //~ ERROR: the asserted expression might not hold
+    prusti_assert!(Int::from(a) == Int::from(a));
+    prusti_assert!(Int::from(1) == Int::from(2)); //~ ERROR: the asserted expression might not hold
 
     let x = 5;
-    let x_int = Int::new(x);
-    prusti_assert!(Int::new(5) == x_int);
+    let x_int = Int::from(x);
+    prusti_assert!(Int::from(5) == x_int);
 }
 
 #[requires(x > -10000 && x < 10000 && y > -10000 && y < 10000 && y != 0)]
 fn operations_equivalent(x: i64, y: i64) {
-    prusti_assert!(Int::new(-x) == -Int::new(x));
-    prusti_assert!(Int::new(x + y) == Int::new(x) + Int::new(y));
-    prusti_assert!(Int::new(x - y) == Int::new(x) - Int::new(y));
+    prusti_assert!(Int::from(-x) == -Int::from(x));
+    prusti_assert!(Int::from(x + y) == Int::from(x) + Int::from(y));
+    prusti_assert!(Int::from(x - y) == Int::from(x) - Int::from(y));
 }
 
 // We need to assume y == 5 to avoid non-linear arithmetic when doing
 // the bounds checks that choke Z3.
 #[requires(x > -10000 && x < 10000 && y == 5)]
 fn operations_equivalent2(x: i64, y: i64) {
-    prusti_assert!(Int::new(-x) == -Int::new(x));
-    prusti_assert!(Int::new(x + y) == Int::new(x) + Int::new(y));
-    prusti_assert!(Int::new(x - y) == Int::new(x) - Int::new(y));
-    prusti_assert!(Int::new(x * y) == Int::new(x) * Int::new(y));
-    prusti_assert!(Int::new(x / y) == Int::new(x) / Int::new(y));
-    prusti_assert!(Int::new(x % y) == Int::new(x) % Int::new(y));
+    prusti_assert!(Int::from(-x) == -Int::from(x));
+    prusti_assert!(Int::from(x + y) == Int::from(x) + Int::from(y));
+    prusti_assert!(Int::from(x - y) == Int::from(x) - Int::from(y));
+    prusti_assert!(Int::from(x * y) == Int::from(x) * Int::from(y));
+    prusti_assert!(Int::from(x / y) == Int::from(x) / Int::from(y));
+    prusti_assert!(Int::from(x % y) == Int::from(x) % Int::from(y));
 }
 
 fn neutral_elements(a: Int) {
-    let i0 = Int::new(0);
-    let i1 = Int::new(1);
+    let i0 = Int::from(0);
+    let i1 = Int::from(1);
 
     prusti_assert!(i0 + a == a);
     prusti_assert!(i1 * a == a);
@@ -64,22 +64,22 @@ fn distributivity(a: Int, b: Int, c: Int) {
 
 fn negations(a: Int, b: Int) {
     prusti_assert!(a + (-b) == a - b);
-    prusti_assert!(a - a == Int::new(0));
+    prusti_assert!(a - a == Int::from(0));
     prusti_assert!(-(-a) == a);
     prusti_assert!((-a) * b == -(a * b));
-    prusti_assert!(-a == Int::new(0) - a);
+    prusti_assert!(-a == Int::from(0) - a);
     prusti_assert!(-(a + b) == (-a) + (-b));
 }
 
 #[requires(a > Int::from(0) && b > Int::from(0))]
 fn remainder1(a: Int, b: Int) {
-    prusti_assert!(a % b >= Int::new(0));
+    prusti_assert!(a % b >= Int::from(0));
 }
 
 #[requires(a > Int::from(0) && b > Int::from(0))]
 fn remainder2(a: Int, b: Int) {
     let r = a % b;
-    prusti_assert!(r >= Int::new(0));
+    prusti_assert!(r >= Int::from(0));
 }
 
 #[requires(a > Int::from(0) && b > Int::from(0))]
@@ -133,5 +133,5 @@ fn mixed_test(a: Int, b: Int, c: Int, x: Int, y: Int, z: Int) {
 }
 
 fn main() {
-    eq(Int::new(0), Int::new(1), Int::new(2));
+    eq(Int::from(0), Int::from(1), Int::from(2));
 }

--- a/prusti-tests/tests/verify_overflow/fail/core_proof/ghost/map.rs
+++ b/prusti-tests/tests/verify_overflow/fail/core_proof/ghost/map.rs
@@ -27,14 +27,14 @@ fn commutativity(k1: u32, v1: u32, k2: u32, v2: u32) {
 }
 
 fn map_len(m1: Map, k: u32, v: u32) {
-    prusti_assert!(Map::empty().len() == Int::new(0));
-    prusti_assert!(map![0 => 0].len() == Int::new(1));
+    prusti_assert!(Map::empty().len() == Int::from(0));
+    prusti_assert!(map![0 => 0].len() == Int::from(1));
 
     prusti_assert!(
-        m1.insert(k, v).len() == m1.len() || m1.insert(k, v).len() == m1.len() + Int::new(1)
+        m1.insert(k, v).len() == m1.len() || m1.insert(k, v).len() == m1.len() + Int::from(1)
     );
 
-    prusti_assert!(Map::empty().insert(0, 0).len() == Int::new(2)); //~ ERROR: the asserted expression might not hold
+    prusti_assert!(Map::empty().insert(0, 0).len() == Int::from(2)); //~ ERROR: the asserted expression might not hold
 }
 
 fn map_lookup(m: Map, k: u32, v1: u32, v2: u32) {

--- a/prusti-tests/tests/verify_overflow/fail/core_proof/ghost/math_types_in_procedures.rs
+++ b/prusti-tests/tests/verify_overflow/fail/core_proof/ghost/math_types_in_procedures.rs
@@ -31,11 +31,11 @@ fn basic_test() {
         seq![1, 2, 3];
         Map::empty();
         map![0 => 1, 3 => 5];
-        Int::new(0) + Int::new(1);
-        Int::new(0) - Int::new(1);
-        Int::new(0) * Int::new(1);
-        Int::new(0) / Int::new(1);
-        Int::new(0) % Int::new(1);
+        Int::from(0) + Int::from(1);
+        Int::from(0) - Int::from(1);
+        Int::from(0) * Int::from(1);
+        Int::from(0) / Int::from(1);
+        Int::from(0) % Int::from(1);
         map![1 => 1, 0 => 2].lookup(1);
         seq![1, 2, 3].lookup(1);
         //seq![1, 2, 3][0]; // references don't yet work

--- a/prusti-tests/tests/verify_overflow/fail/core_proof/ghost/sequences.rs
+++ b/prusti-tests/tests/verify_overflow/fail/core_proof/ghost/sequences.rs
@@ -7,11 +7,11 @@ use prusti_contracts::{self as pc, *};
 type Seq = prusti_contracts::Seq<u32>;
 
 fn empty_seq_zero_len() {
-    prusti_assert!(Seq::empty().len() == Int::new(0));
+    prusti_assert!(Seq::empty().len() == Int::from(0));
 }
 
 fn empty_seq_not_one_len() {
-    prusti_assert!(Seq::empty().len() == Int::new(1)); //~ ERROR: asserted expression might not hold
+    prusti_assert!(Seq::empty().len() == Int::from(1)); //~ ERROR: asserted expression might not hold
 }
 
 fn seq_eq1() {

--- a/prusti-tests/tests/verify_overflow/fail/core_proof/ghost/sequences.rs
+++ b/prusti-tests/tests/verify_overflow/fail/core_proof/ghost/sequences.rs
@@ -34,12 +34,12 @@ fn random_indexing_fails_usize(seq: Seq, idx: usize) {
     prusti_assert!(seq[idx] == seq[idx]); //~ ERROR: the sequence index may be out of bounds
 }
 
-#[requires(0 <= idx && Int::new_usize(idx) < seq.len())]
+#[requires(0 <= idx && Int::from(idx) < seq.len())]
 fn random_indexing_suceeds(seq: Seq, idx: usize) {
     prusti_assert!(seq[idx] == seq[idx]);
 }
 
-#[requires(idx >= Int::new(0))]
+#[requires(idx >= Int::from(0))]
 fn random_indexing_fails_int(seq: Seq, idx: Int) {
     prusti_assert!(seq[idx] == seq[idx]); //~ ERROR: the sequence index may be out of bounds
 }

--- a/prusti-tests/tests/verify_overflow/fail/core_proof/model2.rs
+++ b/prusti-tests/tests/verify_overflow/fail/core_proof/model2.rs
@@ -81,9 +81,9 @@ impl LinkedList {
     #[ensures(result >= Int::from(1))]
     fn len(&self) -> Int {
         match &self.next {
-            None => Int::new(1),
+            None => Int::from(1),
             Some(tail) => {
-                tail.deref().len() + Int::new(1)
+                tail.deref().len() + Int::from(1)
             }
         }
     }
@@ -112,10 +112,10 @@ impl LinkedList {
         match &self.next {
             None => 1,
             Some(tail) => {
-                prusti_assume!(tail.deref().len() + Int::new(1) < Int::new(10));    // Avoid overflow check.
-                prusti_assert!(Int::new_usize(tail.deref().len_shared() + 1) === self.len());
+                prusti_assume!(tail.deref().len() + Int::from(1) < Int::from(10));    // Avoid overflow check.
+                prusti_assert!(Int::from(tail.deref().len_shared() + 1) === self.len());
                 let result = tail.deref().len_shared() + 1;
-                prusti_assert!(Int::new_usize(result) === self.len());
+                prusti_assert!(Int::from(result) === self.len());
                 result
             }
         }
@@ -141,22 +141,22 @@ impl LinkedList {
     #[requires(Int::from(0) <= index && index < self.len())]
     #[terminates(index)]
     fn lookup(&self, index: Int) -> Int {
-        if index == Int::new(0) {
-            Int::new(self.val)
+        if index == Int::from(0) {
+            Int::from(self.val)
         } else {
             prusti_assert!(
-                Int::new(0) <= index &&
+                Int::from(0) <= index &&
                 index < self.len() &&
-                index >= Int::new(1)
+                index >= Int::from(1)
             );
-            prusti_assert!(self.len() > Int::new(1));
+            prusti_assert!(self.len() > Int::from(1));
             match &self.next {
                 None => {
-                    prusti_assert!(self.len() == Int::new(1));
+                    prusti_assert!(self.len() == Int::from(1));
                     unreachable!()
                 },
                 Some(tail) => {
-                    tail.deref().lookup(index - Int::new(1))
+                    tail.deref().lookup(index - Int::from(1))
                 }
             }
         }

--- a/prusti-tests/tests/verify_overflow/fail/core_proof/model2.rs
+++ b/prusti-tests/tests/verify_overflow/fail/core_proof/model2.rs
@@ -78,7 +78,7 @@ impl LinkedList {
     #[pure]
     #[terminates(trusted)]
     // FIXME: This function should be “predicate!”.
-    #[ensures(result >= Int::new(1))]
+    #[ensures(result >= Int::from(1))]
     fn len(&self) -> Int {
         match &self.next {
             None => Int::new(1),
@@ -87,7 +87,7 @@ impl LinkedList {
             }
         }
     }
-    #[ensures((old(self.len()) + Int::new(1)) === result.len())]
+    #[ensures((old(self.len()) + Int::from(1)) === result.len())]
     fn prepend(self, value: i64) -> Self {
         let len = self.len();
         let b = BoxWrapper::new(self);
@@ -97,7 +97,7 @@ impl LinkedList {
             next: Some(b),
         }
     }
-    #[ensures((old(self.len()) + Int::new(1)) === result.len())]
+    #[ensures((old(self.len()) + Int::from(1)) === result.len())]
     fn prepend2(self, value: i64) -> Self {
         let len = self.len();
         Self {
@@ -107,7 +107,7 @@ impl LinkedList {
     }
     #[pure]
     #[terminates(trusted)]
-    #[ensures(Int::new_usize(result) == self.len())]
+    #[ensures(Int::from(result) == self.len())]
     fn len_shared(&self) -> usize {
         match &self.next {
             None => 1,
@@ -138,7 +138,7 @@ impl LinkedList {
     }
     #[pure]
     // FIXME: This function should be “predicate!”.
-    #[requires(Int::new(0) <= index && index < self.len())]
+    #[requires(Int::from(0) <= index && index < self.len())]
     #[terminates(index)]
     fn lookup(&self, index: Int) -> Int {
         if index == Int::new(0) {

--- a/prusti-tests/tests/verify_overflow/fail/core_proof/pure.rs
+++ b/prusti-tests/tests/verify_overflow/fail/core_proof/pure.rs
@@ -36,7 +36,7 @@ fn test4(a: usize) {}
 #[pure]
 #[requires(n >= 0)]
 #[ensures(result <= n)]
-#[terminates(Int::new_usize(n))]
+#[terminates(Int::from(n))]
 fn count(n: usize) -> usize {
     if n == 0 { 0 }
     else { count(n-1) + 1 }

--- a/prusti-tests/tests/verify_overflow/fail/core_proof/pure2.rs
+++ b/prusti-tests/tests/verify_overflow/fail/core_proof/pure2.rs
@@ -8,7 +8,7 @@ use prusti_contracts::*;
 #[pure]
 #[requires(n >= 0)]
 #[ensures(result <= n)]
-#[terminates(Int::new_usize(n))]
+#[terminates(Int::from(n))]
 fn count(n: usize) -> usize {
     if n == 0 { 0 }
     else { count(n-1) + 1 }

--- a/prusti-tests/tests/verify_overflow/fail/termination1.rs
+++ b/prusti-tests/tests/verify_overflow/fail/termination1.rs
@@ -8,7 +8,7 @@ use prusti_contracts::*;
 fn main() {
     while false {
         body_invariant!(false);
-        body_variant!(Int::new(0));
+        body_variant!(Int::from(0));
     }
 }
 
@@ -16,7 +16,7 @@ fn ghost_terminates() {
     ghost! {
         while false {
             body_invariant!(false);
-            body_variant!(Int::new(0));
+            body_variant!(Int::from(0));
         }
     };
 }

--- a/prusti-tests/tests/verify_overflow/fail/termination2.rs
+++ b/prusti-tests/tests/verify_overflow/fail/termination2.rs
@@ -8,7 +8,7 @@ fn main() {}
 
 #[requires(x < 100_000)]
 #[requires(x >= 0)]
-#[terminates(Int::new(x))]
+#[terminates(Int::from(x))]
 fn y1(x: i64) {
     if x > 0 {
         y2(x - 1)
@@ -17,7 +17,7 @@ fn y1(x: i64) {
 
 #[requires(x < 100_000)]
 #[requires(x >= 0)]
-#[terminates(Int::new(x))]
+#[terminates(Int::from(x))]
 fn y2(x: i64) {
     if x > 0 {
         y1(x - 1)
@@ -25,7 +25,7 @@ fn y2(x: i64) {
     z(x * 100)
 }
 
-#[terminates(Int::new(x))]
+#[terminates(Int::from(x))]
 fn z(x: i64) {
     if x > 0 {
         z(x - 1)

--- a/prusti-tests/tests/verify_overflow/fail/termination_trait.rs
+++ b/prusti-tests/tests/verify_overflow/fail/termination_trait.rs
@@ -7,7 +7,7 @@ use prusti_contracts::*;
 fn main() {}
 
 trait Trait {
-    #[terminates(Int::new(x))]
+    #[terminates(Int::from(x))]
     fn fun(&self, x: i64) {}
 }
 
@@ -20,14 +20,14 @@ impl Trait for Struct {
     }
 }
 
-#[terminates(Int::new(x))]
+#[terminates(Int::from(x))]
 fn foo<T: Trait>(t: &T, x: i64) {
     if x > 1 {
         t.fun(x - 1);
     }
 }
 
-#[terminates(Int::new(x))]
+#[terminates(Int::from(x))]
 fn foo2<T: Trait>(t: &T, x: i64) {
     if x > -5 {
         t.fun(x - 1); //~ ERROR: the termination measure of this call might become negative

--- a/prusti-tests/tests/verify_overflow/ui/counterexamples/account.rs
+++ b/prusti-tests/tests/verify_overflow/ui/counterexamples/account.rs
@@ -7,7 +7,7 @@ pub struct Account {
     balance: i32,
 }
 
-#[terminates(Int::new(1))]
+#[terminates(Int::from(1))]
 #[pure]
 fn get_balance(acc: Account) -> i32 {
     acc.balance

--- a/prusti-tests/tests/verify_overflow/ui/counterexamples/bool.rs
+++ b/prusti-tests/tests/verify_overflow/ui/counterexamples/bool.rs
@@ -8,7 +8,7 @@ fn test1(b: bool) -> bool {
 }
 
 #[pure]
-#[terminates(Int::new(1))]
+#[terminates(Int::from(1))]
 #[ensures(result)]
 fn test2(b: bool) -> bool {
     !b

--- a/prusti-tests/tests/verify_overflow/ui/counterexamples/int.rs
+++ b/prusti-tests/tests/verify_overflow/ui/counterexamples/int.rs
@@ -9,7 +9,7 @@ fn test1(x: i32) -> i32 {
 }
 
 #[pure]
-#[terminates(Int::new(1))]
+#[terminates(Int::from(1))]
 #[ensures(result != 42)]
 fn test2(x: i32) -> i32 {
     x + 21

--- a/prusti-tests/tests/verify_overflow/ui/counterexamples/integer.rs
+++ b/prusti-tests/tests/verify_overflow/ui/counterexamples/integer.rs
@@ -12,7 +12,7 @@ fn test1(a: Int) {}
 #[ensures(!result)]
 fn test2(a: Int, b: Int) -> bool{
     let c = a + b;
-    c == Int::new(30)
+    c == Int::from(30)
 }
 
 

--- a/prusti-tests/tests/verify_overflow/ui/counterexamples/integer.rs
+++ b/prusti-tests/tests/verify_overflow/ui/counterexamples/integer.rs
@@ -4,11 +4,11 @@
 
 use prusti_contracts::*;
 
-#[requires(a == Int::new(2))] //force specific counterexample
-#[ensures(a == Int::new(5))]
+#[requires(a == Int::from(2))] //force specific counterexample
+#[ensures(a == Int::from(5))]
 fn test1(a: Int) {}
 
-#[requires(a == Int::new(10))] //force specific counterexample
+#[requires(a == Int::from(10))] //force specific counterexample
 #[ensures(!result)]
 fn test2(a: Int, b: Int) -> bool{
     let c = a + b;
@@ -16,7 +16,7 @@ fn test2(a: Int, b: Int) -> bool{
 }
 
 
-#[requires(a == Int::new(10) && c == Int::new(11) && b == Int::new(0))] //force specific counterexample
+#[requires(a == Int::from(10) && c == Int::from(11) && b == Int::from(0))] //force specific counterexample
 #[ensures(result)]
 fn test3(a: Int, b: Int, c: Int) -> bool {
     a + c >= b + c

--- a/prusti-tests/tests/verify_overflow/ui/counterexamples/integer.stderr
+++ b/prusti-tests/tests/verify_overflow/ui/counterexamples/integer.stderr
@@ -1,7 +1,7 @@
 error: [Prusti: verification error] postcondition might not hold.
  --> $DIR/integer.rs:8:11
   |
-8 | #[ensures(a == Int::new(5))]
+8 | #[ensures(a == Int::from(5))]
   |           ^^^^^^^^^^^^^^^^
   |
 note: the error originates here

--- a/prusti-tests/tests/verify_overflow/ui/counterexamples/integer.stderr
+++ b/prusti-tests/tests/verify_overflow/ui/counterexamples/integer.stderr
@@ -33,7 +33,7 @@ note: the error originates here
    |
 13 | / fn test2(a: Int, b: Int) -> bool{
 14 | |     let c = a + b;
-15 | |     c == Int::new(30)
+15 | |     c == Int::from(30)
 16 | | }
    | |_^
 note: counterexample for "a"
@@ -58,13 +58,13 @@ note: counterexample for "c"
        value:   30
   --> $DIR/integer.rs:15:5
    |
-15 |     c == Int::new(30)
+15 |     c == Int::from(30)
    |     ^
 note: counterexample for "result"
        value:   true
   --> $DIR/integer.rs:15:5
    |
-15 |     c == Int::new(30)
+15 |     c == Int::from(30)
    |     ^^^^^^^^^^^^^^^^^
 
 error: [Prusti: verification error] postcondition might not hold.

--- a/prusti-tests/tests/verify_overflow/ui/counterexamples/model-3.rs
+++ b/prusti-tests/tests/verify_overflow/ui/counterexamples/model-3.rs
@@ -14,26 +14,26 @@ struct VecWrapper<#[concrete] i8> {
 
 impl VecWrapper<i8> {
     #[trusted]
-    #[requires(self.model().values.len() > Int::new(index))]
-    #[ensures(self.model().values[Int::new(index)] == result)]
+    #[requires(self.model().values.len() > Int::from(index))]
+    #[ensures(self.model().values[Int::from(index)] == result)]
     fn lookup(&self, index: i64) -> i8 {
         self.values[index as usize]
     }
 }
 
 
-#[requires(v.model().values.len() == Int::new(4))]
+#[requires(v.model().values.len() == Int::from(4))]
 //force specific counterexample
-#[requires(v.model().values[Int::new(0)] == 9 )] 
-#[requires(v.model().values[Int::new(1)] == 8 )]
-#[requires(v.model().values[Int::new(2)] == 3 )]
-#[requires(v.model().values[Int::new(3)] == 8 )]
+#[requires(v.model().values[Int::from(0)] == 9 )] 
+#[requires(v.model().values[Int::from(1)] == 8 )]
+#[requires(v.model().values[Int::from(2)] == 3 )]
+#[requires(v.model().values[Int::from(3)] == 8 )]
 fn test1(v: &VecWrapper<i8>) {
     assert!(v.lookup(0) + v.lookup(1) + v.lookup(2) + v.lookup(3) == 15)
 }
 
-#[requires(v.model().values.len() == Int::new(1) )]
-#[requires(v.model().values[Int::new(0)] == 3 )] //force specific counterexample
+#[requires(v.model().values.len() == Int::from(1) )]
+#[requires(v.model().values[Int::from(0)] == 3 )] //force specific counterexample
 #[ensures(v.model().values[0] == 1)]
 fn test2(v: VecWrapper<i8>) {}
 

--- a/prusti-tests/tests/verify_overflow/ui/counterexamples/pure-function-1.rs
+++ b/prusti-tests/tests/verify_overflow/ui/counterexamples/pure-function-1.rs
@@ -5,13 +5,13 @@
 use prusti_contracts::*;
 
 #[pure]
-#[terminates(Int::new(1))]
+#[terminates(Int::from(1))]
 fn foo(x: i32) -> i32{
     x + 5
 }
 
 #[pure]
-#[terminates(Int::new(1))]
+#[terminates(Int::from(1))]
 fn bar(x: i32) -> bool{
     x == 3
 }

--- a/prusti-tests/tests/verify_overflow/ui/counterexamples/pure-function-2.rs
+++ b/prusti-tests/tests/verify_overflow/ui/counterexamples/pure-function-2.rs
@@ -9,7 +9,7 @@ struct X {
 
 impl X {
     #[pure]
-    #[terminates(Int::new(1))]
+    #[terminates(Int::from(1))]
     fn get_a(&self) -> i32{
         self.a
     }
@@ -17,7 +17,7 @@ impl X {
 
 
 #[pure]
-#[terminates(Int::new(1))]
+#[terminates(Int::from(1))]
 fn baz(x: X) -> X {
     X {a: x.a + 1}
 }

--- a/prusti-tests/tests/verify_overflow/ui/counterexamples/pure-sum-2.rs
+++ b/prusti-tests/tests/verify_overflow/ui/counterexamples/pure-sum-2.rs
@@ -3,7 +3,7 @@
 use prusti_contracts::*;
 
 #[pure]
-#[terminates(Int::new(x) + Int::new(1))]
+#[terminates(Int::from(x) + Int::from(1))]
 fn sum(x:i64) -> i64 {
     if x <= 0 {
         0

--- a/prusti-tests/tests/verify_overflow/ui/counterexamples/sequences.rs
+++ b/prusti-tests/tests/verify_overflow/ui/counterexamples/sequences.rs
@@ -10,7 +10,7 @@ fn test1(seq: Seq<i32>, idx: usize) {
     prusti_assert!(seq[idx] == seq[idx]);
 }
 
-#[requires(idx >= Int::new(0))]
+#[requires(idx >= Int::from(0))]
 #[requires(idx < seq1.len())]
 #[requires(seq1.len() == seq2.len())]
 fn test2(seq1: Seq<i32>, seq2: Seq<i32>, idx: Int) {
@@ -22,7 +22,7 @@ fn test3() {
     prusti_assert!(seq[2] == 4);
 }
 
-#[requires(seq.len() == Int::new(2))]
+#[requires(seq.len() == Int::from(2))]
 #[requires(a == 2 && a == b)] // force specific counterexample
 fn test4(a: i32, b: i32, seq: Seq<i32>) {
     //the counterexample only contains values for a and b but not for the elements of seq

--- a/prusti-tests/tests/verify_overflow/ui/counterexamples/struct-2.rs
+++ b/prusti-tests/tests/verify_overflow/ui/counterexamples/struct-2.rs
@@ -9,7 +9,7 @@ struct X{
 }
 
 #[pure]
-#[terminates(Int::new(1))]
+#[terminates(Int::from(1))]
 #[requires(x.a == 5)] // force specific counterexample
 #[ensures(!result)]
 fn test_pure(x: X) -> bool{


### PR DESCRIPTION
Adds support for mathematical integers.
Tried to reuse as much as possible from the Reals support, `TyRealLocal` is now a `TyPrimLocal` that generalizes both Ints and Reals, and the functions for encoding Real operations in `mir_pure.rs` have been generalized to work for both.

Previously, it seems that the functions for converting from `i32` and `usize` to `Int` were called `new` and `new_usize`. Following the lead of the Reals implementation, I use the `From` trait instead, and I've updated `prusti-tests` accordingly.