### PR TITLE
Fix encoding of recursive types

### DIFF
--- a/prusti-encoder/src/encoders/ty/use_impure.rs
+++ b/prusti-encoder/src/encoders/ty/use_impure.rs
@@ -1,5 +1,5 @@
 use prusti_rustc_interface::abi;
-use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 use vir::{CastType, PredicateIdn};
 
 use crate::encoders::{
@@ -116,6 +116,8 @@ pub struct TyUseImpureEnumData<'vir> {
 /// This wrapper handles all the generic casts required (e.g. when fold/unfolding).
 pub type TyUseImpureEnc = TyUseEnc<Impure>;
 
+type TyUseImpureResult<'vir, T> = Result<T, EncodeFullError<'vir, TyUseImpureEnc>>;
+
 impl TaskEncoder for TyUseImpureEnc {
     task_encoder::encoder_cache!(TyUseImpureEnc);
     const ENCODER_NAME: &'static str = "impure type use encoder";
@@ -135,14 +137,14 @@ impl TaskEncoder for TyUseImpureEnc {
         deps.emit_output_ref(*task_key, ())?;
 
         let ty_impure = deps.require_dep::<TyImpureEnc>(task_key.ty)?;
-        let mut walker = TyUseImpureWalker::new(deps, task_key.args);
+        let mut walker = TyUseImpureWalker::new(deps, task_key.args)?;
         // Impure encoding needs to know whether the type may be inhabited (to emit
         // the right predicate). It is `None` only from `RustTyDecomposition::identity`.
         let maybe_inhabited = task_key.maybe_inhabited.expect(
             "impure type encoding requires a decomposition with known inhabitedness \
              (from `from_ty`), not one built by `RustTyDecomposition::identity`",
         );
-        let ty_use_impure = walker.encode_ty(task_key.ty.zip(ty_impure), maybe_inhabited);
+        let ty_use_impure = walker.encode_ty(task_key.ty.zip(ty_impure), maybe_inhabited)?;
         Ok(((), ty_use_impure.alloc()))
     }
 
@@ -158,23 +160,26 @@ struct TyUseImpureWalker<'a, 'vir> {
 }
 
 impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
-    fn new(deps: &'a mut TaskEncoderDependencies<'vir, TyUseImpureEnc>, args: GArgs<'vir>) -> Self {
-        let args_t = deps.require_dep::<GArgsTyEnc>(args).unwrap();
-        Self { deps, args_t, args }
+    fn new(
+        deps: &'a mut TaskEncoderDependencies<'vir, TyUseImpureEnc>,
+        args: GArgs<'vir>,
+    ) -> TyUseImpureResult<'vir, Self> {
+        let args_t = deps.require_dep::<GArgsTyEnc>(args)?;
+        Ok(Self { deps, args_t, args })
     }
 
     fn encode_ty(
         &mut self,
         ty: TyData<'vir, (RustTyDatas, ImpureTyDatas)>,
         maybe_inhabited: bool,
-    ) -> TyData<'vir, UseImpureTyDatas> {
+    ) -> TyUseImpureResult<'vir, TyData<'vir, UseImpureTyDatas>> {
         let specifics = match &ty.specifics {
             TySpecifics::Param(..) => TySpecifics::mk_param(()),
             TySpecifics::Opaque(..) => TySpecifics::mk_opaque(()),
             TySpecifics::Primitive(..) => TySpecifics::mk_primitive(()),
             TySpecifics::ImmRef(data) => {
-                let referent_caster = self.encode_normalized(data.0.referent, ty.0.params);
-                let metadata_caster = self.encode_normalized_pure(data.0.metadata, ty.0.params);
+                let referent_caster = self.encode_normalized(data.0.referent, ty.0.params)?;
+                let metadata_caster = self.encode_normalized_pure(data.0.metadata, ty.0.params)?;
                 TySpecifics::mk_immref(TyUseImpureImmRef {
                     referent_caster,
                     metadata_caster,
@@ -183,8 +188,8 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
                 })
             }
             TySpecifics::MutRef(data) => {
-                let referent_caster = self.encode_normalized(data.0.referent, ty.0.params);
-                let metadata_caster = self.encode_normalized_pure(data.0.metadata, ty.0.params);
+                let referent_caster = self.encode_normalized(data.0.referent, ty.0.params)?;
+                let metadata_caster = self.encode_normalized_pure(data.0.metadata, ty.0.params)?;
                 TySpecifics::mk_mutref(TyUseImpureMutRef {
                     referent_caster,
                     metadata_caster,
@@ -194,7 +199,7 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
                 })
             }
             TySpecifics::Raw(data) => {
-                let metadata_caster = self.encode_normalized_pure(data.0.metadata, ty.0.params);
+                let metadata_caster = self.encode_normalized_pure(data.0.metadata, ty.0.params)?;
                 TySpecifics::mk_raw(TyUseImpureRaw {
                     metadata_caster,
                     args: self.args_t,
@@ -202,13 +207,15 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
                 })
             }
             TySpecifics::ArrayLike(data) => {
-                TySpecifics::ArrayLike(self.encode_array(data, ty.1.ref_to_pred, ty.0.params))
+                TySpecifics::ArrayLike(self.encode_array(data, ty.1.ref_to_pred, ty.0.params)?)
             }
-            TySpecifics::StructLike(data) => {
-                TySpecifics::StructLike(self.encode_structlike(data, ty.1.ref_to_pred, ty.0.params))
-            }
+            TySpecifics::StructLike(data) => TySpecifics::StructLike(self.encode_structlike(
+                data,
+                ty.1.ref_to_pred,
+                ty.0.params,
+            )?),
             TySpecifics::EnumLike(data) => {
-                TySpecifics::EnumLike(self.encode_enumlike(data, ty.0.params))
+                TySpecifics::EnumLike(self.encode_enumlike(data, ty.0.params)?)
             }
             TySpecifics::Builtin(..) => TySpecifics::mk_builtin(()),
         };
@@ -217,29 +224,26 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
             impure: *ty.1,
             maybe_inhabited,
         };
-        TyData::new(data, specifics)
+        Ok(TyData::new(data, specifics))
     }
 
     fn encode_normalized(
         &mut self,
         inner: LazyRustTy<'vir>,
         params: GParams<'vir>,
-    ) -> FieldCaster<'vir> {
+    ) -> TyUseImpureResult<'vir, FieldCaster<'vir>> {
         let normalized = inner.decompose_compare_normalize(params, self.args);
-        self.deps
-            .require_dep::<GArgsCastEnc<Impure>>(normalized)
-            .unwrap()
+        self.deps.require_dep::<GArgsCastEnc<Impure>>(normalized)
     }
 
     fn encode_normalized_pure(
         &mut self,
         inner: LazyRustTy<'vir>,
         params: GParams<'vir>,
-    ) -> GArgCaster<'vir, crate::encoders::Pure> {
+    ) -> TyUseImpureResult<'vir, GArgCaster<'vir, crate::encoders::Pure>> {
         let normalized = inner.decompose_compare_normalize(params, self.args);
         self.deps
             .require_dep::<GArgsCastEnc<crate::encoders::Pure>>(normalized)
-            .unwrap()
     }
 
     fn encode_array(
@@ -247,15 +251,15 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
         data: &ArrayData<'vir, (RustTyDatas, ImpureTyDatas)>,
         _ref_to_pred: PredicateIdn<'vir, (vir::Ref, vir::ManyTyVal, vir::ManyCSnap)>,
         params: GParams<'vir>,
-    ) -> ArrayData<'vir, UseImpureTyDatas> {
-        let caster = self.encode_normalized(*data.0, params);
+    ) -> TyUseImpureResult<'vir, ArrayData<'vir, UseImpureTyDatas>> {
+        let caster = self.encode_normalized(*data.0, params)?;
         let slice = data.slice;
         let data = TyUseImpureArrayData {
             args: self.args_t,
             impure: *data.data.1,
             element_caster: caster,
         };
-        ArrayData::new(data, slice)
+        Ok(ArrayData::new(data, slice))
     }
 
     fn encode_structlike(
@@ -263,46 +267,46 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
         data: &StructData<'vir, (RustTyDatas, ImpureTyDatas)>,
         ref_to_pred: PredicateIdn<'vir, (vir::Ref, vir::ManyTyVal, vir::ManyCSnap)>,
         params: GParams<'vir>,
-    ) -> StructData<'vir, UseImpureTyDatas> {
+    ) -> TyUseImpureResult<'vir, StructData<'vir, UseImpureTyDatas>> {
         let fields = data
             .fields
             .iter()
             .map(|field| {
-                let caster = self.encode_normalized(field.0.ty(), params);
-                TyUseImpureField {
+                let caster = self.encode_normalized(field.0.ty(), params)?;
+                Ok(TyUseImpureField {
                     caster,
                     args: self.args_t,
                     impure: *field.1,
-                }
+                })
             })
-            .collect::<Vec<_>>();
+            .collect::<TyUseImpureResult<'vir, Vec<_>>>()?;
         let data = TyUseImpureStructData {
             args: self.args_t,
             ref_to_pred,
             impure: *data.1,
         };
-        StructData::new(data, fields)
+        Ok(StructData::new(data, fields))
     }
 
     fn encode_enumlike(
         &mut self,
         data: &EnumData<'vir, (RustTyDatas, ImpureTyDatas)>,
         params: GParams<'vir>,
-    ) -> EnumData<'vir, UseImpureTyDatas> {
+    ) -> TyUseImpureResult<'vir, EnumData<'vir, UseImpureTyDatas>> {
         let variants = data
             .variants
             .iter()
             .map(|variant| {
                 let structlike =
-                    self.encode_structlike(&variant.inner, variant.1.predicate, params);
-                VariantData::new((), structlike)
+                    self.encode_structlike(&variant.inner, variant.1.predicate, params)?;
+                Ok(VariantData::new((), structlike))
             })
-            .collect::<Vec<_>>();
+            .collect::<TyUseImpureResult<'vir, Vec<_>>>()?;
         let data = TyUseImpureEnumData {
             args: self.args_t,
             impure: *data.1,
         };
-        EnumData::new(data, variants)
+        Ok(EnumData::new(data, variants))
     }
 }
 

