### PR TITLE
Improve `impl` spec inheritance and refinement diagnostics

### DIFF
--- a/prusti-contracts/prusti-specs/src/lib.rs
+++ b/prusti-contracts/prusti-specs/src/lib.rs
@@ -625,6 +625,7 @@ pub fn refine_trait_spec(_attr: TokenStream, tokens: TokenStream) -> TokenStream
     impl_block.items = new_items;
     quote_spanned! {impl_block.span()=>
         #(#generated_spec_items)*
+        #[prusti::refine_trait_spec]
         #[prusti::specs_version = #SPECS_VERSION]
         #impl_block
     }

--- a/prusti-contracts/prusti-specs/src/lib.rs
+++ b/prusti-contracts/prusti-specs/src/lib.rs
@@ -58,7 +58,7 @@ macro_rules! result_to_tokens {
 
 fn extract_prusti_attributes(
     item: &mut untyped::AnyFnItem,
-) -> Vec<(SpecAttributeKind, TokenStream)> {
+) -> Vec<(SpecAttributeKind, Span, TokenStream)> {
     let mut prusti_attributes = Vec::new();
     let mut regular_attributes = Vec::new();
     for attr in item.attrs_mut().drain(0..) {
@@ -67,6 +67,9 @@ fn extract_prusti_attributes(
         {
             let idx = attr.path.segments.len() - 1;
             if let Ok(attr_kind) = attr.path.segments[idx].ident.to_string().try_into() {
+                // The span of the annotation itself, so diagnostics can point
+                // at the specific attribute rather than the whole item.
+                let attr_span = attr.path.span();
                 let tokens = match attr_kind {
                     SpecAttributeKind::Requires
                     | SpecAttributeKind::Ensures
@@ -98,7 +101,7 @@ fn extract_prusti_attributes(
                         unreachable!("print_counterexample on function")
                     }
                 };
-                prusti_attributes.push((attr_kind, tokens));
+                prusti_attributes.push((attr_kind, attr_span, tokens));
             } else {
                 regular_attributes.push(attr);
             }
@@ -121,8 +124,9 @@ pub fn rewrite_prusti_attributes(
 ) -> TokenStream {
     let mut item: untyped::AnyFnItem = handle_result!(syn::parse2(item_tokens));
 
-    // Start with the outer attribute
-    let mut prusti_attributes = vec![(outer_attr_kind, outer_attr_tokens)];
+    // Start with the outer attribute. It is the one the compiler ran as the
+    // procedural macro, so its span is the call site.
+    let mut prusti_attributes = vec![(outer_attr_kind, Span::call_site(), outer_attr_tokens)];
 
     // Collect the remaining Prusti attributes, removing them from `item`.
     prusti_attributes.extend(extract_prusti_attributes(&mut item));
@@ -130,7 +134,7 @@ pub fn rewrite_prusti_attributes(
     // make sure to also update the check in the predicate! handling method
     if prusti_attributes
         .iter()
-        .any(|(ak, _)| ak == &SpecAttributeKind::Predicate)
+        .any(|(ak, _, _)| ak == &SpecAttributeKind::Predicate)
     {
         return syn::Error::new(
             item.span(),
@@ -154,22 +158,26 @@ type GeneratedResult = syn::Result<(Vec<syn::Item>, Vec<syn::Attribute>)>;
 
 /// Generate spec items and attributes for `item` from the Prusti attributes
 fn generate_spec_and_assertions(
-    mut prusti_attributes: Vec<(SpecAttributeKind, TokenStream)>,
+    mut prusti_attributes: Vec<(SpecAttributeKind, Span, TokenStream)>,
     item: &untyped::AnyFnItem,
 ) -> GeneratedResult {
     let mut generated_items = vec![];
     let mut generated_attributes = vec![];
 
-    for (attr_kind, attr_tokens) in prusti_attributes.drain(..) {
+    for (attr_kind, attr_span, attr_tokens) in prusti_attributes.drain(..) {
         let rewriting_result = match attr_kind {
-            SpecAttributeKind::Requires => generate_for_requires(attr_tokens, item),
-            SpecAttributeKind::Ensures => generate_for_ensures(attr_tokens, item),
-            SpecAttributeKind::AfterExpiry => generate_for_after_expiry(attr_tokens, item),
-            SpecAttributeKind::AssertOnExpiry => generate_for_assert_on_expiry(attr_tokens, item),
-            SpecAttributeKind::Pure => generate_for_pure(attr_tokens, item),
-            SpecAttributeKind::Verified => generate_for_verified(attr_tokens, item),
-            SpecAttributeKind::Terminates => generate_for_terminates(attr_tokens, item),
-            SpecAttributeKind::Trusted => generate_for_trusted(attr_tokens, item),
+            SpecAttributeKind::Requires => generate_for_requires(attr_tokens, attr_span, item),
+            SpecAttributeKind::Ensures => generate_for_ensures(attr_tokens, attr_span, item),
+            SpecAttributeKind::AfterExpiry => {
+                generate_for_after_expiry(attr_tokens, attr_span, item)
+            }
+            SpecAttributeKind::AssertOnExpiry => {
+                generate_for_assert_on_expiry(attr_tokens, attr_span, item)
+            }
+            SpecAttributeKind::Pure => generate_for_pure(attr_tokens, attr_span, item),
+            SpecAttributeKind::Verified => generate_for_verified(attr_tokens, attr_span, item),
+            SpecAttributeKind::Terminates => generate_for_terminates(attr_tokens, attr_span, item),
+            SpecAttributeKind::Trusted => generate_for_trusted(attr_tokens, attr_span, item),
             // Predicates are handled separately below; the entry in the SpecAttributeKind enum
             // only exists so we successfully parse it and emit an error in
             // `check_incompatible_attrs`; so we'll never reach here.
@@ -188,7 +196,11 @@ fn generate_spec_and_assertions(
 }
 
 /// Generate spec items and attributes to typecheck the and later retrieve "requires" annotations.
-fn generate_for_requires(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult {
+fn generate_for_requires(
+    attr: TokenStream,
+    span: Span,
+    item: &untyped::AnyFnItem,
+) -> GeneratedResult {
     let mut rewriter = rewriter::AstRewriter::new();
     let spec_id = rewriter.generate_spec_id();
     let spec_id_str = spec_id.to_string();
@@ -196,14 +208,18 @@ fn generate_for_requires(attr: TokenStream, item: &untyped::AnyFnItem) -> Genera
         rewriter.process_assertion(rewriter::SpecItemType::Precondition, spec_id, attr, item)?;
     Ok((
         vec![spec_item],
-        vec![parse_quote_spanned! {item.span()=>
+        vec![parse_quote_spanned! {span=>
             #[prusti::pre_spec_id_ref = #spec_id_str]
         }],
     ))
 }
 
 /// Generate spec items and attributes to typecheck the and later retrieve "ensures" annotations.
-fn generate_for_ensures(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult {
+fn generate_for_ensures(
+    attr: TokenStream,
+    span: Span,
+    item: &untyped::AnyFnItem,
+) -> GeneratedResult {
     let mut rewriter = rewriter::AstRewriter::new();
     let spec_id = rewriter.generate_spec_id();
     let spec_id_str = spec_id.to_string();
@@ -211,28 +227,36 @@ fn generate_for_ensures(attr: TokenStream, item: &untyped::AnyFnItem) -> Generat
         rewriter.process_assertion(rewriter::SpecItemType::Postcondition, spec_id, attr, item)?;
     Ok((
         vec![spec_item],
-        vec![parse_quote_spanned! {item.span()=>
+        vec![parse_quote_spanned! {span=>
             #[prusti::post_spec_id_ref = #spec_id_str]
         }],
     ))
 }
 
 /// Generate spec items and attributes to typecheck and later retrieve "after_expiry" annotations.
-fn generate_for_after_expiry(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult {
+fn generate_for_after_expiry(
+    attr: TokenStream,
+    span: Span,
+    item: &untyped::AnyFnItem,
+) -> GeneratedResult {
     let mut rewriter = rewriter::AstRewriter::new();
     let spec_id = rewriter.generate_spec_id();
     let spec_id_str = spec_id.to_string();
     let spec_item = rewriter.process_pledge(spec_id, attr, item)?;
     Ok((
         vec![spec_item],
-        vec![parse_quote_spanned! {item.span()=>
+        vec![parse_quote_spanned! {span=>
             #[prusti::pledge_spec_id_ref = #spec_id_str]
         }],
     ))
 }
 
 /// Generate spec items and attributes to typecheck and later retrieve "after_expiry" annotations.
-fn generate_for_assert_on_expiry(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult {
+fn generate_for_assert_on_expiry(
+    attr: TokenStream,
+    span: Span,
+    item: &untyped::AnyFnItem,
+) -> GeneratedResult {
     let mut rewriter = rewriter::AstRewriter::new();
     let spec_id_lhs = rewriter.generate_spec_id();
     let spec_id_lhs_str = spec_id_lhs.to_string();
@@ -243,10 +267,10 @@ fn generate_for_assert_on_expiry(attr: TokenStream, item: &untyped::AnyFnItem) -
     Ok((
         vec![spec_item_lhs, spec_item_rhs],
         vec![
-            parse_quote_spanned! {item.span()=>
+            parse_quote_spanned! {span=>
                 #[prusti::assert_pledge_spec_id_ref_lhs = #spec_id_lhs_str]
             },
-            parse_quote_spanned! {item.span()=>
+            parse_quote_spanned! {span=>
                 #[prusti::assert_pledge_spec_id_ref_rhs = #spec_id_rhs_str]
             },
         ],
@@ -254,7 +278,11 @@ fn generate_for_assert_on_expiry(attr: TokenStream, item: &untyped::AnyFnItem) -
 }
 
 /// Generate spec items and attributes to typecheck and later retrieve "terminates" annotations.
-fn generate_for_terminates(mut attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult {
+fn generate_for_terminates(
+    mut attr: TokenStream,
+    span: Span,
+    item: &untyped::AnyFnItem,
+) -> GeneratedResult {
     if attr.is_empty() {
         attr = quote! { Int::from(1) };
     } else {
@@ -275,14 +303,14 @@ fn generate_for_terminates(mut attr: TokenStream, item: &untyped::AnyFnItem) -> 
 
     Ok((
         vec![spec_item],
-        vec![parse_quote_spanned! {item.span()=>
+        vec![parse_quote_spanned! {span=>
             #[prusti::terminates_spec_id_ref = #spec_id_str]
         }],
     ))
 }
 
 /// Generate spec items and attributes to typecheck and later retrieve "pure" annotations.
-fn generate_for_pure(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult {
+fn generate_for_pure(attr: TokenStream, span: Span, _item: &untyped::AnyFnItem) -> GeneratedResult {
     if !attr.is_empty() {
         return Err(syn::Error::new(
             attr.span(),
@@ -292,14 +320,18 @@ fn generate_for_pure(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedR
 
     Ok((
         vec![],
-        vec![parse_quote_spanned! {item.span()=>
+        vec![parse_quote_spanned! {span=>
             #[prusti::pure]
         }],
     ))
 }
 
 /// Generate spec items and attributes to typecheck and later retrieve "verified" annotations.
-fn generate_for_verified(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult {
+fn generate_for_verified(
+    attr: TokenStream,
+    span: Span,
+    _item: &untyped::AnyFnItem,
+) -> GeneratedResult {
     if !attr.is_empty() {
         return Err(syn::Error::new(
             attr.span(),
@@ -309,7 +341,7 @@ fn generate_for_verified(attr: TokenStream, item: &untyped::AnyFnItem) -> Genera
 
     Ok((
         vec![],
-        vec![parse_quote_spanned! {item.span()=>
+        vec![parse_quote_spanned! {span=>
             #[prusti::verified]
         }],
     ))
@@ -331,7 +363,11 @@ fn generate_for_pure_refinements(item: &untyped::AnyFnItem) -> GeneratedResult {
 }
 
 /// Generate spec items and attributes to typecheck and later retrieve "trusted" annotations.
-fn generate_for_trusted(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult {
+fn generate_for_trusted(
+    attr: TokenStream,
+    span: Span,
+    _item: &untyped::AnyFnItem,
+) -> GeneratedResult {
     if !attr.is_empty() {
         return Err(syn::Error::new(
             attr.span(),
@@ -341,7 +377,7 @@ fn generate_for_trusted(attr: TokenStream, item: &untyped::AnyFnItem) -> Generat
 
     Ok((
         vec![],
-        vec![parse_quote_spanned! {item.span()=>
+        vec![parse_quote_spanned! {span=>
             #[prusti::trusted]
         }],
     ))
@@ -565,8 +601,8 @@ pub fn refine_trait_spec(_attr: TokenStream, tokens: TokenStream) -> TokenStream
 
                 let illegal_attribute_span = prusti_attributes
                     .iter()
-                    .filter(|(kind, _)| kind == &SpecAttributeKind::RefineSpec)
-                    .map(|(_, tokens)| tokens.span())
+                    .filter(|(kind, _, _)| kind == &SpecAttributeKind::RefineSpec)
+                    .map(|(_, _, tokens)| tokens.span())
                     .next();
                 if let Some(span) = illegal_attribute_span {
                     let err = Err(syn::Error::new(

--- a/prusti-contracts/prusti-specs/src/type_cond_specs/mod.rs
+++ b/prusti-contracts/prusti-specs/src/type_cond_specs/mod.rs
@@ -16,8 +16,14 @@ pub fn generate(attr: TokenStream, item: &untyped::AnyFnItem) -> GeneratedResult
 
     for nested_spec in type_cond_spec.specs {
         let (mut generated_items, generated_attrs) = match nested_spec {
-            NestedSpec::Ensures(tokens) => generate_for_ensures(tokens, item)?,
-            NestedSpec::Requires(tokens) => generate_for_requires(tokens, item)?,
+            NestedSpec::Ensures(tokens) => {
+                let span = tokens.span();
+                generate_for_ensures(tokens, span, item)?
+            }
+            NestedSpec::Requires(tokens) => {
+                let span = tokens.span();
+                generate_for_requires(tokens, span, item)?
+            }
             NestedSpec::Pure => generate_for_pure_refinements(item)?,
         };
 

--- a/prusti-encoder/src/encoders/mir_fn/function.rs
+++ b/prusti-encoder/src/encoders/mir_fn/function.rs
@@ -232,12 +232,12 @@ impl TaskEncoder for FunctionEnc {
 
             let posts = spec
                 .posts
-                .into_iter()
-                .map(|post| {
+                .iter()
+                .map(|(post, _)| {
                     // use inhale-exhale expression to prevent viper checking that
                     // the function body expression satisfies the postcondition:
                     // that's checked in the method encoding of this function.
-                    vcx.mk_inhale_exhale_expr(post, vcx.mk_bool::<true>())
+                    vcx.mk_inhale_exhale_expr(*post, vcx.mk_bool::<true>())
                 })
                 .collect::<Vec<_>>();
             let posts = vcx.alloc_slice(&posts);
@@ -255,7 +255,7 @@ impl TaskEncoder for FunctionEnc {
             let caller = vcx.mk_function(
                 caller_ref,
                 (&func_args, generics.ty_decls(), generics.const_decls()),
-                vcx.alloc_slice(&spec.pres),
+                vcx.alloc_slice(&spec.pre_exprs().collect::<Vec<_>>()),
                 posts,
                 None,
                 Some(wrapped_call),

--- a/prusti-encoder/src/encoders/mir_fn/method.rs
+++ b/prusti-encoder/src/encoders/mir_fn/method.rs
@@ -349,8 +349,8 @@ impl TaskEncoder for MethodEnc {
             };
 
             // Add functional specification as the last pre- and postconditions.
-            pres.extend(spec.pres);
-            posts.extend(spec.posts);
+            pres.extend(spec.pre_exprs());
+            posts.extend(spec.post_exprs());
 
             Ok((
                 MethodEncOutput {

--- a/prusti-encoder/src/encoders/mir_fn/mod.rs
+++ b/prusti-encoder/src/encoders/mir_fn/mod.rs
@@ -98,7 +98,7 @@ pub fn encode_all_in_crate<'tcx>(tcx: ty::TyCtxt<'tcx>) {
                 let (is_pure, is_trusted) = crate::encoders::with_proc_spec(
                     SpecQuery::GetProcKind(def_id, ty::List::identity_for_item(tcx, def_id)),
                     |proc_spec| {
-                        let is_pure = proc_spec.kind.is_pure().unwrap_or_default();
+                        let is_pure = crate::encoders::kind_is_pure(def_id, &proc_spec.kind);
                         let is_trusted = proc_spec.trusted.extract_inherit().unwrap_or_default();
                         (is_pure, is_trusted)
                     },

--- a/prusti-encoder/src/encoders/mir_fn/mod.rs
+++ b/prusti-encoder/src/encoders/mir_fn/mod.rs
@@ -98,7 +98,10 @@ pub fn encode_all_in_crate<'tcx>(tcx: ty::TyCtxt<'tcx>) {
                 let (is_pure, is_trusted) = crate::encoders::with_proc_spec(
                     SpecQuery::GetProcKind(def_id, ty::List::identity_for_item(tcx, def_id)),
                     |proc_spec| {
-                        let is_pure = crate::encoders::kind_is_pure(def_id, &proc_spec.kind);
+                        // Report an invalid trait-to-impl kind refinement once,
+                        // here, rather than on every purity query.
+                        crate::encoders::report_kind_refinement_error(def_id, &proc_spec.kind);
+                        let is_pure = crate::encoders::kind_is_pure(&proc_spec.kind);
                         let is_trusted = proc_spec.trusted.extract_inherit().unwrap_or_default();
                         (is_pure, is_trusted)
                     },

--- a/prusti-encoder/src/encoders/mod.rs
+++ b/prusti-encoder/src/encoders/mod.rs
@@ -30,6 +30,7 @@ pub use pure::spec::MirSpecEnc;
 pub(super) use spec::with_proc_spec;
 pub use spec::{
     SpecEnc, SpecEncTask, is_function_pure, is_function_trusted, is_type_trusted, kind_is_pure,
+    report_kind_refinement_error,
 };
 pub use ty::{
     use_impure::TyUseImpureEnc,

--- a/prusti-encoder/src/encoders/mod.rs
+++ b/prusti-encoder/src/encoders/mod.rs
@@ -28,7 +28,9 @@ pub use mir_impure::ImpureEncVisitor;
 pub use mir_pure::{MirPureEnc, MirPureEncTask, PureKind};
 pub use pure::spec::MirSpecEnc;
 pub(super) use spec::with_proc_spec;
-pub use spec::{SpecEnc, SpecEncTask, is_function_pure, is_function_trusted, is_type_trusted};
+pub use spec::{
+    SpecEnc, SpecEncTask, is_function_pure, is_function_trusted, is_type_trusted, kind_is_pure,
+};
 pub use ty::{
     use_impure::TyUseImpureEnc,
     use_pure::TyUsePureEnc,

--- a/prusti-encoder/src/encoders/pure/spec.rs
+++ b/prusti-encoder/src/encoders/pure/spec.rs
@@ -91,14 +91,10 @@ pub struct EncodedPledge<'vir> {
 
 #[derive(Clone)]
 pub struct MirSpecEncOutput<'vir> {
-    pub pres: Vec<vir::ExprBool<'vir>>,
-    pub posts: Vec<vir::ExprBool<'vir>>,
-    /// The source spans of `pres`/`posts` (each condition's spec item). Kept
-    /// private and in lockstep with them (built by the same `unzip`); only
-    /// exposed paired with the condition via [`Self::pres_with_spans`] /
-    /// [`Self::posts_with_spans`] so the two cannot be consumed out of sync.
-    pre_spans: Vec<Span>,
-    post_spans: Vec<Span>,
+    /// Each precondition paired with the source span of its spec item.
+    pub pres: Vec<(vir::ExprBool<'vir>, Span)>,
+    /// Each postcondition paired with the source span of its spec item.
+    pub posts: Vec<(vir::ExprBool<'vir>, Span)>,
     pub pledges: Vec<EncodedPledge<'vir>>,
     pub pre_args: &'vir FxHashMap<mir::Local, vir::ExprSnap<'vir>>,
     #[allow(dead_code)]
@@ -106,22 +102,14 @@ pub struct MirSpecEncOutput<'vir> {
 }
 
 impl<'vir> MirSpecEncOutput<'vir> {
-    /// The preconditions paired with the source span of each one.
-    pub fn pres_with_spans(&self) -> impl Iterator<Item = (vir::ExprBool<'vir>, Span)> + '_ {
-        debug_assert_eq!(self.pres.len(), self.pre_spans.len());
-        self.pres
-            .iter()
-            .copied()
-            .zip(self.pre_spans.iter().copied())
+    /// The precondition expressions, discarding their spans.
+    pub fn pre_exprs(&self) -> impl Iterator<Item = vir::ExprBool<'vir>> + '_ {
+        self.pres.iter().map(|(pre, _)| *pre)
     }
 
-    /// The postconditions paired with the source span of each one.
-    pub fn posts_with_spans(&self) -> impl Iterator<Item = (vir::ExprBool<'vir>, Span)> + '_ {
-        debug_assert_eq!(self.posts.len(), self.post_spans.len());
-        self.posts
-            .iter()
-            .copied()
-            .zip(self.post_spans.iter().copied())
+    /// The postcondition expressions, discarding their spans.
+    pub fn post_exprs(&self) -> impl Iterator<Item = vir::ExprBool<'vir>> + '_ {
+        self.posts.iter().map(|(post, _)| *post)
     }
 }
 
@@ -218,7 +206,7 @@ impl TaskEncoder for MirSpecEnc {
             // it uses an unsupported feature), report the error at *that spec's*
             // span and skip only it, keeping the permission contract and the other
             // specs intact.
-            let (pres, pre_spans): (Vec<vir::ExprBool<'_>>, Vec<Span>) = specs
+            let pres: Vec<(vir::ExprBool<'_>, Span)> = specs
                 .pres
                 .iter()
                 .filter_map(|spec_def_id| {
@@ -236,7 +224,7 @@ impl TaskEncoder for MirSpecEnc {
                     let span = vcx.tcx().def_span(*spec_def_id);
                     Some((vcx.with_span(span, |_| expr), span))
                 })
-                .unzip();
+                .collect();
 
             let post_args = match enc_mode {
                 MirSpecEncMode::Impure => {
@@ -252,7 +240,7 @@ impl TaskEncoder for MirSpecEnc {
                 }
                 MirSpecEncMode::PureWithResult | MirSpecEncMode::PureWithoutResult => all_args,
             };
-            let (posts, post_spans): (Vec<vir::ExprBool<'_>>, Vec<Span>) = specs
+            let posts: Vec<(vir::ExprBool<'_>, Span)> = specs
                 .posts
                 .iter()
                 .filter_map(|spec_def_id| {
@@ -278,7 +266,7 @@ impl TaskEncoder for MirSpecEnc {
                         Some((expr, span))
                     })
                 })
-                .unzip();
+                .collect();
             let pledges = specs
                 .pledges
                 .iter()
@@ -337,8 +325,6 @@ impl TaskEncoder for MirSpecEnc {
             let data = MirSpecEncOutput {
                 pres,
                 posts,
-                pre_spans,
-                post_spans,
                 pledges,
                 pre_args,
                 post_args,

--- a/prusti-encoder/src/encoders/pure/spec.rs
+++ b/prusti-encoder/src/encoders/pure/spec.rs
@@ -93,10 +93,36 @@ pub struct EncodedPledge<'vir> {
 pub struct MirSpecEncOutput<'vir> {
     pub pres: Vec<vir::ExprBool<'vir>>,
     pub posts: Vec<vir::ExprBool<'vir>>,
+    /// The source spans of `pres`/`posts` (each condition's spec item). Kept
+    /// private and in lockstep with them (built by the same `unzip`); only
+    /// exposed paired with the condition via [`Self::pres_with_spans`] /
+    /// [`Self::posts_with_spans`] so the two cannot be consumed out of sync.
+    pre_spans: Vec<Span>,
+    post_spans: Vec<Span>,
     pub pledges: Vec<EncodedPledge<'vir>>,
     pub pre_args: &'vir FxHashMap<mir::Local, vir::ExprSnap<'vir>>,
     #[allow(dead_code)]
     pub post_args: &'vir FxHashMap<mir::Local, vir::ExprSnap<'vir>>,
+}
+
+impl<'vir> MirSpecEncOutput<'vir> {
+    /// The preconditions paired with the source span of each one.
+    pub fn pres_with_spans(&self) -> impl Iterator<Item = (vir::ExprBool<'vir>, Span)> + '_ {
+        debug_assert_eq!(self.pres.len(), self.pre_spans.len());
+        self.pres
+            .iter()
+            .copied()
+            .zip(self.pre_spans.iter().copied())
+    }
+
+    /// The postconditions paired with the source span of each one.
+    pub fn posts_with_spans(&self) -> impl Iterator<Item = (vir::ExprBool<'vir>, Span)> + '_ {
+        debug_assert_eq!(self.posts.len(), self.post_spans.len());
+        self.posts
+            .iter()
+            .copied()
+            .zip(self.post_spans.iter().copied())
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -192,7 +218,7 @@ impl TaskEncoder for MirSpecEnc {
             // it uses an unsupported feature), report the error at *that spec's*
             // span and skip only it, keeping the permission contract and the other
             // specs intact.
-            let pres = specs
+            let (pres, pre_spans): (Vec<vir::ExprBool<'_>>, Vec<Span>) = specs
                 .pres
                 .iter()
                 .filter_map(|spec_def_id| {
@@ -208,9 +234,9 @@ impl TaskEncoder for MirSpecEnc {
                     let expr = spec.expr.downcast_ty::<vir::Bool>();
                     let expr = expr.reify(vcx, (*spec_def_id, pre_args));
                     let span = vcx.tcx().def_span(*spec_def_id);
-                    Some(vcx.with_span(span, |_| expr))
+                    Some((vcx.with_span(span, |_| expr), span))
                 })
-                .collect::<Vec<vir::ExprBool<'_>>>();
+                .unzip();
 
             let post_args = match enc_mode {
                 MirSpecEncMode::Impure => {
@@ -226,7 +252,7 @@ impl TaskEncoder for MirSpecEnc {
                 }
                 MirSpecEncMode::PureWithResult | MirSpecEncMode::PureWithoutResult => all_args,
             };
-            let posts = specs
+            let (posts, post_spans): (Vec<vir::ExprBool<'_>>, Vec<Span>) = specs
                 .posts
                 .iter()
                 .filter_map(|spec_def_id| {
@@ -249,10 +275,10 @@ impl TaskEncoder for MirSpecEnc {
                         });
                         let expr = spec.expr.downcast_ty::<vir::Bool>();
                         let expr = expr.reify(vcx, (*spec_def_id, post_args));
-                        Some(expr)
+                        Some((expr, span))
                     })
                 })
-                .collect::<Vec<vir::ExprBool<'_>>>();
+                .unzip();
             let pledges = specs
                 .pledges
                 .iter()
@@ -311,6 +337,8 @@ impl TaskEncoder for MirSpecEnc {
             let data = MirSpecEncOutput {
                 pres,
                 posts,
+                pre_spans,
+                post_spans,
                 pledges,
                 pre_args,
                 post_args,

--- a/prusti-encoder/src/encoders/spec.rs
+++ b/prusti-encoder/src/encoders/spec.rs
@@ -3,7 +3,8 @@ use std::cell::RefCell;
 use prusti_interface::specs::{
     specifications::SpecQuery,
     typed::{
-        DefSpecificationMap, ExternSpecKind, Pledge, ProcedureSpecification, SpecificationItem,
+        self, DefSpecificationMap, ExternSpecKind, Pledge, ProcedureSpecification,
+        SpecificationItem,
     },
 };
 use prusti_rustc_interface::{middle::ty, span::def_id::DefId};
@@ -62,9 +63,31 @@ pub fn is_function_trusted(def_id: DefId) -> bool {
 pub fn is_function_pure<'tcx>(def_id: DefId, args: GArgs<'tcx>) -> bool {
     with_proc_spec(
         SpecQuery::GetProcKind(def_id, args.args()),
-        |proc_spec: &ProcedureSpecification| proc_spec.kind.is_pure().unwrap_or_default(),
+        |proc_spec: &ProcedureSpecification| kind_is_pure(def_id, &proc_spec.kind),
     )
     .unwrap_or_default()
+}
+
+/// `kind.is_pure()` with an invalid trait-to-impl kind refinement reported as
+/// a user error rather than silently treated as impure.
+pub fn kind_is_pure(
+    def_id: DefId,
+    kind: &SpecificationItem<typed::ProcedureSpecificationKind>,
+) -> bool {
+    kind.is_pure().unwrap_or_else(|err| {
+        let typed::ProcedureSpecificationKindError::InvalidSpecKindRefinement(base, refined) = err;
+        vir::with_vcx(|vcx| {
+            vcx.emit_early_error(prusti_interface::PrustiError::incorrect(
+                format!(
+                    "invalid specification refinement for `{}`: the trait declares the method as \
+                    {base:?} but the implementation refines it as {refined:?}",
+                    vcx.tcx().def_path_str(def_id),
+                ),
+                vcx.tcx().def_span(def_id).into(),
+            ));
+        });
+        false
+    })
 }
 
 pub fn is_type_trusted(ty: ty::Ty) -> bool {

--- a/prusti-encoder/src/encoders/spec.rs
+++ b/prusti-encoder/src/encoders/spec.rs
@@ -74,17 +74,45 @@ pub fn kind_is_pure(
     def_id: DefId,
     kind: &SpecificationItem<typed::ProcedureSpecificationKind>,
 ) -> bool {
+    use typed::ProcedureSpecificationKind::*;
     kind.is_pure().unwrap_or_else(|err| {
         let typed::ProcedureSpecificationKindError::InvalidSpecKindRefinement(base, refined) = err;
         vir::with_vcx(|vcx| {
-            vcx.emit_early_error(prusti_interface::PrustiError::incorrect(
-                format!(
-                    "invalid specification refinement for `{}`: the trait declares the method as \
-                    {base:?} but the implementation refines it as {refined:?}",
-                    vcx.tcx().def_path_str(def_id),
+            let name = vcx.tcx().def_path_str(def_id);
+            let span = vcx.tcx().def_span(def_id).into();
+            let error = match (base, refined) {
+                (Pure, Impure) => {
+                    let mut error = prusti_interface::PrustiError::incorrect(
+                        format!("`{name}` implements a `#[pure]` trait method and so must itself be `#[pure]`"),
+                        span,
+                    )
+                    .set_help("add `#[pure]` to the implementation");
+                    // Point at the `#[pure]` in the trait definition (its
+                    // `specs_version` marker is spanned at the annotation), when
+                    // the trait method is available locally.
+                    if let Some(trait_item) = vcx
+                        .tcx()
+                        .opt_associated_item(def_id)
+                        .and_then(|item| item.trait_item_def_id)
+                    {
+                        let trait_attrs = vcx.tcx().get_all_attrs(trait_item);
+                        if let Some(pure_span) =
+                            prusti_interface::utils::prusti_attr_span(trait_attrs, "pure")
+                        {
+                            error = error.add_note(
+                                "the trait method is declared `#[pure]` here",
+                                Some(pure_span),
+                            );
+                        }
+                    }
+                    error
+                }
+                _ => prusti_interface::PrustiError::incorrect(
+                    format!("the specification of `{name}` is incompatible with the trait declaration"),
+                    span,
                 ),
-                vcx.tcx().def_span(def_id).into(),
-            ));
+            };
+            vcx.emit_early_error(error);
         });
         false
     })

--- a/prusti-encoder/src/encoders/spec.rs
+++ b/prusti-encoder/src/encoders/spec.rs
@@ -63,59 +63,69 @@ pub fn is_function_trusted(def_id: DefId) -> bool {
 pub fn is_function_pure<'tcx>(def_id: DefId, args: GArgs<'tcx>) -> bool {
     with_proc_spec(
         SpecQuery::GetProcKind(def_id, args.args()),
-        |proc_spec: &ProcedureSpecification| kind_is_pure(def_id, &proc_spec.kind),
+        |proc_spec: &ProcedureSpecification| kind_is_pure(&proc_spec.kind),
     )
     .unwrap_or_default()
 }
 
-/// `kind.is_pure()` with an invalid trait-to-impl kind refinement reported as
-/// a user error rather than silently treated as impure.
-pub fn kind_is_pure(
+/// `kind.is_pure()`, treating an invalid trait-to-impl kind refinement as
+/// impure. This is a pure query; the refinement error itself is reported to
+/// the user separately by [`report_kind_refinement_error`].
+pub fn kind_is_pure(kind: &SpecificationItem<typed::ProcedureSpecificationKind>) -> bool {
+    kind.is_pure().unwrap_or(false)
+}
+
+/// Emit a user error for an invalid trait-to-impl kind refinement (e.g. an
+/// `impl` of a `#[pure]` trait method that is not itself `#[pure]`); a no-op if
+/// the refinement is valid. Kept separate from the purity query so it can be
+/// called once per function, at encoding time, rather than on every query.
+pub fn report_kind_refinement_error(
     def_id: DefId,
     kind: &SpecificationItem<typed::ProcedureSpecificationKind>,
-) -> bool {
+) {
     use typed::ProcedureSpecificationKind::*;
-    kind.is_pure().unwrap_or_else(|err| {
-        let typed::ProcedureSpecificationKindError::InvalidSpecKindRefinement(base, refined) = err;
-        vir::with_vcx(|vcx| {
-            let name = vcx.tcx().def_path_str(def_id);
-            let span = vcx.tcx().def_span(def_id).into();
-            let error = match (base, refined) {
-                (Pure, Impure) => {
-                    let mut error = prusti_interface::PrustiError::incorrect(
-                        format!("`{name}` implements a `#[pure]` trait method and so must itself be `#[pure]`"),
-                        span,
-                    )
-                    .set_help("add `#[pure]` to the implementation");
-                    // Point at the `#[pure]` in the trait definition (its
-                    // `specs_version` marker is spanned at the annotation), when
-                    // the trait method is available locally.
-                    if let Some(trait_item) = vcx
-                        .tcx()
-                        .opt_associated_item(def_id)
-                        .and_then(|item| item.trait_item_def_id)
-                    {
-                        let trait_attrs = vcx.tcx().get_all_attrs(trait_item);
-                        if let Some(pure_span) =
-                            prusti_interface::utils::prusti_attr_span(trait_attrs, "pure")
-                        {
-                            error = error.add_note(
-                                "the trait method is declared `#[pure]` here",
-                                Some(pure_span),
-                            );
-                        }
-                    }
-                    error
-                }
-                _ => prusti_interface::PrustiError::incorrect(
-                    format!("the specification of `{name}` is incompatible with the trait declaration"),
+    let Err(typed::ProcedureSpecificationKindError::InvalidSpecKindRefinement(base, refined)) =
+        kind.is_pure()
+    else {
+        return;
+    };
+    vir::with_vcx(|vcx| {
+        let name = vcx.tcx().def_path_str(def_id);
+        let span = vcx.tcx().def_span(def_id).into();
+        let error = match (base, refined) {
+            (Pure, Impure) => {
+                let mut error = prusti_interface::PrustiError::incorrect(
+                    format!("`{name}` implements a `#[pure]` trait method and so must itself be `#[pure]`"),
                     span,
-                ),
-            };
-            vcx.emit_early_error(error);
-        });
-        false
-    })
+                )
+                .set_help("add `#[pure]` to the implementation");
+                // Point at the `#[pure]` in the trait definition (its
+                // `specs_version` marker is spanned at the annotation), when
+                // the trait method is available locally.
+                if let Some(trait_item) = vcx
+                    .tcx()
+                    .opt_associated_item(def_id)
+                    .and_then(|item| item.trait_item_def_id)
+                {
+                    let trait_attrs = vcx.tcx().get_all_attrs(trait_item);
+                    if let Some(pure_span) =
+                        prusti_interface::utils::prusti_attr_span(trait_attrs, "pure")
+                    {
+                        error = error.add_note(
+                            "the trait method is declared `#[pure]` here",
+                            Some(pure_span),
+                        );
+                    }
+                }
+                error
+            }
+            _ => prusti_interface::PrustiError::incorrect(
+                format!("the specification of `{name}` is incompatible with the trait declaration"),
+                span,
+            ),
+        };
+        vcx.emit_early_error(error);
+    });
 }
 
 pub fn is_type_trusted(ty: ty::Ty) -> bool {

--- a/prusti-encoder/src/encoders/ty/generics/trait_fn.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait_fn.rs
@@ -194,7 +194,7 @@ impl TaskEncoder for TraitFnEnc {
                 (def_id, def_id, MirSpecEncMode::PureWithoutResult),
                 span,
             )?;
-            let pres = vcx.mk_conj(&spec.pres);
+            let pres = vcx.mk_conj(&spec.pre_exprs().collect::<Vec<_>>());
             let pre_func_call = pre_func.call()(
                 func_arg_exprs,
                 item_generics.ty_exprs(),
@@ -210,7 +210,7 @@ impl TaskEncoder for TraitFnEnc {
                         (pres) ==> (pre_func_call)
                 },
             ));
-            let mut posts = spec.posts;
+            let mut posts = spec.post_exprs().collect::<Vec<_>>();
             if has_body && is_pure {
                 let pure_func = deps.require_dep::<FunctionCallEnc>(
                     CallTaskDescription::new(def_id, item_params.rust_params(), def_id)

--- a/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
@@ -1,6 +1,7 @@
 use prusti_interface::PrustiError;
 use prusti_rustc_interface::{
     data_structures::fx::{FxIndexMap, FxIndexSet},
+    errors::MultiSpan,
     middle::{mir, ty},
     span::def_id::DefId,
 };
@@ -125,6 +126,11 @@ impl TaskEncoder for TraitImplEnc {
                 let mut pre_weaken_pres = impure_arg_preds.clone();
                 pre_weaken_pres.extend(trait_item_spec.pres.clone());
 
+                // Spans of the trait method's preconditions, to point the
+                // behavioral-subtyping error's hint at them.
+                let trait_pre_spans: Vec<_> =
+                    trait_item_spec.pres_with_spans().map(|(_, s)| s).collect();
+
                 methods.push(vcx.mk_method(
                     MethodIdn::<(vir::ManyRef, vir::ManyTyVal, vir::ManyCSnap)>::new(
                         vir_format_identifier!(vcx, "trait_{trait_name}_impl_{implementing_ty}_{idx}_fn_pre_weaken_{item_name}"),
@@ -138,11 +144,21 @@ impl TaskEncoder for TraitImplEnc {
                         vcx.mk_cfg_block(
                             &vir::CfgBlockLabelData::Start,
                             &[],
-                            vcx.alloc_slice(&impl_item_spec.pres.iter()
-                                .map(|pre| vcx.with_span(impl_span, |vcx| {
-                                    // TODO: make span point precisely to the precondition we cannot show
+                            vcx.alloc_slice(&impl_item_spec.pres_with_spans()
+                                .map(|(pre, pre_span)| vcx.with_span(pre_span, |vcx| {
+                                    let trait_pre_spans = trait_pre_spans.clone();
                                     vcx.handle_error("exhale.failed:assertion.false", move |_| {
-                                        Some(vec![PrustiError::verification("trait implementation is not a behavioral subtype (precondition is not weakened)", impl_span.into())])
+                                        let mut err = PrustiError::verification(
+                                            "the implementation's precondition is stronger than the trait method's",
+                                            pre_span.into(),
+                                        );
+                                        for trait_span in &trait_pre_spans {
+                                            err = err.add_note(
+                                                "the trait method's precondition is declared here",
+                                                Some(*trait_span),
+                                            );
+                                        }
+                                        Some(vec![err])
                                     });
                                     vcx.mk_exhale_stmt(pre)
                                 }))
@@ -153,7 +169,7 @@ impl TaskEncoder for TraitImplEnc {
                 ));
 
                 let mut post_strengthen_pres = impure_arg_preds;
-                post_strengthen_pres.extend(trait_item_spec.pres);
+                post_strengthen_pres.extend(trait_item_spec.pres.iter().copied());
 
                 // exceptionally, we also put the allocated result in the precondition
                 post_strengthen_pres.push(local_defs[mir::RETURN_PLACE].impure_pred);
@@ -183,11 +199,29 @@ impl TaskEncoder for TraitImplEnc {
                         ([local_defs[mir::RETURN_PLACE].impure_snap]) == ([pure_func_app])
                     }));
                 }
-                for post in trait_item_spec.posts {
+                // The failing exhale is a trait postcondition, but the problem
+                // is the impl's postcondition being too weak: point the error at
+                // the impl's postcondition(s) and hint at the trait's.
+                let impl_post_spans: Vec<_> =
+                    impl_item_spec.posts_with_spans().map(|(_, s)| s).collect();
+                for (post, trait_post_span) in trait_item_spec.posts_with_spans() {
+                    let impl_post_spans = impl_post_spans.clone();
                     vcx.with_span(impl_span, |vcx| {
-                        // TODO: make span point precisely to the postcondition we cannot show
                         vcx.handle_error("exhale.failed:assertion.false", move |_| {
-                            Some(vec![PrustiError::verification("trait implementation is not a behavioral subtype (postcondition is not strengthened)", impl_span.into())])
+                            let primary = if impl_post_spans.is_empty() {
+                                impl_span.into()
+                            } else {
+                                MultiSpan::from_spans(impl_post_spans.clone())
+                            };
+                            let err = PrustiError::verification(
+                                "the implementation's postcondition is weaker than the trait method's",
+                                primary,
+                            )
+                            .add_note(
+                                "the trait method's (stronger) postcondition is declared here",
+                                Some(trait_post_span),
+                            );
+                            Some(vec![err])
                         });
                         stmts.push(vcx.mk_exhale_stmt(post));
                     });

--- a/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait_impls.rs
@@ -124,12 +124,12 @@ impl TaskEncoder for TraitImplEnc {
                 // TODO: wands
 
                 let mut pre_weaken_pres = impure_arg_preds.clone();
-                pre_weaken_pres.extend(trait_item_spec.pres.clone());
+                pre_weaken_pres.extend(trait_item_spec.pre_exprs());
 
                 // Spans of the trait method's preconditions, to point the
                 // behavioral-subtyping error's hint at them.
                 let trait_pre_spans: Vec<_> =
-                    trait_item_spec.pres_with_spans().map(|(_, s)| s).collect();
+                    trait_item_spec.pres.iter().map(|(_, s)| *s).collect();
 
                 methods.push(vcx.mk_method(
                     MethodIdn::<(vir::ManyRef, vir::ManyTyVal, vir::ManyCSnap)>::new(
@@ -144,12 +144,12 @@ impl TaskEncoder for TraitImplEnc {
                         vcx.mk_cfg_block(
                             &vir::CfgBlockLabelData::Start,
                             &[],
-                            vcx.alloc_slice(&impl_item_spec.pres_with_spans()
+                            vcx.alloc_slice(&impl_item_spec.pres.iter().copied()
                                 .map(|(pre, pre_span)| vcx.with_span(pre_span, |vcx| {
                                     let trait_pre_spans = trait_pre_spans.clone();
                                     vcx.handle_error("exhale.failed:assertion.false", move |_| {
                                         let mut err = PrustiError::verification(
-                                            "the implementation's precondition is stronger than the trait method's",
+                                            "the implementation's precondition may be stronger than the trait method's",
                                             pre_span.into(),
                                         );
                                         for trait_span in &trait_pre_spans {
@@ -169,7 +169,7 @@ impl TaskEncoder for TraitImplEnc {
                 ));
 
                 let mut post_strengthen_pres = impure_arg_preds;
-                post_strengthen_pres.extend(trait_item_spec.pres.iter().copied());
+                post_strengthen_pres.extend(trait_item_spec.pre_exprs());
 
                 // exceptionally, we also put the allocated result in the precondition
                 post_strengthen_pres.push(local_defs[mir::RETURN_PLACE].impure_pred);
@@ -177,7 +177,7 @@ impl TaskEncoder for TraitImplEnc {
                 // here we inhale the impl postconditions, since they
                 // can contain "old" variables
                 let mut stmts = Vec::new();
-                for post in &impl_item_spec.posts {
+                for post in impl_item_spec.post_exprs() {
                     stmts.push(vcx.mk_inhale_stmt(post));
                 }
                 if impl_item_has_body && impl_item_is_pure {
@@ -203,8 +203,8 @@ impl TaskEncoder for TraitImplEnc {
                 // is the impl's postcondition being too weak: point the error at
                 // the impl's postcondition(s) and hint at the trait's.
                 let impl_post_spans: Vec<_> =
-                    impl_item_spec.posts_with_spans().map(|(_, s)| s).collect();
-                for (post, trait_post_span) in trait_item_spec.posts_with_spans() {
+                    impl_item_spec.posts.iter().map(|(_, s)| *s).collect();
+                for &(post, trait_post_span) in &trait_item_spec.posts {
                     let impl_post_spans = impl_post_spans.clone();
                     vcx.with_span(impl_span, |vcx| {
                         vcx.handle_error("exhale.failed:assertion.false", move |_| {
@@ -214,7 +214,7 @@ impl TaskEncoder for TraitImplEnc {
                                 MultiSpan::from_spans(impl_post_spans.clone())
                             };
                             let err = PrustiError::verification(
-                                "the implementation's postcondition is weaker than the trait method's",
+                                "the implementation's postcondition may be weaker than the trait method's",
                                 primary,
                             )
                             .add_note(
@@ -243,7 +243,7 @@ impl TaskEncoder for TraitImplEnc {
                     );
                     vcx.with_span(impl_span, |vcx| {
                         vcx.handle_error("exhale.failed:assertion.false", move |_| {
-                            Some(vec![PrustiError::verification("trait implementation is not a behavioral subtype (body is not strengthened)", impl_span.into())])
+                            Some(vec![PrustiError::verification("the implementation's result may differ from the trait method's (pure functions must be behavioural subtypes)", impl_span.into())])
                         });
                         stmts.push(vcx.mk_exhale_stmt(vir::expr! {
                             ([local_defs[mir::RETURN_PLACE].impure_snap]) == ([pure_func_app])
@@ -447,7 +447,7 @@ impl TaskEncoder for TraitImplConditionEnc {
                             ),
                             impl_span,
                         )?;
-                        let pres = vcx.mk_conj(&impl_item_spec.pres);
+                        let pres = vcx.mk_conj(&impl_item_spec.pre_exprs().collect::<Vec<_>>());
 
                         let signature = RustSignature::new(trait_item_def_id);
 
@@ -476,7 +476,7 @@ impl TaskEncoder for TraitImplConditionEnc {
                                     (pres) ==> (pre_func_call)
                             },
                         ));
-                        let mut posts = impl_item_spec.posts;
+                        let mut posts = impl_item_spec.post_exprs().collect::<Vec<_>>();
                         if impl_item_has_body && impl_item_is_pure {
                             let pure_func = deps.require_dep::<FunctionCallEnc>(
                                 CallTaskDescription::new(

--- a/prusti-interface/src/specs/mod.rs
+++ b/prusti-interface/src/specs/mod.rs
@@ -126,6 +126,34 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
         def_spec
     }
 
+    /// A trait implementation may only carry Prusti annotations if its `impl`
+    /// block is marked `#[refine_trait_spec]`. Without it, an annotated method
+    /// silently fails to refine the inherited trait spec (and would conflict
+    /// with a `#[pure]` trait method), so we reject it instead. Inherent impls
+    /// and trait items are unaffected.
+    fn check_trait_impl_refinement(&self, method_def_id: DefId, span: Span) {
+        let tcx = self.env.tcx();
+        let Some(impl_def_id) = tcx.impl_of_assoc(method_def_id) else {
+            return;
+        };
+        if tcx.impl_trait_ref(impl_def_id).is_none() {
+            return;
+        }
+        let Some(impl_local) = impl_def_id.as_local() else {
+            return;
+        };
+        let impl_attrs = self.env.query.get_local_attributes(impl_local);
+        if !has_prusti_attr(impl_attrs, "refine_trait_spec") {
+            PrustiError::incorrect(
+                "Prusti annotations on a trait implementation require the \
+                 `#[refine_trait_spec]` attribute on the `impl` block"
+                    .to_string(),
+                MultiSpan::from_span(span),
+            )
+            .emit(&self.env.diagnostic);
+        }
+    }
+
     fn determine_procedure_specs(&self, def_spec: &mut typed::DefSpecificationMap) {
         for (local_id, refs) in self.procedure_specs.iter() {
             let mut spec = SpecGraph::new(ProcedureSpecification::empty(local_id.to_def_id()));
@@ -539,6 +567,7 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for SpecCollector<'a, 'tcx> {
 
             // Collect procedure specifications
             if let Some(procedure_spec_ref) = get_procedure_spec_ids(def_id, attrs) {
+                self.check_trait_impl_refinement(def_id, span);
                 self.procedure_specs.insert(local_id, procedure_spec_ref);
             }
 

--- a/prusti-interface/src/specs/mod.rs
+++ b/prusti-interface/src/specs/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     environment::Environment,
     utils::{
         has_abstract_predicate_attr, has_extern_spec_attr, has_prusti_attr, has_to_model_fn_attr,
-        read_prusti_attr, read_prusti_attrs,
+        prusti_annotation_spans, read_prusti_attr, read_prusti_attrs,
     },
     PrustiError,
 };
@@ -130,8 +130,11 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
     /// block is marked `#[refine_trait_spec]`. Without it, an annotated method
     /// silently fails to refine the inherited trait spec (and would conflict
     /// with a `#[pure]` trait method), so we reject it instead. Inherent impls
-    /// and trait items are unaffected.
-    fn check_trait_impl_refinement(&self, method_def_id: DefId, span: Span) {
+    /// and trait items are unaffected. The error points at the offending
+    /// annotation (the `prusti::specs_version` marker the attribute macros emit
+    /// at the invocation site) with a note pointing at the `impl` block, where
+    /// the missing `#[refine_trait_spec]` must be added.
+    fn check_trait_impl_refinement(&self, method_def_id: DefId) {
         let tcx = self.env.tcx();
         let Some(impl_def_id) = tcx.impl_of_assoc(method_def_id) else {
             return;
@@ -143,15 +146,32 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
             return;
         };
         let impl_attrs = self.env.query.get_local_attributes(impl_local);
-        if !has_prusti_attr(impl_attrs, "refine_trait_spec") {
-            PrustiError::incorrect(
-                "Prusti annotations on a trait implementation require the \
-                 `#[refine_trait_spec]` attribute on the `impl` block"
-                    .to_string(),
-                MultiSpan::from_span(span),
-            )
-            .emit(&self.env.diagnostic);
+        if has_prusti_attr(impl_attrs, "refine_trait_spec") {
+            return;
         }
+        let method_attrs = self
+            .env
+            .query
+            .get_local_attributes(method_def_id.expect_local());
+        // Point at the offending annotation(s). Each carries its own span, so
+        // this is precise even when several are stacked. No annotation marker
+        // means no explicit annotation - e.g. the implicit trusted from opt-in
+        // verification - which must not error.
+        let annotation_spans = prusti_annotation_spans(method_attrs).collect::<Vec<_>>();
+        if annotation_spans.is_empty() {
+            return;
+        }
+        PrustiError::incorrect(
+            "Prusti annotations on a trait implementation require the \
+             `#[refine_trait_spec]` attribute on the `impl` block"
+                .to_string(),
+            MultiSpan::from_spans(annotation_spans),
+        )
+        .add_note(
+            "add `#[refine_trait_spec]` to this `impl` block",
+            Some(tcx.def_span(impl_def_id)),
+        )
+        .emit(&self.env.diagnostic);
     }
 
     fn determine_procedure_specs(&self, def_spec: &mut typed::DefSpecificationMap) {
@@ -389,33 +409,27 @@ fn get_procedure_spec_ids(def_id: DefId, attrs: &[hir::Attribute]) -> Option<Pro
 
     spec_id_refs.extend(
         read_prusti_attrs("pre_spec_id_ref", attrs)
-            .into_iter()
             .map(|raw_spec_id| SpecIdRef::Precondition(parse_spec_id(raw_spec_id, def_id))),
     );
     spec_id_refs.extend(
         read_prusti_attrs("post_spec_id_ref", attrs)
-            .into_iter()
             .map(|raw_spec_id| SpecIdRef::Postcondition(parse_spec_id(raw_spec_id, def_id))),
     );
     spec_id_refs.extend(
         read_prusti_attrs("pure_spec_id_ref", attrs)
-            .into_iter()
             .map(|raw_spec_id| SpecIdRef::Purity(parse_spec_id(raw_spec_id, def_id))),
     );
     spec_id_refs.extend(
         read_prusti_attrs("terminates_spec_id_ref", attrs)
-            .into_iter()
             .map(|raw_spec_id| SpecIdRef::Terminates(parse_spec_id(raw_spec_id, def_id))),
     );
     spec_id_refs.extend(
         // TODO: pledges with LHS that is not "result" would need to carry the
         // LHS expression through typing
-        read_prusti_attrs("pledge_spec_id_ref", attrs)
-            .into_iter()
-            .map(|raw_spec_id| SpecIdRef::Pledge {
-                lhs: None,
-                rhs: parse_spec_id(raw_spec_id, def_id),
-            }),
+        read_prusti_attrs("pledge_spec_id_ref", attrs).map(|raw_spec_id| SpecIdRef::Pledge {
+            lhs: None,
+            rhs: parse_spec_id(raw_spec_id, def_id),
+        }),
     );
     match (
         read_prusti_attr("assert_pledge_spec_id_ref_lhs", attrs),
@@ -567,7 +581,7 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for SpecCollector<'a, 'tcx> {
 
             // Collect procedure specifications
             if let Some(procedure_spec_ref) = get_procedure_spec_ids(def_id, attrs) {
-                self.check_trait_impl_refinement(def_id, span);
+                self.check_trait_impl_refinement(def_id);
                 self.procedure_specs.insert(local_id, procedure_spec_ref);
             }
 

--- a/prusti-interface/src/specs/specifications.rs
+++ b/prusti-interface/src/specs/specifications.rs
@@ -166,15 +166,18 @@ impl<'tcx> Specifications<'tcx> {
         impl_query: &SpecQuery<'tcx>,
         trait_query: &SpecQuery<'tcx>,
     ) -> Option<&'a ProcedureSpecification> {
-        let impl_spec = self
-            .get_proc_spec(impl_query)
-            .cloned()
-            .unwrap_or_else(|| ProcedureSpecification::empty(impl_query.referred_def_id()));
-
         let trait_spec = self
             .get_proc_spec(trait_query)
             .cloned()
             .unwrap_or_else(|| ProcedureSpecification::empty(trait_query.referred_def_id()));
+
+        // A trait impl that does not carry a `#[refine_trait_spec]` has no
+        // annotations (enforced during collection) and hence no spec entry:
+        // it inherits the trait spec wholesale. An impl that does refine has a
+        // spec entry, which refines the trait spec below.
+        let impl_spec = self.get_proc_spec(impl_query).cloned().unwrap_or_else(|| {
+            ProcedureSpecification::empty_inheriting(impl_query.referred_def_id())
+        });
         let refined = impl_spec.refine(&trait_spec);
 
         self.refined_specs.insert(*impl_query, refined);

--- a/prusti-interface/src/specs/typed.rs
+++ b/prusti-interface/src/specs/typed.rs
@@ -226,6 +226,25 @@ impl ProcedureSpecification {
             purity: SpecificationItem::Inherent(None),
         }
     }
+
+    /// Like [Self::empty], but with every item `Empty` so that refinement
+    /// against a trait spec inherits it wholesale. Used for a trait impl that
+    /// does not carry `#[refine_trait_spec]`: it has no annotations of its own
+    /// (enforced during collection), so unlike [Self::empty] its defaults must
+    /// not override the trait spec (e.g. with an impure kind).
+    pub fn empty_inheriting(source: DefId) -> Self {
+        ProcedureSpecification {
+            source,
+            extern_spec: None,
+            kind: SpecificationItem::Empty,
+            pres: SpecificationItem::Empty,
+            posts: SpecificationItem::Empty,
+            pledges: SpecificationItem::Empty,
+            trusted: SpecificationItem::Empty,
+            terminates: SpecificationItem::Empty,
+            purity: SpecificationItem::Empty,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, TyEncodable, TyDecodable)]

--- a/prusti-interface/src/utils.rs
+++ b/prusti-interface/src/utils.rs
@@ -9,6 +9,7 @@
 use prusti_rustc_interface::{
     hir,
     middle::{mir, ty::TyCtxt},
+    span::Span,
 };
 use std::borrow::Borrow;
 
@@ -85,21 +86,46 @@ impl<'tcx> VecPlace<'tcx> {
     }
 }
 
+/// Returns an iterator over all Prusti attributes (i.e. `prusti::<attr_name>="...")`.
+fn get_prusti_attrs<T: Borrow<hir::Attribute>>(
+    attrs: &[T],
+) -> impl Iterator<Item = &hir::AttrItem> {
+    attrs.iter().filter_map(|attr| match attr.borrow() {
+        hir::Attribute::Unparsed(item)
+            if item.path.segments.len() == 2 && item.path.segments[0].as_str() == "prusti" =>
+        {
+            Some(&**item)
+        }
+        _ => None,
+    })
+}
+
+fn get_prusti_attr<'a, T: Borrow<hir::Attribute>>(
+    attrs: &'a [T],
+    attr_name: &str,
+) -> Option<&'a hir::AttrItem> {
+    get_prusti_attrs(attrs).find(|item| item.path.segments[1].as_str() == attr_name)
+}
+
 /// Check if `prusti::<name>` is among the attributes.
 /// Any arguments of the attribute are ignored.
 pub fn has_prusti_attr(attrs: &[hir::Attribute], name: &str) -> bool {
-    attrs.iter().any(|attr| match attr {
-        hir::Attribute::Unparsed(normal_attr) => {
-            let hir::AttrItem {
-                span: _,
-                path: hir::AttrPath { span: _, segments },
-                args: _,
-                ..
-            } = &**normal_attr;
-            segments.len() == 2 && segments[0].as_str() == "prusti" && segments[1].as_str() == name
-        }
-        _ => false,
-    })
+    get_prusti_attr(attrs, name).is_some()
+}
+
+/// The span of the `prusti::<name>` marker among `attrs`, if present.
+pub fn prusti_attr_span(attrs: &[hir::Attribute], name: &str) -> Option<Span> {
+    get_prusti_attr(attrs, name).map(|item| item.span)
+}
+
+/// The spans of the user's Prusti annotations among `attrs`: every
+/// `prusti::<name>` marker except the per-item version marker. Each marker is
+/// emitted at its own annotation's span, so these point at the individual
+/// attributes rather than the whole item.
+pub fn prusti_annotation_spans(attrs: &[hir::Attribute]) -> impl Iterator<Item = Span> + '_ {
+    get_prusti_attrs(attrs)
+        .filter(|item| item.path.segments[1].as_str() != "specs_version")
+        .map(|item| item.span)
 }
 
 /// Check if `prusti::spec_only` is among the attributes.
@@ -137,35 +163,21 @@ pub fn has_abstract_predicate_attr(attrs: &[hir::Attribute]) -> bool {
 }
 
 /// Read the value stored in a Prusti attribute (e.g. `prusti::<attr_name>="...")`.
-pub fn read_prusti_attrs<T: Borrow<hir::Attribute>>(attr_name: &str, attrs: &[T]) -> Vec<String> {
-    let mut strings = vec![];
-    for attr in attrs {
-        if let hir::Attribute::Unparsed(normal_attr) = &attr.borrow() {
-            if let hir::AttrItem {
-                span: _,
-                path: hir::AttrPath { span: _, segments },
-                args: hir::AttrArgs::Eq { expr, eq_span: _ },
-                ..
-            } = &**normal_attr
-            {
-                // Skip attributes whose path don't match with "prusti::<attr_name>"
-                if !(segments.len() == 2
-                    && segments[0].as_str() == "prusti"
-                    && segments[1].as_str() == attr_name)
-                {
-                    continue;
-                }
-                fn extract_string(token: &prusti_rustc_interface::ast::token::Lit) -> String {
-                    token.symbol.as_str().replace("\\\"", "\"")
-                }
-                strings.push(extract_string(&expr.as_token_lit()));
+pub fn read_prusti_attrs<'a, T: Borrow<hir::Attribute>>(
+    attr_name: &'a str,
+    attrs: &'a [T],
+) -> impl Iterator<Item = String> + 'a {
+    get_prusti_attrs(attrs)
+        .filter(move |item| item.path.segments[1].as_str() == attr_name)
+        .filter_map(|item| match &item.args {
+            hir::AttrArgs::Eq { expr, .. } => {
+                Some(expr.as_token_lit().symbol.as_str().replace("\\\"", "\""))
             }
-        };
-    }
-    strings
+            _ => None,
+        })
 }
 
 /// Read the value stored in a single Prusti attribute (e.g. `prusti::<attr_name>="...")`.
 pub fn read_prusti_attr<T: Borrow<hir::Attribute>>(attr_name: &str, attrs: &[T]) -> Option<String> {
-    read_prusti_attrs(attr_name, attrs).pop()
+    read_prusti_attrs(attr_name, attrs).next()
 }

--- a/prusti-tests/tests/verify/fail/trait-contracts-refinement/annotation-requires-refine.rs
+++ b/prusti-tests/tests/verify/fail/trait-contracts-refinement/annotation-requires-refine.rs
@@ -1,0 +1,19 @@
+//! Prusti annotations on a trait implementation are only allowed if the `impl`
+//! block is marked `#[refine_trait_spec]`. Otherwise the annotation would
+//! silently fail to refine the inherited trait specification, so it is rejected.
+
+use prusti_contracts::*;
+
+trait Trait {
+    #[pure]
+    fn foo(&self) -> i32;
+}
+
+struct Struct;
+
+impl Trait for Struct {
+    #[trusted] //~ ERROR: Prusti annotations on a trait implementation require the `#[refine_trait_spec]` attribute on the `impl` block
+    fn foo(&self) -> i32 {
+        5
+    }
+}

--- a/prusti-tests/tests/verify/fail/trait-contracts-refinement/refine-behavioural.rs
+++ b/prusti-tests/tests/verify/fail/trait-contracts-refinement/refine-behavioural.rs
@@ -18,8 +18,8 @@ struct Struct;
 
 #[refine_trait_spec]
 impl Trait for Struct {
-    #[requires(x > 2)] //~ ERROR: the implementation's precondition is stronger than the trait method's
-    #[ensures(result >= 0)] //~ ERROR: the implementation's postcondition is weaker than the trait method's
+    #[requires(x > 2)] //~ ERROR: the implementation's precondition may be stronger than the trait method's
+    #[ensures(result >= 0)] //~ ERROR: the implementation's postcondition may be weaker than the trait method's
     #[ensures(result <= 99)]
     fn foo(&self, x: i32) -> i32 {
         10

--- a/prusti-tests/tests/verify/fail/trait-contracts-refinement/refine-behavioural.rs
+++ b/prusti-tests/tests/verify/fail/trait-contracts-refinement/refine-behavioural.rs
@@ -1,0 +1,27 @@
+//! A `#[refine_trait_spec]` implementation must be a behavioral subtype of the
+//! trait method it refines: its precondition may only be weaker (accept more)
+//! and its postcondition only stronger (promise more). Here the implementation
+//! does the opposite - a stronger precondition and a weaker postcondition - so
+//! both are rejected.
+
+use prusti_contracts::*;
+
+trait Trait {
+    #[requires(x > 1)]
+    #[requires(x < 100)]
+    #[ensures(result >= 0)]
+    #[ensures(result < 99)]
+    fn foo(&self, x: i32) -> i32;
+}
+
+struct Struct;
+
+#[refine_trait_spec]
+impl Trait for Struct {
+    #[requires(x > 2)] //~ ERROR: the implementation's precondition is stronger than the trait method's
+    #[ensures(result >= 0)] //~ ERROR: the implementation's postcondition is weaker than the trait method's
+    #[ensures(result <= 99)]
+    fn foo(&self, x: i32) -> i32 {
+        10
+    }
+}

--- a/prusti-tests/tests/verify/fail/trait-contracts-refinement/refine-missing-pure.rs
+++ b/prusti-tests/tests/verify/fail/trait-contracts-refinement/refine-missing-pure.rs
@@ -1,0 +1,22 @@
+//! A `#[refine_trait_spec]` implementation takes over the specification of the
+//! trait method it refines. If the trait method is `#[pure]` but the refining
+//! implementation omits `#[pure]`, it would refine a pure method into an impure
+//! one, which is rejected.
+
+use prusti_contracts::*;
+
+trait Trait {
+    #[pure]
+    fn foo(&self) -> i32;
+}
+
+struct Struct;
+
+#[refine_trait_spec]
+impl Trait for Struct {
+    // Missing `#[pure]` while refining a pure trait method.
+    #[ensures(result == 5)]
+    fn foo(&self) -> i32 { //~ ERROR: implements a `#[pure]` trait method and so must itself be `#[pure]`
+        5
+    }
+}

--- a/prusti-tests/tests/verify/pass/simple-specs/timeout.rs
+++ b/prusti-tests/tests/verify/pass/simple-specs/timeout.rs
@@ -35,6 +35,7 @@ pub fn test2<T: Copy>(x: &Pair<T>) -> T {
 }
 
 use std::ops::Add;
+#[refine_trait_spec]
 impl<'a, T> Add<&'a Pair<T>> for Pair<T> {
     type Output = Pair<T>;
 

--- a/prusti-tests/tests/verify/pass/trait-contracts-refinement/inherit-unrefined.rs
+++ b/prusti-tests/tests/verify/pass/trait-contracts-refinement/inherit-unrefined.rs
@@ -1,0 +1,30 @@
+//! A trait implementation that is *not* marked `#[refine_trait_spec]` carries
+//! no specification of its own and inherits the trait method's specification
+//! wholesale. In particular it inherits the `#[pure]` kind, so the method stays
+//! usable inside pure functions and specifications without repeating `#[pure]`.
+
+use prusti_contracts::*;
+
+trait Trait {
+    #[pure]
+    fn foo(&self) -> i32;
+}
+
+struct Struct;
+
+// No `#[refine_trait_spec]` and no `#[pure]` here: both are inherited.
+impl Trait for Struct {
+    fn foo(&self) -> i32 {
+        5
+    }
+}
+
+// Usable in a pure function only because `foo` inherited `#[pure]`.
+#[pure]
+fn get(s: &Struct) -> i32 {
+    s.foo()
+}
+
+// Usable in a specification for the same reason.
+#[requires(s.foo() == 5)]
+fn requires_foo(s: &Struct) {}

--- a/prusti-tests/tests/verify/pass/trait-contracts-refinement/refine-pure.rs
+++ b/prusti-tests/tests/verify/pass/trait-contracts-refinement/refine-pure.rs
@@ -1,0 +1,27 @@
+//! A `#[refine_trait_spec]` implementation may strengthen the trait method's
+//! specification. Here the impl keeps the method `#[pure]` (as required to
+//! refine a pure trait method) and adds a postcondition, which callers can then
+//! rely on.
+
+use prusti_contracts::*;
+
+trait Trait {
+    #[pure]
+    fn foo(&self) -> i32;
+}
+
+struct Struct(i32);
+
+#[refine_trait_spec]
+impl Trait for Struct {
+    #[pure]
+    #[ensures(result == self.0)]
+    fn foo(&self) -> i32 {
+        self.0
+    }
+}
+
+fn client(s: &Struct) {
+    // Relies on the refined postcondition of `foo`.
+    assert!(s.foo() == s.0);
+}


### PR DESCRIPTION
Two changes to how trait-impl specifications are inherited and reported:

**Spec inheritance.** A trait `impl` may now carry Prusti annotations only if it is marked `#[refine_trait_spec]`; otherwise it inherits the trait method's spec wholesale (so a `derive`d or plain impl of a `#[pure]` trait method stays usable in pure code without repeating `#[pure]`). Bare annotations without `#[refine_trait_spec]` are rejected instead of silently ignored, and an invalid pure→impure refinement now reports a clear error rather than being swallowed.

**Diagnostics.** Refinement errors point at the offending code instead of the whole function: the "requires `#[refine_trait_spec]`" error underlines each stacked annotation (with a note on the `impl` block), the purity error uses `#[pure]` wording with hints at both the implementation and the trait's `#[pure]`, and behavioral-subtype errors point at the specific pre/post-condition with a hint at the trait's. Adds pass/fail tests covering each case.