### PR TITLE
Use ECX for ty consts

### DIFF
--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -8,10 +8,9 @@ use prusti_rustc_interface::{
             self, ConstValue,
             interpret::{GlobalAlloc, Scalar},
         },
-        ty,
-        ty::TypingEnv,
+        ty::{self, TypingEnv},
     },
-    span::{Span, def_id::DefId},
+    span::{DUMMY_SP, Span, def_id::DefId},
 };
 use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 use vir::{CastType, FunctionIdn};
@@ -20,7 +19,7 @@ use crate::encoders::{
     MirPureEnc, MirPureEncTask, PureKind,
     addr::RefDataEnc,
     ty::{
-        RustTyDecomposition, TySpecifics,
+        RustTyDecomposition,
         generics::{GParams, GenericParamsEnc},
         use_pure::{TyUsePure, TyUsePureEnc},
     },
@@ -30,7 +29,8 @@ use crate::encoders::{
 pub enum ConstEncTask<'vir> {
     Ty {
         const_: ty::Const<'vir>,
-        ty: RustTyDecomposition<'vir>,
+        ty: ty::Ty<'vir>,
+        context: GParams<'vir>,
     },
     Mir {
         const_: mir::Const<'vir>,
@@ -245,67 +245,32 @@ impl ConstEnc {
     fn encode_ty_const<'vir>(
         deps: &mut TaskEncoderDependencies<'vir, Self>,
         const_: ty::Const<'vir>,
-        ty: RustTyDecomposition<'vir>,
+        ty: ty::Ty<'vir>,
+        context: impl Into<GParams<'vir>>,
     ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, ConstEnc>> {
+        let ty_decomp = RustTyDecomposition::from_ty(ty, context);
+
         match const_.kind() {
             ty::ConstKind::Param(param) => {
-                let params = deps.require_dep::<GenericParamsEnc>(ty.args.context())?;
+                let params = deps.require_dep::<GenericParamsEnc>(ty_decomp.args.context())?;
                 Ok(params.const_expr(param))
             }
             ty::ConstKind::Value(val) => {
                 let val = vir::with_vcx(|vcx| vcx.tcx().valtree_to_const_val(val));
-                Self::encode_const_val_ty(deps, val, ty)
+                let ty_ctxt_at = vir::with_vcx(|vcx| vcx.tcx().at(DUMMY_SP));
+                let (ecx, valtree) =
+                    mk_eval_cx_for_const_val(ty_ctxt_at, TypingEnv::fully_monomorphized(), val, ty)
+                        .unwrap();
+                let mut enc = Enc {
+                    ecx: &ecx,
+                    deps,
+                    span: DUMMY_SP,
+                    functions: Vec::new(),
+                };
+                enc.encode_const_val_tree(valtree, ty_decomp)
             }
             k => todo!("const kind {k:?}"),
         }
-    }
-
-    fn encode_const_val_ty<'vir>(
-        deps: &mut TaskEncoderDependencies<'vir, Self>,
-        val: ConstValue,
-        ty: RustTyDecomposition<'vir>,
-    ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, ConstEnc>> {
-        let ty_enc = deps.require_dep::<TyUsePureEnc>(ty)?;
-        Ok(match val {
-            ConstValue::Scalar(s) => Self::encode_scalar_ty(deps, s, ty, ty_enc)?,
-            ConstValue::ZeroSized => {
-                let s = ty_enc.expect_structlike();
-                s.field_snaps_to_snap(Vec::new())
-            }
-            // Encode `&str` constants to an opaque domain. If we ever want to perform string reasoning
-            // we will need to revisit this encoding, but for the moment this allows assertions to avoid
-            // crashing Prusti.
-            ConstValue::Slice { meta, .. } => {
-                let kind = ty
-                    .ty
-                    .ref_data()
-                    .expect("slice constant should be a reference type");
-                let metadata_ty = kind.metadata.decompose_normalize(ty.args);
-                assert!(
-                    metadata_ty.ty.expect_primitive().is_usize(),
-                    "slice constant metadata should be a usize"
-                );
-                let ref_ty = ty_enc.expect_immref();
-
-                let metadata = deps
-                    .require_dep::<TyUsePureEnc>(metadata_ty)?
-                    .expect_primitive();
-                let inner_ty = kind.referent.decompose_normalize(ty.args);
-                let inner = deps.require_dep::<TyUsePureEnc>(inner_ty)?;
-                let TySpecifics::Opaque(inner) = &inner.specifics else {
-                    todo!("ConstValue::Slice: {ty:?}");
-                };
-                // first, we create the metadata and string snapshots
-                let meta =
-                    metadata.expr_from_bits(*metadata_ty.ty.expect_primitive(), meta as u128);
-                let meta = metadata.prim_to_snap(meta).upcast_ty();
-                // TODO: this should use `fresh_function` instead to get a different value for different constants!
-                let inner = (inner.arbitrary)().upcast_ty();
-                // wrap it in a ref
-                vir::with_vcx(|vcx| ref_ty.prim_to_snap(vcx.mk_null(), meta, inner))
-            }
-            ConstValue::Indirect { .. } => todo!("ConstValue::Indirect"),
-        })
     }
 
     fn encode_scalar_ty<'vir>(
@@ -385,9 +350,14 @@ impl TaskEncoder for ConstEnc {
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(*task_key, ())?;
         Ok(match *task_key {
-            ConstEncTask::Ty { const_, ty } => {
-                (Vec::new(), Self::encode_ty_const(deps, const_, ty)?)
-            }
+            ConstEncTask::Ty {
+                const_,
+                ty,
+                context,
+            } => (
+                Vec::new(),
+                Self::encode_ty_const(deps, const_, ty, context)?,
+            ),
             ConstEncTask::Mir {
                 const_,
                 encoding_depth,
@@ -426,8 +396,7 @@ impl TaskEncoder for ConstEnc {
                     }
                 })?,
                 mir::Const::Ty(ty, const_) => {
-                    let ty = RustTyDecomposition::from_ty(ty, def_id);
-                    (Vec::new(), Self::encode_ty_const(deps, const_, ty)?)
+                    (Vec::new(), Self::encode_ty_const(deps, const_, ty, def_id)?)
                 }
             },
         })

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -57,7 +57,10 @@ thread_local! {
 struct Enc<'enc, 'vir: 'enc> {
     deps: &'enc mut TaskEncoderDependencies<'vir, ConstEnc>,
     ecx: &'enc InterpCx<'vir, CompileTimeMachine<'vir>>,
-    span: Span,
+    /// Source location the constant originates from, used only to name the
+    /// emitted functions. Type-level constants lose their span (a monomorphized
+    /// valtree has no source location), so this is `None` for them.
+    span: Option<Span>,
     functions: Vec<vir::Function<'vir>>,
 }
 
@@ -215,18 +218,23 @@ impl<'enc, 'vir: 'enc> Enc<'enc, 'vir> {
                 v
             });
             // `source_callsite()` walks out of any macro expansion to the user's call site.
-            let span_pos = vcx
-                .tcx()
-                .sess
-                .source_map()
-                .lookup_char_pos(self.span.source_callsite().lo());
-            let idn = vir::vir_format_identifier!(
-                vcx,
-                "const_{}_{}_{}",
-                span_pos.line,
-                span_pos.col_display,
-                id,
-            );
+            let idn = match self.span {
+                Some(span) => {
+                    let span_pos = vcx
+                        .tcx()
+                        .sess
+                        .source_map()
+                        .lookup_char_pos(span.source_callsite().lo());
+                    vir::vir_format_identifier!(
+                        vcx,
+                        "const_{}_{}_{}",
+                        span_pos.line,
+                        span_pos.col_display,
+                        id,
+                    )
+                }
+                None => vir::vir_format_identifier!(vcx, "const_{id}"),
+            };
             let gen_snap_func_idn: FunctionIdn<'_, (), T> = FunctionIdn::new(idn, (), result_ty);
             self.functions.push(vcx.mk_function(
                 gen_snap_func_idn,
@@ -246,30 +254,19 @@ impl ConstEnc {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
         const_: ty::Const<'vir>,
         ty: ty::Ty<'vir>,
-        context: impl Into<GParams<'vir>>,
+        context: GParams<'vir>,
     ) -> EncodeFullResult<'vir, Self> {
-        let ty_decomp = RustTyDecomposition::from_ty(ty, context);
-
         match const_.kind() {
             ty::ConstKind::Param(param) => {
+                let ty_decomp = RustTyDecomposition::from_ty(ty, context);
                 let params = deps.require_dep::<GenericParamsEnc>(ty_decomp.args.context())?;
                 Ok((Vec::new(), params.const_expr(param)))
             }
             ty::ConstKind::Value(val) => {
                 let val = vir::with_vcx(|vcx| vcx.tcx().valtree_to_const_val(val));
-                // TODO: Exchange DUMMY_SP here and below with an actual Span. Otherwise opaque functions will always start with const_1_0
-                let ty_ctxt_at = vir::with_vcx(|vcx| vcx.tcx().at(DUMMY_SP));
-                let (ecx, valtree) =
-                    mk_eval_cx_for_const_val(ty_ctxt_at, TypingEnv::fully_monomorphized(), val, ty)
-                        .unwrap();
-                let mut enc = Enc {
-                    ecx: &ecx,
-                    deps,
-                    span: DUMMY_SP,
-                    functions: Vec::new(),
-                };
-                let expr = enc.encode_const_val_tree(valtree, ty_decomp)?;
-                Ok((enc.functions, expr))
+                // Type-level constants carry no span, so the emitted functions
+                // are named from the counter alone.
+                Self::encode_const_val(deps, val, ty, context, None)
             }
             k => todo!("const kind {k:?}"),
         }
@@ -302,9 +299,11 @@ impl ConstEnc {
         val: ConstValue,
         ty: ty::Ty<'vir>,
         context: GParams<'vir>,
-        span: Span,
+        span: Option<Span>,
     ) -> EncodeFullResult<'vir, Self> {
-        let ty_ctxt_at = vir::with_vcx(|vcx| vcx.tcx().at(span));
+        // The span only steers const-eval diagnostics; the error itself is
+        // propagated, so a missing span (type-level constant) is fine here.
+        let ty_ctxt_at = vir::with_vcx(|vcx| vcx.tcx().at(span.unwrap_or(DUMMY_SP)));
         let (ecx, valtree) =
             mk_eval_cx_for_const_val(ty_ctxt_at, TypingEnv::fully_monomorphized(), val, ty)
                 .unwrap();
@@ -339,11 +338,6 @@ impl TaskEncoder for ConstEnc {
                 program.add_function(fun);
             }
         }
-        // reset the counter across compilations
-        CONST_CTR.with(|c| {
-            let v = c.get();
-            c.set(v + 1);
-        });
     }
 
     fn do_encode_full<'vir>(
@@ -364,7 +358,7 @@ impl TaskEncoder for ConstEnc {
                 span,
             } => match const_ {
                 mir::Const::Val(val, ty) => {
-                    Self::encode_const_val(deps, val, ty, def_id.into(), span)?
+                    Self::encode_const_val(deps, val, ty, def_id.into(), Some(span))?
                 }
                 mir::Const::Unevaluated(uneval, ty) => vir::with_vcx(|vcx| {
                     let resolved = {
@@ -373,7 +367,7 @@ impl TaskEncoder for ConstEnc {
                             .const_eval_resolve(typing_env, uneval, vcx.tcx().def_span(def_id))
                     };
                     if let Ok(val) = resolved {
-                        Self::encode_const_val(deps, val, ty, def_id.into(), span)
+                        Self::encode_const_val(deps, val, ty, def_id.into(), Some(span))
                     } else if let Some(promoted) = uneval.promoted {
                         let task = MirPureEncTask {
                             encoding_depth: encoding_depth + 1,
@@ -394,7 +388,9 @@ impl TaskEncoder for ConstEnc {
                         todo!("const too generic")
                     }
                 })?,
-                mir::Const::Ty(ty, const_) => Self::encode_ty_const(deps, const_, ty, def_id)?,
+                mir::Const::Ty(ty, const_) => {
+                    Self::encode_ty_const(deps, const_, ty, def_id.into())?
+                }
             },
         })
     }

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -247,16 +247,17 @@ impl ConstEnc {
         const_: ty::Const<'vir>,
         ty: ty::Ty<'vir>,
         context: impl Into<GParams<'vir>>,
-    ) -> Result<vir::ExprCSnap<'vir>, EncodeFullError<'vir, ConstEnc>> {
+    ) -> EncodeFullResult<'vir, Self> {
         let ty_decomp = RustTyDecomposition::from_ty(ty, context);
 
         match const_.kind() {
             ty::ConstKind::Param(param) => {
                 let params = deps.require_dep::<GenericParamsEnc>(ty_decomp.args.context())?;
-                Ok(params.const_expr(param))
+                Ok((Vec::new(), params.const_expr(param)))
             }
             ty::ConstKind::Value(val) => {
                 let val = vir::with_vcx(|vcx| vcx.tcx().valtree_to_const_val(val));
+                // TODO: Exchange DUMMY_SP here and below with an actual Span. Otherwise opaque functions will always start with const_1_0
                 let ty_ctxt_at = vir::with_vcx(|vcx| vcx.tcx().at(DUMMY_SP));
                 let (ecx, valtree) =
                     mk_eval_cx_for_const_val(ty_ctxt_at, TypingEnv::fully_monomorphized(), val, ty)
@@ -267,7 +268,8 @@ impl ConstEnc {
                     span: DUMMY_SP,
                     functions: Vec::new(),
                 };
-                enc.encode_const_val_tree(valtree, ty_decomp)
+                let expr = enc.encode_const_val_tree(valtree, ty_decomp)?;
+                Ok((enc.functions, expr))
             }
             k => todo!("const kind {k:?}"),
         }
@@ -354,10 +356,7 @@ impl TaskEncoder for ConstEnc {
                 const_,
                 ty,
                 context,
-            } => (
-                Vec::new(),
-                Self::encode_ty_const(deps, const_, ty, context)?,
-            ),
+            } => Self::encode_ty_const(deps, const_, ty, context)?,
             ConstEncTask::Mir {
                 const_,
                 encoding_depth,
@@ -395,9 +394,7 @@ impl TaskEncoder for ConstEnc {
                         todo!("const too generic")
                     }
                 })?,