--- a/prusti-encoder/src/encoders/ty/use_impure.rs
+++ b/prusti-encoder/src/encoders/ty/use_impure.rs
@@ -116,7 +116,7 @@ pub struct TyUseImpureEnumData<'vir> {
 /// This wrapper handles all the generic casts required (e.g. when fold/unfolding).
 pub type TyUseImpureEnc = TyUseEnc<Impure>;
 
-type TyUseImpureResult<'vir, T> = Result<T, EncodeFullError<'vir, TyUseImpureEnc>>;
+type EncResult<'vir, T> = Result<T, EncodeFullError<'vir, TyUseImpureEnc>>;
 
 impl TaskEncoder for TyUseImpureEnc {
     task_encoder::encoder_cache!(TyUseImpureEnc);
@@ -163,7 +163,7 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
     fn new(
         deps: &'a mut TaskEncoderDependencies<'vir, TyUseImpureEnc>,
         args: GArgs<'vir>,
-    ) -> TyUseImpureResult<'vir, Self> {
+    ) -> EncResult<'vir, Self> {
         let args_t = deps.require_dep::<GArgsTyEnc>(args)?;
         Ok(Self { deps, args_t, args })
     }
@@ -172,7 +172,7 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
         &mut self,
         ty: TyData<'vir, (RustTyDatas, ImpureTyDatas)>,
         maybe_inhabited: bool,
