### PR TITLE
Add test for impl with const params

### DIFF
--- a/prusti-tests/tests/verify/pass/generic/const-params.rs
+++ b/prusti-tests/tests/verify/pass/generic/const-params.rs
@@ -1,0 +1,34 @@
+#![feature(adt_const_params)]
+
+use std::marker::ConstParamTy;
+
+#[derive(ConstParamTy, PartialEq, Eq)]
+struct A {
+    x: i32
+}
+
+impl A {
+    fn foo(&self) -> i32 {
+        self.x
+    }
+}
+
+fn alpha<const X: A>() -> i32 {
+    X.foo()
+}
+
+fn beta() {
+    let x = <Bar as Foo<{A {x: 5}}>>::foo();
+}
+
+trait Foo<const X: A> {
+    fn foo() -> i32;
+}
+
+struct Bar {}
+
+impl<const X: A> Foo<X> for Bar {
+    fn foo() -> i32 {
+        X.x
+    }
+}


### PR DESCRIPTION
This PR fixes an issue, where const params of trait impls were not added to the axioms of the pre- and postconditions. The provided test file used to crash Prusti, the PR solves this crash.