-                mir::Const::Ty(ty, const_) => {
-                    (Vec::new(), Self::encode_ty_const(deps, const_, ty, def_id)?)
-                }
+                mir::Const::Ty(ty, const_) => Self::encode_ty_const(deps, const_, ty, def_id)?,
             },
         })
     }

--- a/prusti-encoder/src/encoders/ty/generics/args_ty.rs
+++ b/prusti-encoder/src/encoders/ty/generics/args_ty.rs
@@ -82,8 +82,11 @@ impl TaskEncoder for GArgsTyEnc {
                     ty::ConstKind::Param(p) => task_key.context.expect_const(p.index as usize).1,
                     other => unreachable!("unexpected ConstKind: {other:?}"),
                 };
-                let ty = RustTyDecomposition::from_ty(ty, task_key.context);
-                deps.require_dep::<ConstEnc>(ConstEncTask::Ty { const_, ty })
+                deps.require_dep::<ConstEnc>(ConstEncTask::Ty {
+                    const_,
+                    ty,
+                    context: task_key.context,
+                })
             })
             .collect::<Result<Vec<_>, _>>()?;
         let args = vir::with_vcx(|vcx| GArgsTy {

--- a/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
@@ -706,8 +706,11 @@ impl TraitImplEnc {
                     let projection =
                         trait_.assoc_consts[&proj_pred.def_id()](gargs.get_ty(), gargs.get_const());
                     let ty = tcx.type_of(proj_pred.def_id()).instantiate_identity();
-                    let ty = RustTyDecomposition::from_ty(ty, impl_ctx);
-                    let const_task = ConstEncTask::Ty { const_, ty };
+                    let const_task = ConstEncTask::Ty {
+                        const_,
+                        ty,
+                        context: impl_ctx,
+                    };
                     let const_expr = deps.require_dep::<ConstEnc>(const_task)?;
                     if let ty::ConstKind::Param(p) = const_.kind() {
                         generics_map

--- a/prusti-encoder/src/encoders/ty/kinds/opaque.rs
+++ b/prusti-encoder/src/encoders/ty/kinds/opaque.rs
@@ -8,10 +8,9 @@ use task_encoder::{EncodeFullError, TaskEncoderDependencies};
 pub(crate) fn ty_pure<'vir>(
     _data: &RustOpaque<'vir>,
     _deps: &mut TaskEncoderDependencies<'vir, TyPureEnc>,
-    builder: &mut DomainBuilder<'vir>,
+    _builder: &mut DomainBuilder<'vir>,
 ) -> Result<TyPureOpaque<'vir>, EncodeFullError<'vir, TyPureEnc>> {
-    let arbitrary = builder.function("arbitrary", (), builder.self_type());
-    Ok(TyPureOpaqueData { arbitrary })
+    Ok(TyPureOpaqueData {})
 }
 
 pub(crate) fn ty_impure<'vir>(

--- a/prusti-encoder/src/encoders/ty/pure.rs
+++ b/prusti-encoder/src/encoders/ty/pure.rs
@@ -28,7 +28,7 @@ pub(super) type PureTyDatas = ViperTyDatas<Pure>;
 
 impl<'vir> TyDatas<'vir> for PureTyDatas {
     type TyData = TyPureRef<'vir>;
-    type OpaqueData = TyPureOpaqueData<'vir>;
+    type OpaqueData = TyPureOpaqueData;
     type ArrayData = TyPureArrayData<'vir>;
     type PrimitiveData = TyPurePrimData<'vir>;
     type ImmRefData = TyPureImmRefData<'vir>;
@@ -61,11 +61,7 @@ pub enum TyPureBuiltinData {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct TyPureOpaqueData<'vir> {
-    /// Some arbitrary value of this type. Should probably be removed
-    /// eventually, but used for now in e.g. the str-const encoding.
-    pub arbitrary: FunctionIdn<'vir, (), vir::CSnap>,
-}
+pub struct TyPureOpaqueData {}
 
 /// Pure data for a raw pointer. Modelled like a reference (`TyPureImmRefData`)
 /// but with the pointee left opaque: the snapshot carries the address and the


### PR DESCRIPTION
This PR combines the control flows for mir consts and ty val consts by using the ECX for the latter as well. This PR also removes the use of arbitrary values for string consts completely (instead, each const leads to one fresh function). 
Because of the unavailability of span in args_ty.rs, ty consts currently use a dummy span, meaning that the fresh constant functions will always start with `const_1_0`