-    ) -> TyUseImpureResult<'vir, TyData<'vir, UseImpureTyDatas>> {
+    ) -> EncResult<'vir, TyData<'vir, UseImpureTyDatas>> {
         let specifics = match &ty.specifics {
             TySpecifics::Param(..) => TySpecifics::mk_param(()),
             TySpecifics::Opaque(..) => TySpecifics::mk_opaque(()),
@@ -231,7 +231,7 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
         &mut self,
         inner: LazyRustTy<'vir>,
         params: GParams<'vir>,
-    ) -> TyUseImpureResult<'vir, FieldCaster<'vir>> {
+    ) -> EncResult<'vir, FieldCaster<'vir>> {
         let normalized = inner.decompose_compare_normalize(params, self.args);
         self.deps.require_dep::<GArgsCastEnc<Impure>>(normalized)
     }
@@ -240,7 +240,7 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
         &mut self,
         inner: LazyRustTy<'vir>,
         params: GParams<'vir>,
-    ) -> TyUseImpureResult<'vir, GArgCaster<'vir, crate::encoders::Pure>> {
+    ) -> EncResult<'vir, GArgCaster<'vir, crate::encoders::Pure>> {
         let normalized = inner.decompose_compare_normalize(params, self.args);
         self.deps
             .require_dep::<GArgsCastEnc<crate::encoders::Pure>>(normalized)
@@ -251,7 +251,7 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
         data: &ArrayData<'vir, (RustTyDatas, ImpureTyDatas)>,
         _ref_to_pred: PredicateIdn<'vir, (vir::Ref, vir::ManyTyVal, vir::ManyCSnap)>,
         params: GParams<'vir>,
-    ) -> TyUseImpureResult<'vir, ArrayData<'vir, UseImpureTyDatas>> {
+    ) -> EncResult<'vir, ArrayData<'vir, UseImpureTyDatas>> {
         let caster = self.encode_normalized(*data.0, params)?;
         let slice = data.slice;
         let data = TyUseImpureArrayData {
@@ -267,7 +267,7 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
         data: &StructData<'vir, (RustTyDatas, ImpureTyDatas)>,
         ref_to_pred: PredicateIdn<'vir, (vir::Ref, vir::ManyTyVal, vir::ManyCSnap)>,
         params: GParams<'vir>,
-    ) -> TyUseImpureResult<'vir, StructData<'vir, UseImpureTyDatas>> {
+    ) -> EncResult<'vir, StructData<'vir, UseImpureTyDatas>> {
         let fields = data
             .fields
             .iter()
@@ -279,7 +279,7 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
                     impure: *field.1,
                 })
             })
-            .collect::<TyUseImpureResult<'vir, Vec<_>>>()?;
+            .collect::<EncResult<'vir, Vec<_>>>()?;
         let data = TyUseImpureStructData {
             args: self.args_t,
             ref_to_pred,
@@ -292,7 +292,7 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
         &mut self,
         data: &EnumData<'vir, (RustTyDatas, ImpureTyDatas)>,
         params: GParams<'vir>,
-    ) -> TyUseImpureResult<'vir, EnumData<'vir, UseImpureTyDatas>> {
+    ) -> EncResult<'vir, EnumData<'vir, UseImpureTyDatas>> {
         let variants = data
             .variants
             .iter()
@@ -301,7 +301,7 @@ impl<'a, 'vir> TyUseImpureWalker<'a, 'vir> {
                     self.encode_structlike(&variant.inner, variant.1.predicate, params)?;
                 Ok(VariantData::new((), structlike))
             })
-            .collect::<TyUseImpureResult<'vir, Vec<_>>>()?;
+            .collect::<EncResult<'vir, Vec<_>>>()?;
         let data = TyUseImpureEnumData {
             args: self.args_t,
             impure: *data.1,

--- a/prusti-encoder/src/encoders/ty/use_pure.rs
+++ b/prusti-encoder/src/encoders/ty/use_pure.rs
@@ -1,4 +1,4 @@
-use task_encoder::{EncodeFullResult, TaskEncoder};
+use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder};
 use vir::CastType;
 
 use crate::encoders::{
@@ -91,6 +91,8 @@ pub struct TyUsePureStructData<'vir> {
 /// This wrapper handles all the generic casts required.
 pub type TyUsePureEnc = TyUseEnc<Pure>;
 
+type TyUsePureResult<'vir, T> = Result<T, EncodeFullError<'vir, TyUsePureEnc>>;
+
 #[derive(Debug, Clone, Copy)]
 pub struct TyUsePureRef<'vir> {
     pub snapshot: vir::TypeSnap<'vir>,
@@ -134,8 +136,8 @@ impl TaskEncoder for TyUsePureEnc {
 
         let ty_pure = deps.require_dep::<TyPureEnc>(task_key.ty)?;
         let ty = task_key.ty.zip(ty_pure);
-        let mut walker = TyUsePureWalker::new(deps, task_key.args);
-        let specifics = walker.encode_ty(ty);
+        let mut walker = TyUsePureWalker::new(deps, task_key.args)?;
+        let specifics = walker.encode_ty(ty)?;
         let ty_use_pure = TyData::new(inner, specifics);
         Ok(((), ty_use_pure.alloc()))
     }
@@ -155,23 +157,23 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
     fn new(
         deps: &'a mut task_encoder::TaskEncoderDependencies<'vir, TyUsePureEnc>,
         args: GArgs<'vir>,
-    ) -> Self {
-        let args_t = deps.require_dep::<GArgsTyEnc>(args).unwrap();
-        TyUsePureWalker { deps, args_t, args }
+    ) -> TyUsePureResult<'vir, Self> {
+        let args_t = deps.require_dep::<GArgsTyEnc>(args)?;
+        Ok(TyUsePureWalker { deps, args_t, args })
     }
 
     fn encode_ty(
         &mut self,
         ty: TyData<'vir, (RustTyDatas, PureTyDatas)>,
-    ) -> TySpecifics<'vir, UsePureTyDatas> {
-        match &ty.specifics {
+    ) -> TyUsePureResult<'vir, TySpecifics<'vir, UsePureTyDatas>> {
+        let specifics = match &ty.specifics {
             TySpecifics::Param(data) => {
                 let _: () = *data.1;
                 TySpecifics::mk_param(())
             }
             TySpecifics::Opaque(data) => TySpecifics::mk_opaque(*data.1),
             TySpecifics::Raw((data, raw_domain)) => {
-                let metadata_caster = self.encode_normalized(data.metadata, ty.0.params);
+                let metadata_caster = self.encode_normalized(data.metadata, ty.0.params)?;
                 TySpecifics::mk_raw(TyUsePureRaw {
                     metadata_caster,
                     pure: **raw_domain,
@@ -179,8 +181,8 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
             }
             TySpecifics::Primitive(data) => TySpecifics::mk_primitive(*data.1),
             TySpecifics::ImmRef((data, ref_domain)) => {
-                let referent_caster = self.encode_normalized(data.referent, ty.0.params);
-                let metadata_caster = self.encode_normalized(data.metadata, ty.0.params);
+                let referent_caster = self.encode_normalized(data.referent, ty.0.params)?;
+                let metadata_caster = self.encode_normalized(data.metadata, ty.0.params)?;
                 TySpecifics::mk_immref(TyUsePureImmRef {
                     referent_caster,
                     metadata_caster,
@@ -188,8 +190,8 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
                 })
             }
             TySpecifics::MutRef((data, ref_domain)) => {
-                let referent_caster = self.encode_normalized(data.referent, ty.0.params);
-                let metadata_caster = self.encode_normalized(data.metadata, ty.0.params);
+                let referent_caster = self.encode_normalized(data.referent, ty.0.params)?;
+                let metadata_caster = self.encode_normalized(data.metadata, ty.0.params)?;
                 TySpecifics::mk_mutref(TyUsePureMutRef {
                     referent_caster,
                     metadata_caster,
@@ -197,82 +199,81 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
                 })
             }
             TySpecifics::ArrayLike(data) => {
-                TySpecifics::ArrayLike(self.encode_array(data, ty.0.params))
+                TySpecifics::ArrayLike(self.encode_array(data, ty.0.params)?)
             }
             TySpecifics::StructLike(data) => {
-                TySpecifics::StructLike(self.encode_structlike(data, ty.0.params))
+                TySpecifics::StructLike(self.encode_structlike(data, ty.0.params)?)
             }
             TySpecifics::EnumLike(data) => {
-                TySpecifics::EnumLike(self.encode_enumlike(data, ty.0.params))
+                TySpecifics::EnumLike(self.encode_enumlike(data, ty.0.params)?)
             }
             TySpecifics::Builtin(data) => TySpecifics::mk_builtin(*data.1),
-        }
+        };
+        Ok(specifics)
     }
 
     fn encode_normalized(
         &mut self,
         inner: LazyRustTy<'vir>,
         params: GParams<'vir>,
-    ) -> FieldCaster<'vir> {
+    ) -> TyUsePureResult<'vir, FieldCaster<'vir>> {
         let normalized = inner.decompose_compare_normalize(params, self.args);
-        self.deps
-            .require_dep::<GArgsCastEnc<Pure>>(normalized)
-            .unwrap()
+        self.deps.require_dep::<GArgsCastEnc<Pure>>(normalized)
     }
 
     fn encode_array(
         &mut self,
         data: &ArrayData<'vir, (RustTyDatas, PureTyDatas)>,
         params: GParams<'vir>,
-    ) -> ArrayData<'vir, UsePureTyDatas> {
-        let caster = self.encode_normalized(*data.0, params);
+    ) -> TyUsePureResult<'vir, ArrayData<'vir, UsePureTyDatas>> {
+        let caster = self.encode_normalized(*data.0, params)?;
         let slice = data.slice;
         let data = TyUsePureArrayData {
             caster,
             args: self.args_t,
             pure: *data.data.1,
         };
-        ArrayData::new(data, slice)
+        Ok(ArrayData::new(data, slice))
     }
 
     fn encode_structlike(
         &mut self,
         data: &StructData<'vir, (RustTyDatas, PureTyDatas)>,
         params: GParams<'vir>,
-    ) -> StructData<'vir, UsePureTyDatas> {
+    ) -> TyUsePureResult<'vir, StructData<'vir, UsePureTyDatas>> {
         let fields = data
             .fields
             .iter()
             .map(|field| {
-                let caster = self.encode_normalized(field.0.ty(), params);
-                TyUsePureField {
+                let caster = self.encode_normalized(field.0.ty(), params)?;
+                Ok(TyUsePureField {
                     caster,
                     args: self.args_t,
                     pure: *field.1,
-                }
+                })
             })
-            .collect::<Vec<_>>();
+            .collect::<TyUsePureResult<'vir, Vec<_>>>()?;
         let data = TyUsePureStructData {
             args: self.args_t,
             pure: *data.1,
         };
-        StructData::new(data, fields)
+        Ok(StructData::new(data, fields))
     }
 
     fn encode_enumlike(
         &mut self,
         data: &EnumData<'vir, (RustTyDatas, PureTyDatas)>,
         params: GParams<'vir>,
-    ) -> EnumData<'vir, UsePureTyDatas> {
+    ) -> TyUsePureResult<'vir, EnumData<'vir, UsePureTyDatas>> {
         let variants = data
             .variants
             .iter()
             .map(|variant| {
-                let structlike = self.encode_structlike(&variant.inner, params);
-                VariantData::new(*variant.1, structlike)
+                let structlike = self.encode_structlike(&variant.inner, params)?;
+                Ok(VariantData::new(*variant.1, structlike))
             })
-            .collect::<Vec<_>>();
-        EnumData::new(*data.1, variants)
+            .collect::<TyUsePureResult<'vir, Vec<_>>>()?;
+        Ok(EnumData::new(*data.1, variants))
     }
 }
 

--- a/prusti-encoder/src/encoders/ty/use_pure.rs
+++ b/prusti-encoder/src/encoders/ty/use_pure.rs
@@ -91,7 +91,7 @@ pub struct TyUsePureStructData<'vir> {
 /// This wrapper handles all the generic casts required.
 pub type TyUsePureEnc = TyUseEnc<Pure>;
 
-type TyUsePureResult<'vir, T> = Result<T, EncodeFullError<'vir, TyUsePureEnc>>;
+type EncResult<'vir, T> = Result<T, EncodeFullError<'vir, TyUsePureEnc>>;
 
 #[derive(Debug, Clone, Copy)]
 pub struct TyUsePureRef<'vir> {
@@ -157,7 +157,7 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
     fn new(
         deps: &'a mut task_encoder::TaskEncoderDependencies<'vir, TyUsePureEnc>,
         args: GArgs<'vir>,
-    ) -> TyUsePureResult<'vir, Self> {
+    ) -> EncResult<'vir, Self> {
         let args_t = deps.require_dep::<GArgsTyEnc>(args)?;
         Ok(TyUsePureWalker { deps, args_t, args })
     }
@@ -165,7 +165,7 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
     fn encode_ty(
         &mut self,
         ty: TyData<'vir, (RustTyDatas, PureTyDatas)>,
-    ) -> TyUsePureResult<'vir, TySpecifics<'vir, UsePureTyDatas>> {
+    ) -> EncResult<'vir, TySpecifics<'vir, UsePureTyDatas>> {
         let specifics = match &ty.specifics {
             TySpecifics::Param(data) => {
                 let _: () = *data.1;
@@ -216,7 +216,7 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
         &mut self,
         inner: LazyRustTy<'vir>,
         params: GParams<'vir>,
-    ) -> TyUsePureResult<'vir, FieldCaster<'vir>> {
+    ) -> EncResult<'vir, FieldCaster<'vir>> {
         let normalized = inner.decompose_compare_normalize(params, self.args);
         self.deps.require_dep::<GArgsCastEnc<Pure>>(normalized)
     }
@@ -225,7 +225,7 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
         &mut self,
         data: &ArrayData<'vir, (RustTyDatas, PureTyDatas)>,
         params: GParams<'vir>,
-    ) -> TyUsePureResult<'vir, ArrayData<'vir, UsePureTyDatas>> {
+    ) -> EncResult<'vir, ArrayData<'vir, UsePureTyDatas>> {
         let caster = self.encode_normalized(*data.0, params)?;
         let slice = data.slice;
         let data = TyUsePureArrayData {
@@ -240,7 +240,7 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
         &mut self,
         data: &StructData<'vir, (RustTyDatas, PureTyDatas)>,
         params: GParams<'vir>,
-    ) -> TyUsePureResult<'vir, StructData<'vir, UsePureTyDatas>> {
+    ) -> EncResult<'vir, StructData<'vir, UsePureTyDatas>> {
         let fields = data
             .fields
             .iter()
@@ -252,7 +252,7 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
                     pure: *field.1,
                 })
             })
-            .collect::<TyUsePureResult<'vir, Vec<_>>>()?;
+            .collect::<EncResult<'vir, Vec<_>>>()?;
         let data = TyUsePureStructData {
             args: self.args_t,
             pure: *data.1,
@@ -264,7 +264,7 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
         &mut self,
         data: &EnumData<'vir, (RustTyDatas, PureTyDatas)>,
         params: GParams<'vir>,
-    ) -> TyUsePureResult<'vir, EnumData<'vir, UsePureTyDatas>> {
+    ) -> EncResult<'vir, EnumData<'vir, UsePureTyDatas>> {
         let variants = data
             .variants
             .iter()
@@ -272,7 +272,7 @@ impl<'a, 'vir> TyUsePureWalker<'a, 'vir> {
                 let structlike = self.encode_structlike(&variant.inner, params)?;
                 Ok(VariantData::new(*variant.1, structlike))
             })
-            .collect::<TyUsePureResult<'vir, Vec<_>>>()?;
+            .collect::<EncResult<'vir, Vec<_>>>()?;
         Ok(EnumData::new(*data.1, variants))
     }
 }


### PR DESCRIPTION
Fixes the encoding of recursive types by propagating the `AlreadyEncoded` error rather than panicing via `unwrap()`. This resolves `gitlab-issues/issue-98.rs`