### PR TITLE
Emit PCG repacks and operand reads at their temporal positions

### DIFF
--- a/prusti-contracts/prusti-contracts/src/core_spec/eq.rs
+++ b/prusti-contracts/prusti-contracts/src/core_spec/eq.rs
@@ -15,5 +15,16 @@ trait PartialEq<Rhs> {
     fn ne(&self, other: &Rhs) -> bool;
 }
 
+#[extern_spec]
+impl<T: PartialEq> PartialEq for Option<T> {
+    #[pure]
+    #[ensures(result == match (self, other) {
+        (Some(l), Some(r)) => *l == *r,
+        (None, None) => true,
+        _ => false,
+    })]
+    fn eq(&self, other: &Option<T>) -> bool;
+}
+
 /// Specifies that `PartialEq::eq`, if implemented, is a pure method, allowing its usage in specs.
 pub auto trait PureEq {}

--- a/prusti-encoder/src/encoders/builtin/bin_op.rs
+++ b/prusti-encoder/src/encoders/builtin/bin_op.rs
@@ -11,6 +11,13 @@ use crate::encoders::ty::{
 /// etc.) as Viper functions with the correct semantics.
 pub struct MirBuiltinBinOpEnc;
 
+#[derive(Clone, Debug)]
+pub enum MirBuiltinBinOpEncError {
+    Unsupported(#[allow(dead_code)] String),
+}
+
+type EncodeResult<'vir, T> = Result<T, EncodeFullError<'vir, MirBuiltinBinOpEnc>>;
+
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct MirBuiltinBinOpTask<'vir> {
     result_ty: RustTyDecomposition<'vir>,
@@ -46,6 +53,8 @@ impl TaskEncoder for MirBuiltinBinOpEnc {
 
     type OutputFullDependency<'vir> = vir::FunctionIdn<'vir, (vir::CSnap, vir::CSnap), vir::CSnap>;
     type OutputFullLocal<'vir> = vir::Function<'vir>;
+
+    type EncodingError = MirBuiltinBinOpEncError;
 
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
         *task
@@ -103,7 +112,7 @@ impl TaskEncoder for MirBuiltinBinOpEnc {
                     } else {
                         let res_ty = *result_ty.ty.expect_primitive();
                         let (pres, val) =
-                            Self::handle_bin_op_native(vcx, lhs, rhs, res_ty, op, l_ty);
+                            Self::handle_bin_op_native(vcx, lhs, rhs, res_ty, op, l_ty)?;
                         (pres, res.expect_primitive().prim_to_snap(val))
                     }
                 }
@@ -135,8 +144,18 @@ impl MirBuiltinBinOpEnc {
         res_ty: ty::Ty<'vir>,
         op: mir::BinOp,
         in_ty: ty::Ty<'vir>,
-    ) -> (Vec<vir::ExprBool<'vir>>, vir::ExprPrim<'vir>) {
+    ) -> EncodeResult<'vir, (Vec<vir::ExprBool<'vir>>, vir::ExprPrim<'vir>)> {
         use mir::BinOp::*;
+        if matches!(op, BitXor | BitAnd | BitOr) && !in_ty.is_bool() {
+            // Viper `Int`s have no native bitwise operations; the `BinOpKind`
+            // mapping (`!=`/`&&`/`||`) is only correct for `bool` operands.
+            return Err(EncodeFullError::EncodingError(
+                MirBuiltinBinOpEncError::Unsupported(format!(
+                    "bitwise operation `{op:?}` on `{in_ty}`"
+                )),
+                None,
+            ));
+        }
         if matches!(op, Shl | Shr) {
             // RHS must be smaller than the bit width of the LHS, this is
             // implicit in the `Shl` and `Shr` operators.
@@ -164,13 +183,13 @@ impl MirBuiltinBinOpEnc {
                     vcx.mk_ternary_expr(b_gt_a, vcx.mk_int::<-1>(), vcx.mk_int::<0>()),
                 )
                 .upcast_ty();
-            (vec![], val)
+            Ok((vec![], val))
         } else {
             let op_kind = vir::BinOpKind::from(op);
             let viper_val = vcx
                 .mk_bin_op_expr_inner(op_kind, lhs.as_dyn(), rhs.as_dyn())
                 .downcast_ty();
-            match op {
+            Ok(match op {
                 // Overflow well defined as wrapping (implicit) and for the shifts
                 // the RHS will be masked to the bit width.
                 Add | Sub | Mul | Shl | Shr => (
@@ -267,7 +286,8 @@ impl MirBuiltinBinOpEnc {
                     }
                     (pres, val)
                 }
-                // Cannot overflow and no undefined behavior
+                // Cannot overflow and no undefined behavior (the bitwise
+                // operations are `bool`-only, rejected above for integers)
                 BitXor | BitAnd | BitOr | Eq | Lt | Le | Ne | Ge | Gt | Offset => {
                     (Vec::new(), viper_val)
                 }
@@ -277,7 +297,7 @@ impl MirBuiltinBinOpEnc {
 
                 // this is handled separately, earlier
                 Cmp => unreachable!(),
-            }
+            })
         }
     }
 

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -1905,7 +1905,11 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             | mir::TerminatorKind::FalseEdge {
                 real_target: target,
                 ..
-            } => {
+            }
+            // A `Drop`'s semantics (releasing the dropped place's permission
+            // via a weaken exhale) are carried by the PCG statements, so only
+            // its goto remains to be encoded here.
+            | mir::TerminatorKind::Drop { target, .. } => {
                 self.pcs_succ_to(*target)?;
                 let set_flag = self.set_from_to_flag(location.block, *target);
                 self.stmt(set_flag);
@@ -2162,13 +2166,6 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 self.stmt(self.vcx.mk_exhale_stmt(self.vcx.mk_bool::<false>()));
                 self.vcx.mk_assume_false_stmt()
             }),
-
-            mir::TerminatorKind::Drop { target, .. } => {
-                let set_flag = self.set_from_to_flag(location.block, *target);
-                self.stmt(set_flag);
-                self.vcx
-                    .mk_goto_stmt(self.current_block_succs.as_ref().unwrap()[target])
-            }
 
             mir::TerminatorKind::UnwindResume | mir::TerminatorKind::UnwindTerminate(..) => {
                 self.vcx.with_span(span, |vcx| {

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -1125,7 +1125,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
         &mut self,
         statement: &mir::Statement<'vir>,
         location: mir::Location,
-    ) -> EncodeResult<'vir, FxHashMap<mir::Place<'vir>, vir::ExprSnap<'vir>>, E> {
+    ) -> EncodeResult<'vir, OperandSnaps<'vir>, E> {
         use mir::visit::Visitor;
         struct OperandCollector<'vir>(Vec<mir::Operand<'vir>>);
         impl<'vir> Visitor<'vir> for OperandCollector<'vir> {
@@ -1146,7 +1146,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             let snap = self.capture_operand_snap(operand)?;
             snaps.insert(place, snap);
         }
-        Ok(snaps)
+        Ok(Some(snaps))
     }
 
     pub(crate) fn encode_place(&mut self, place: Place<'vir>) -> EncodePlaceResult<'vir> {
@@ -1779,7 +1779,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             // operand's place may alias the destination, whose predicate the
             // `PreMain` weaken exhales before the effect is encoded (`x /= y`
             // lowers to `x = Div(copy x, move y)`).
-            let captured = Some(self.capture_operand_snaps(statement, location)?);
+            let captured = self.capture_operand_snaps(statement, location)?;
 
             self.pcg_phase_actions(location, EvalStmtPhase::PostOperands)?;
             self.pcg_phase_actions(location, EvalStmtPhase::PreMain)?;

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -19,7 +19,7 @@ use pcg::{
     free_pcs::{RepackGuide, RepackOp},
     r#loop::{LoopAnalysis, LoopId},
     pcg::{CapabilityKind, EvalStmtPhase, Pcg, PcgNode, PcgSuccessor},
-    results::PcgBasicBlock,
+    results::{PcgBasicBlock, PcgLocation},
     utils::{
         CompilerCtxt, HasPlace, Place, SnapshotLocation, display::DisplayWithCtxt,
         maybe_old::MaybeLabelledPlace,
@@ -467,15 +467,49 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
     /// TODO: clean this up
     fn collect_pcs_succ<'a>(
         &mut self,
-        state: &Pcg<'_, 'vir>,
+        cfpcs: &PcgLocation<'_, 'vir>,
         pcs: &'a PcgSuccessor<'_, 'vir>,
     ) -> Result<Vec<vir::Stmt<'vir>>, EncodeFullError<'vir, E>> {
         let current_stmts = self.current_stmts.take();
         self.current_stmts = Some(Vec::new());
-        let res = self.pcs_succ(state, pcs);
+        let res = self.pcs_succ(cfpcs, pcs);
         let new_stmts = self.current_stmts.take().unwrap();
         self.current_stmts = current_stmts;
         res.map(|()| new_stmts)
+    }
+
+    /// Emit the repacks of the terminator edge to `target` ([Self::pcs_succ]).
+    /// The succ is found by block: the target is usually the terminator's
+    /// only non-unwind successor, but for a ghost switch the (second)
+    /// `ghost_erased` successor is skipped.
+    fn pcs_succ_to(&mut self, target: mir::BasicBlock) -> Result<(), EncodeFullError<'vir, E>> {
+        let current_fpcs = self.current_fpcs.take().unwrap();
+        let cfpcs = current_fpcs.statements.last().unwrap();
+        let succ = current_fpcs
+            .terminator
+            .succs
+            .iter()
+            .find(|succ| succ.block() == target)
+            .unwrap();
+        let res = self.pcs_succ(cfpcs, succ);
+        self.current_fpcs = Some(current_fpcs);
+        res
+    }
+
+    /// [Self::collect_pcs_succ] for the `idx`-th successor: a `SwitchInt`
+    /// edge, identified by index since several values may share a target.
+    fn collect_pcs_succ_at(
+        &mut self,
+        idx: usize,
+        target: mir::BasicBlock,
+    ) -> Result<Vec<vir::Stmt<'vir>>, EncodeFullError<'vir, E>> {
+        let current_fpcs = self.current_fpcs.take().unwrap();
+        let cfpcs = current_fpcs.statements.last().unwrap();
+        let succ = &current_fpcs.terminator.succs[idx];
+        assert_eq!(succ.block(), target);
+        let res = self.collect_pcs_succ(cfpcs, succ);
+        self.current_fpcs = Some(current_fpcs);
+        res
     }
 
     pub(crate) fn block<Err>(
@@ -809,6 +843,20 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
         }
         Ok(())
     }
+
+    /// Emit the repacks of `phase` at `location`.
+    fn pcg_phase_actions(
+        &mut self,
+        location: mir::Location,
+        phase: EvalStmtPhase,
+    ) -> EncodeResult<'vir, (), E> {
+        let current_fpcs = self.current_fpcs.take().unwrap();
+        let cfpcs = &current_fpcs.statements[location.statement_index];
+        self.pcg_actions(&cfpcs.states[phase], &cfpcs.actions(phase), false)?;
+        self.current_fpcs = Some(current_fpcs);
+        Ok(())
+    }
+
     fn borrow_action(
         &mut self,
         pcg: &Pcg<'_, 'vir>,
@@ -978,11 +1026,17 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
 
     fn pcs_succ<'a>(
         &mut self,
-        pcg_state: &Pcg<'_, 'vir>,
+        cfpcs: &PcgLocation<'_, 'vir>,
         succ: &'a PcgSuccessor<'_, 'vir>,
     ) -> Result<(), EncodeFullError<'vir, E>> {
+        // The terminator's deferred `PostMain` actions (e.g. the collapse
+        // re-packing owned places for the CFG join); see
+        // [Self::visit_terminator].
+        comment!(self, "PCG (T) {}", EvalStmtPhase::PostMain);
+        let post_main = &cfpcs.states[EvalStmtPhase::PostMain];
+        self.pcg_actions(post_main, &cfpcs.actions(EvalStmtPhase::PostMain), false)?;
         let edge_to_loop = self.loop_head_of(succ.block()).is_some();
-        self.pcg_actions(pcg_state, succ.actions(), edge_to_loop)
+        self.pcg_actions(post_main, succ.actions(), edge_to_loop)
     }
 
     fn encode_operand(
@@ -1651,26 +1705,21 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
 
             comment!(self, "[MIR] {location:?}: {statement:?}");
 
-            let current_fpcs = self.current_fpcs.take().unwrap();
-            let cfpcs = &current_fpcs.statements[location.statement_index];
-            for phase in EvalStmtPhase::phases() {
-                self.pcg_actions(&cfpcs.states[phase], &cfpcs.actions(phase), false)?;
-            }
-            self.current_fpcs = Some(current_fpcs);
-
-            // TODO: these should not be ignored, but should havoc the local instead
-            // This clears up the noise a bit, making sure StorageLive and other
-            // kinds do not show up in the comments.
-            // TODO: also make sure we don't ignore PCG annotations for these,
-            //   *if* the pcs calls for mid-statement are moved later.
-            const IGNORE_NOP_STMTS: bool = true;
-            if IGNORE_NOP_STMTS {
-                match &statement.kind {
-                    mir::StatementKind::StorageLive(..) | mir::StatementKind::StorageDead(..) => {
-                        return Ok(());
-                    }
-                    _ => {}
-                }
+            // `PostMain` is emitted after the statement's effect below.
+            // TODO: the operands are read lazily while encoding the effect,
+            //   which is wrong when an operand's place overlaps the
+            //   destination, whose predicate the `PreMain` weaken exhales.
+            //   MIR mostly materializes temporaries for such operands, but
+            //   `x /= y` lowers to `x = Div(copy x, move y)` (same for other
+            //   unchecked `op=` operators) and fails with insufficient
+            //   permission. Operands should instead be captured between the
+            //   `PreOperands` and `PostOperands` repacks.
+            for phase in [
+                EvalStmtPhase::PreOperands,
+                EvalStmtPhase::PostOperands,
+                EvalStmtPhase::PreMain,
+            ] {
+                self.pcg_phase_actions(location, phase)?;
             }
 
             let span = statement.source_info.span;
@@ -1739,6 +1788,8 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                     statement.kind
                 ),
             }
+
+            self.pcg_phase_actions(location, EvalStmtPhase::PostMain)?;
             Ok(())
         })
     }
@@ -1754,13 +1805,23 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
         comment!(self, "[MIR] {location:?}: {:?}", terminator.kind);
         let span = terminator.source_info.span;
 
-        let current_fpcs = self.current_fpcs.take().unwrap();
-        let cfpcs = &current_fpcs.statements[location.statement_index];
-        for phase in EvalStmtPhase::phases() {
+        // `PostMain` is not emitted here: a terminator's operands are read
+        // after these phases' repacks (e.g. a `SwitchInt` discriminant that
+        // projects into an aggregate is read in the branch condition, relying
+        // on the `PreOperands` unfolds), while the `PostMain` actions re-pack
+        // owned places for the CFG join and thus may fold those operands'
+        // places away. They are instead emitted on each outgoing edge by
+        // [Self::pcs_succ], after the terminator's operands have been read.
+        // Terminators that do not go through [Self::pcs_succ] have no
+        // successor state to re-pack for.
+        for phase in [
+            EvalStmtPhase::PreOperands,
+            EvalStmtPhase::PostOperands,
+            EvalStmtPhase::PreMain,
+        ] {
             comment!(self, "PCG (T) {phase}");
-            self.pcg_actions(&cfpcs.states[phase], &cfpcs.actions(phase), false)?;
+            self.pcg_phase_actions(location, phase)?;
         }
-        self.current_fpcs = Some(current_fpcs);
 
         // A `ghost!` block's `if false` switch is encoded as an unconditional
         // jump into the ghost arm (the inline ghost body); the runtime
@@ -1783,20 +1844,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 real_target: target,
                 ..
             } => {
-                let current_fpcs = self.current_fpcs.take().unwrap();
-                let borrows =
-                    &current_fpcs.statements.last().unwrap().states[EvalStmtPhase::PostMain];
-                // The succ used for the repacks, found by block: the target is
-                // usually the terminator's only successor, but for a ghost
-                // switch the (second) `ghost_erased` successor is skipped.
-                let succ = current_fpcs
-                    .terminator
-                    .succs
-                    .iter()
-                    .find(|succ| &succ.block() == target)
-                    .unwrap();
-                self.pcs_succ(borrows, succ)?;
-                self.current_fpcs = Some(current_fpcs);
+                self.pcs_succ_to(*target)?;
                 let set_flag = self.set_from_to_flag(location.block, *target);
                 self.stmt(set_flag);
                 self.vcx
@@ -1811,17 +1859,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                         .iter()
                         .enumerate()
                         .map(|(idx, (value, target))| {
-                            assert_eq!(
-                                self.current_fpcs.as_ref().unwrap().terminator.succs[idx].block(),
-                                target
-                            );
-
-                            let current_fpcs = self.current_fpcs.take().unwrap();
-                            let borrows = &current_fpcs.statements.last().unwrap().states
-                                [EvalStmtPhase::PostMain];
-                            let mut extra_stmts = self
-                                .collect_pcs_succ(borrows, &current_fpcs.terminator.succs[idx])?;
-                            self.current_fpcs = Some(current_fpcs);
+                            let mut extra_stmts = self.collect_pcs_succ_at(idx, target)?;
                             extra_stmts.push(self.set_from_to_flag(location.block, target));
 
                             Ok(self.vcx.mk_goto_if_target(
@@ -1836,20 +1874,8 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                     self.current_block_succs.as_ref().unwrap()[&targets.otherwise()];
 
                 let otherwise_succ_idx = goto_targets.len();
-                assert_eq!(
-                    self.current_fpcs.as_ref().unwrap().terminator.succs[otherwise_succ_idx]
-                        .block(),
-                    targets.otherwise()
-                );
-
-                let current_fpcs = self.current_fpcs.take().unwrap();
-                let borrows =
-                    &current_fpcs.statements.last().unwrap().states[EvalStmtPhase::PostMain];
-                let mut otherwise_stmts = self.collect_pcs_succ(
-                    borrows,
-                    &current_fpcs.terminator.succs[otherwise_succ_idx],
-                )?;
-                self.current_fpcs = Some(current_fpcs);
+                let mut otherwise_stmts =
+                    self.collect_pcs_succ_at(otherwise_succ_idx, targets.otherwise())?;
                 otherwise_stmts.push(self.set_from_to_flag(location.block, targets.otherwise()));
 
                 let discr_ex = discr_ty
@@ -1975,23 +2001,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
 
                 match *target {
                     Some(target) => {
-                        const REAL_TARGET_SUCC_IDX: usize = 0;
-                        // Ensure that the terminator succ that we use for the repacks is the correct one
-                        assert_eq!(
-                            self.current_fpcs.as_ref().unwrap().terminator.succs
-                                [REAL_TARGET_SUCC_IDX]
-                                .block(),
-                            target
-                        );
-                        let current_fpcs = self.current_fpcs.take().unwrap();
-                        let borrows = current_fpcs.statements.last().unwrap().states
-                            [EvalStmtPhase::PostMain]
-                            .clone();
-                        self.pcs_succ(
-                            &borrows,
-                            &current_fpcs.terminator.succs[REAL_TARGET_SUCC_IDX],
-                        )?;
-                        self.current_fpcs = Some(current_fpcs);
+                        self.pcs_succ_to(target)?;
                         let set_flag = self.set_from_to_flag(location.block, target);
                         self.stmt(set_flag);
 
@@ -2020,25 +2030,8 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 target,
                 ..
             } => {
-                const REAL_TARGET_SUCC_IDX: usize = 0;
-                // Ensure that the terminator succ that we use for the repacks is the correct one
-                assert_eq!(
-                    &self.current_fpcs.as_ref().unwrap().terminator.succs[REAL_TARGET_SUCC_IDX]
-                        .block(),
-                    target,
-                );
-                let current_fpcs = self.current_fpcs.take().unwrap();
-                let borrows =
-                    current_fpcs.statements.last().unwrap().states[EvalStmtPhase::PostMain].clone();
-                self.pcs_succ(
-                    &borrows,
-                    &current_fpcs.terminator.succs[REAL_TARGET_SUCC_IDX],
-                )?;
-                self.current_fpcs = Some(current_fpcs);
-
                 let enc = self
-                    .encode_operand_snap(cond, &())
-                    .unwrap()
+                    .encode_operand_snap(cond, &())?
                     .downcast_ty::<vir::Bool>();
                 let expected = self
                     .vcx
@@ -2088,6 +2081,10 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 } else {
                     self.stmt(self.vcx.mk_inhale_stmt(assert));
                 }
+                // The check is the terminator's main effect, emitted before
+                // the deferred `PostMain` re-pack, which may fold the place
+                // the condition projects into.
+                self.pcs_succ_to(*target)?;
                 let set_flag = self.set_from_to_flag(location.block, *target);
                 self.stmt(set_flag);
                 self.vcx

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -328,7 +328,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             }
 
             mir::Rvalue::BinaryOp(op, box (l, r)) => Ok(self
-                .encode_binop_snap(rvalue_ty, *op, l, r, operand_snaps)
+                .encode_binop_snap(rvalue_ty, *op, l, r, operand_snaps, span)
                 .map_err(EncodeRvalueError::from)?
                 .into()),
 

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -215,6 +215,13 @@ macro_rules! comment {
 
 type EncodeResult<'vir, T, E> = Result<T, EncodeFullError<'vir, E>>;
 
+/// Snapshots of the current statement's operands, captured between the
+/// `PreOperands` and `PostOperands` repacks by
+/// [ImpureEncVisitor::capture_operand_snaps] and passed (as the
+/// [PureRvalueEnc::EncodePlaceCtxt]) only to the encoding of the statement's
+/// effect; all other operand reads (terminators, repack guides) pass `None`.
+type OperandSnaps<'vir> = Option<FxHashMap<mir::Place<'vir>, vir::ExprSnap<'vir>>>;
+
 struct EncodedRvalue<'vir> {
     /// A snapshot of the rvalue. This snapshot is guaranteed to be well-formed
     /// in the state *before* the Rvalue has been assigned to a place. For
@@ -300,30 +307,33 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
         &mut self,
         rvalue: &mir::Rvalue<'vir>,
         span: Span,
+        operand_snaps: &OperandSnaps<'vir>,
     ) -> Result<EncodedRvalue<'vir>, EncodeRvalueError<'vir, E>> {
         let rvalue_ty = rvalue.ty(self.local_decls, self.vcx.tcx());
         match rvalue {
             mir::Rvalue::Use(op) => Ok(self
-                .encode_operand_snap(op, &())
+                .encode_operand_snap(op, operand_snaps)
                 .map_err(EncodeRvalueError::from)?
                 .into()),
             mir::Rvalue::Cast(cast_kind, operand, ty) => {
                 assert_eq!(*ty, rvalue_ty);
                 let (stmt, cast) = self
-                    .encode_cast_snap(rvalue_ty, *cast_kind, operand, &())
+                    .encode_cast_snap(rvalue_ty, *cast_kind, operand, operand_snaps)
                     .map_err(EncodeRvalueError::from)?;
                 self.stmts(stmt);
                 Ok(cast.into())
             }
-            mir::Rvalue::Len(place) => Ok(self.encode_len_snap((*place).into(), &())?.into()),
+            mir::Rvalue::Len(place) => {
+                Ok(self.encode_len_snap((*place).into(), operand_snaps)?.into())
+            }
 
             mir::Rvalue::BinaryOp(op, box (l, r)) => Ok(self
-                .encode_binop_snap(rvalue_ty, *op, l, r, &())
+                .encode_binop_snap(rvalue_ty, *op, l, r, operand_snaps)
                 .map_err(EncodeRvalueError::from)?
                 .into()),
 
             mir::Rvalue::UnaryOp(unop, operand) => Ok(self
-                .encode_unary_op_snap(rvalue_ty, *unop, operand, &())
+                .encode_unary_op_snap(rvalue_ty, *unop, operand, operand_snaps)
                 .map_err(EncodeRvalueError::from)?
                 .into()),
 
@@ -333,7 +343,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 let tmp_exp: vir::ExprCSnap<'vir> =
                     self.new_tmp(e_rvalue_ty.snapshot.downcast_ty());
                 for (idx, element) in elements.iter().enumerate() {
-                    let element_snap = self.encode_operand_snap(element, &())?;
+                    let element_snap = self.encode_operand_snap(element, operand_snaps)?;
                     self.stmt(
                         self.vcx.mk_inhale_stmt(
                             self.vcx.mk_eq_expr(
@@ -357,7 +367,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 | mir::AggregateKind::Closure(..)),
                 fields,
             ) => Ok(self
-                .encode_aggregate_snap(rvalue_ty, kind, fields, &())
+                .encode_aggregate_snap(rvalue_ty, kind, fields, operand_snaps)
                 .map_err(EncodeRvalueError::from)?
                 .into()),
 
@@ -366,7 +376,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 let al = e_rvalue_ty.expect_array();
                 let tmp_exp: vir::ExprCSnap<'vir> =
                     self.new_tmp(e_rvalue_ty.snapshot.downcast_ty());
-                let operand_snap = self.encode_operand_snap(operand, &())?;
+                let operand_snap = self.encode_operand_snap(operand, operand_snaps)?;
                 self.stmt(self.vcx.mk_inhale_stmt(vir::expr! {
                     forall idx: Int :: {[al.index(tmp_exp, idx)]}
                         ([al.index(tmp_exp, idx)]) == ([operand_snap])
@@ -560,7 +570,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             match expansion.expansion()[0].place().projection.last() {
                 Some(&mir::ProjectionElem::Index(index_local)) => {
                     let index = self
-                        .encode_operand_snap(&mir::Operand::Copy(index_local.into()), &())
+                        .encode_operand_snap(&mir::Operand::Copy(index_local.into()), &None)
                         .unwrap();
                     let usize_ty_out = self.ty_use_pure(self.vcx.tcx().types.usize);
                     Some(
@@ -946,7 +956,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 let index = guide.and_then(|guide| match guide {
                     RepackGuide::Index(index_local, _) => {
                         let index = self
-                            .encode_operand_snap(&mir::Operand::Copy(index_local.into()), &())
+                            .encode_operand_snap(&mir::Operand::Copy(index_local.into()), &None)
                             .unwrap();
                         let usize_ty_out = self.ty_use_pure(self.vcx.tcx().types.usize);
                         Some(
@@ -1053,7 +1063,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             }
             &mir::Operand::Copy(_source) => {
                 let ty_out = self.ty_use_impure(ty);
-                (self.encode_operand_snap(operand, &())?, ty_out)
+                (self.encode_operand_snap(operand, &None)?, ty_out)
             }
             mir::Operand::Constant(box constant) => {
                 let ty_out = self.ty_use_impure(ty);
@@ -1080,6 +1090,63 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 Ok(self.encode_constant_snap(constant)?.upcast_ty())
             }
         }
+    }
+
+    /// Read `operand`'s snapshot into a fresh temporary at the current
+    /// program point; a `Move` operand additionally consumes its place,
+    /// exhaling the place's predicate.
+    fn capture_operand_snap(
+        &mut self,
+        operand: &mir::Operand<'vir>,
+    ) -> EncodeResult<'vir, vir::ExprSnap<'vir>, E> {
+        match operand {
+            &mir::Operand::Copy(place) | &mir::Operand::Move(place) => {
+                let (result, snap_val, _, ty_out) = self.encode_place_with_snap(Place::from(place));
+                let tmp = self.new_tmp(ty_out.snapshot());
+                self.stmt(self.vcx.mk_pure_assign_stmt(tmp, snap_val));
+                if matches!(operand, mir::Operand::Move(_)) {
+                    self.stmt(self.vcx.mk_exhale_stmt(ty_out.ref_to_pred(
+                        self.vcx,
+                        result.expr.expect_predicate(),
+                        None,
+                    )));
+                }
+                Ok(tmp)
+            }
+            mir::Operand::Constant(box constant) => {
+                Ok(self.encode_constant_snap(constant)?.upcast_ty())
+            }
+        }
+    }
+
+    /// Read `statement`'s operands into an [OperandSnaps] map; see the call
+    /// site in [Self::visit_statement].
+    fn capture_operand_snaps(
+        &mut self,
+        statement: &mir::Statement<'vir>,
+        location: mir::Location,
+    ) -> EncodeResult<'vir, FxHashMap<mir::Place<'vir>, vir::ExprSnap<'vir>>, E> {
+        use mir::visit::Visitor;
+        struct OperandCollector<'vir>(Vec<mir::Operand<'vir>>);
+        impl<'vir> Visitor<'vir> for OperandCollector<'vir> {
+            fn visit_operand(&mut self, operand: &mir::Operand<'vir>, _location: mir::Location) {
+                if operand.place().is_some() {
+                    self.0.push(operand.clone());
+                }
+            }
+        }
+        let mut collector = OperandCollector(Vec::new());
+        collector.visit_statement(statement, location);
+        let mut snaps = FxHashMap::default();
+        for operand in &collector.0 {
+            let place = operand.place().unwrap();
+            if snaps.contains_key(&place) {
+                continue;
+            }
+            let snap = self.capture_operand_snap(operand)?;
+            snaps.insert(place, snap);
+        }
+        Ok(snaps)
     }
 
     pub(crate) fn encode_place(&mut self, place: Place<'vir>) -> EncodePlaceResult<'vir> {
@@ -1705,22 +1772,17 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
 
             comment!(self, "[MIR] {location:?}: {statement:?}");
 
-            // `PostMain` is emitted after the statement's effect below.
-            // TODO: the operands are read lazily while encoding the effect,
-            //   which is wrong when an operand's place overlaps the
-            //   destination, whose predicate the `PreMain` weaken exhales.
-            //   MIR mostly materializes temporaries for such operands, but
-            //   `x /= y` lowers to `x = Div(copy x, move y)` (same for other
-            //   unchecked `op=` operators) and fails with insufficient
-            //   permission. Operands should instead be captured between the
-            //   `PreOperands` and `PostOperands` repacks.
-            for phase in [
-                EvalStmtPhase::PreOperands,
-                EvalStmtPhase::PostOperands,
-                EvalStmtPhase::PreMain,
-            ] {
-                self.pcg_phase_actions(location, phase)?;
-            }
+            self.pcg_phase_actions(location, EvalStmtPhase::PreOperands)?;
+
+            // Read the statement's operands at their temporal position,
+            // between the `PreOperands` and `PostOperands` repacks. An
+            // operand's place may alias the destination, whose predicate the
+            // `PreMain` weaken exhales before the effect is encoded (`x /= y`
+            // lowers to `x = Div(copy x, move y)`).
+            let captured = Some(self.capture_operand_snaps(statement, location)?);
+
+            self.pcg_phase_actions(location, EvalStmtPhase::PostOperands)?;
+            self.pcg_phase_actions(location, EvalStmtPhase::PreMain)?;
 
             let span = statement.source_info.span;
 
@@ -1733,7 +1795,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                         .expect_predicate();
 
                     // The snapshot of the value that we are assigning.
-                    let rval_enc = self.encode_rvalue(rvalue, span);
+                    let rval_enc = self.encode_rvalue(rvalue, span, &captured);
 
                     match rval_enc {
                         Ok(rval_enc) => {
@@ -1879,7 +1941,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 otherwise_stmts.push(self.set_from_to_flag(location.block, targets.otherwise()));
 
                 let discr_ex = discr_ty
-                    .snap_to_prim(self.encode_operand_snap(discr, &()).unwrap().downcast_ty());
+                    .snap_to_prim(self.encode_operand_snap(discr, &None).unwrap().downcast_ty());
                 self.vcx.mk_goto_if_stmt(
                     discr_ex.as_dyn(), // self.vcx.mk_local_ex(discr_name),
                     goto_targets,
@@ -2031,7 +2093,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 ..
             } => {
                 let enc = self
-                    .encode_operand_snap(cond, &())?
+                    .encode_operand_snap(cond, &None)?
                     .downcast_ty::<vir::Bool>();
                 let expected = self
                     .vcx
@@ -2181,7 +2243,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
         Ok(if let Some(intrinsic) = intrinsic {
             Some((
                 false,
-                self.encode_intrinsic(intrinsic, caller_substs, args, &())?,
+                self.encode_intrinsic(intrinsic, caller_substs, args, &None)?,
             ))
         } else if let Some(builtin) = PrustiBuiltin::new(func_def_id, self.gargs(caller_substs)) {
             // A `prusti_contracts` builtin used in executable code
@@ -2214,7 +2276,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                     self.gargs(caller_substs),
                     args,
                     span,
-                    &(),
+                    &None,
                 )?
                 .unwrap();
             Some((false, expr))
@@ -2231,7 +2293,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 .iter()
                 .map(|arg| {
                     self.vcx.with_span(arg.span, |_| {
-                        self.encode_operand_snap(&arg.node, &()).unwrap()
+                        self.encode_operand_snap(&arg.node, &None).unwrap()
                     })
                 })
                 .collect::<Vec<_>>();
@@ -2244,7 +2306,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
 
 impl<'vir, 'enc, E: TaskEncoder> PureRvalueEnc<'vir> for ImpureEncVisitor<'vir, 'enc, E> {
     type Encoder = E;
-    type EncodePlaceCtxt = ();
+    type EncodePlaceCtxt = OperandSnaps<'vir>;
     const PURE: bool = false;
     type ExprCurr = ();
     type ExprNext = !;
@@ -2274,26 +2336,23 @@ impl<'vir, 'enc, E: TaskEncoder> PureRvalueEnc<'vir> for ImpureEncVisitor<'vir, 
     fn encode_operand_snap(
         &mut self,
         operand: &mir::Operand<'vir>,
-        _ctxt: &Self::EncodePlaceCtxt,
+        operand_snaps: &Self::EncodePlaceCtxt,
     ) -> Result<vir::ExprSnap<'vir>, EncodeFullError<'vir, E>> {
+        // While a statement's effect is encoded, every place operand must
+        // have been captured by [Self::capture_operand_snaps]. In particular,
+        // `Move` operands were already consumed at capture time (snapshot
+        // temporary plus predicate exhale) and must not be consumed again.
+        if let Some(operand_snaps) = operand_snaps
+            && let Some(place) = operand.place()
+        {
+            let snap = operand_snaps.get(&place).unwrap_or_else(|| {
+                panic!("operand {operand:?} was not captured for the current statement")
+            });
+            return Ok(*snap);
+        }
         match operand {
-            &mir::Operand::Move(source) => {
-                let (result, snap_val, _, ty_out) =
-                    self.encode_place_with_snap(Place::from(source));
-
-                let tmp_exp = self.new_tmp(ty_out.snapshot());
-                self.stmt(self.vcx.mk_pure_assign_stmt(tmp_exp, snap_val));
-                self.stmt(self.vcx.mk_exhale_stmt(ty_out.ref_to_pred(
-                    self.vcx,
-                    result.expr.expect_predicate(),
-                    None,
-                )));
-                Ok(tmp_exp)
-            }
-            &mir::Operand::Copy(place) => Ok(self.encode_place_with_snap(place.into()).1),
-            mir::Operand::Constant(box constant) => {
-                Ok(self.encode_constant_snap(constant)?.upcast_ty())
-            }
+            mir::Operand::Move(_) => self.capture_operand_snap(operand),
+            _ => self.encode_operand_snap_immediate(operand),
         }
     }
 

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -992,7 +992,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
                 Ok(snap.upcast_ty())
             }
             mir::Rvalue::BinaryOp(op, box (l, r)) => {
-                self.encode_binop_snap(rvalue_ty, *op, l, r, curr_ver)
+                self.encode_binop_snap(rvalue_ty, *op, l, r, curr_ver, span)
             }
             mir::Rvalue::UnaryOp(unop, operand) => {
                 self.encode_unary_op_snap(rvalue_ty, *unop, operand, curr_ver)

--- a/prusti-encoder/src/encoders/mir_shared.rs
+++ b/prusti-encoder/src/encoders/mir_shared.rs
@@ -140,6 +140,7 @@ pub(crate) trait PureRvalueEnc<'vir> {
         l: &mir::Operand<'vir>,
         r: &mir::Operand<'vir>,
         ctxt: &Self::EncodePlaceCtxt,
+        span: Span,
     ) -> ExprResult<'vir, Self> {
         let l_ty = l.ty(self.body(), self.vcx().tcx());
         let r_ty = r.ty(self.body(), self.vcx().tcx());
@@ -147,7 +148,9 @@ pub(crate) trait PureRvalueEnc<'vir> {
         let r_ty = RustTyDecomposition::from_ty(r_ty, self.context());
         let rvalue_ty = RustTyDecomposition::from_ty(rvalue_ty, self.context());
         let task = MirBuiltinBinOpTask::new(rvalue_ty, op, l_ty, r_ty);
-        let op = self.deps().require_dep::<MirBuiltinBinOpEnc>(task)?;
+        let op = self
+            .deps()
+            .require_dep_spanned::<MirBuiltinBinOpEnc>(task, span)?;
 
         let encoded_l = self.encode_operand_snap(l, ctxt)?;
         let encoded_r = self.encode_operand_snap(r, ctxt)?;

--- a/prusti-encoder/src/encoders/ty/generics/trait_fn.rs
+++ b/prusti-encoder/src/encoders/ty/generics/trait_fn.rs
@@ -11,7 +11,7 @@ use crate::{
         FunctionCallEnc, MirLocalDefEnc, MirLocalDefEncTask, MirSpecEnc,
         mir_fn::CallTaskDescription,
         pure::spec::MirSpecEncMode,
-        ty::generics::{GArgs, GParams, GenericParamsEnc},
+        ty::generics::{GArgs, GParams, GenericParamsEnc, r#trait::TraitEnc},
     },
     trait_support::is_function_with_body,
 };
@@ -176,6 +176,10 @@ impl TaskEncoder for TraitFnEnc {
                     call_stub_pure_function,
                 },
             )?;
+            // The stubs' semantics are given by the impls' axioms; require the
+            // trait so that its impls' condition/axiom triggers are registered
+            // (foreign traits are not encoded by `encode_all_in_crate`).
+            deps.require_ref::<TraitEnc>(trait_def_id)?;
             dom_funcs.push(vcx.mk_domain_function(pre_func, false, None));
             dom_funcs.push(vcx.mk_domain_function(post_func, false, None));
 

--- a/prusti-tests/tests/verify/pass/no-annotations/int-match.rs
+++ b/prusti-tests/tests/verify/pass/no-annotations/int-match.rs
@@ -8,3 +8,42 @@ fn main() {
         _ => unreachable!()
     };
 }
+
+// A `match` with a literal in an aggregate field makes MIR switch on the
+// field place directly (e.g. `switchInt(copy (_3.0))`), so the discriminant
+// must be read before the PCG re-packs the aggregate for the CFG join.
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+fn tuple_literal(m: i32, n: i32) -> i32 {
+    match (m, n) {
+        (0, n) => n,
+        (m, _) => m,
+    }
+}
+
+fn struct_literal(p: Point) -> i32 {
+    match p {
+        Point { x: 0, y } => y,
+        Point { x, .. } => x,
+    }
+}
+
+fn nested_literal(t: ((i32, i32), i32)) -> i32 {
+    match t {
+        ((0, x), _) => x,
+        ((x, _), _) => x,
+    }
+}
+
+fn multiple_literals(t: (i32, i32)) -> i32 {
+    match t {
+        (0, 0) => 0,
+        (0, y) => y,
+        (x, 0) => x,
+        (x, y) => x + y,
+    }
+}

--- a/prusti-tests/tests/verify/pass/no-annotations/operations.rs
+++ b/prusti-tests/tests/verify/pass/no-annotations/operations.rs
@@ -10,3 +10,24 @@ fn main() {
 
     assert!(9 / 2 == 4);
 }
+
+// Compound assignments on primitives lower to a same-place form, e.g.
+// `x /= y` to `x = Div(copy x, move y)`: the destination is also an operand,
+// so its snapshot must be read before the assignment exhales its predicate.
+
+fn compound_assign(x: i32, y: i32) -> i32 {
+    let mut x = x;
+    if y != 0 {
+        x /= y;
+        x %= 7;
+    }
+    x
+}
+
+fn compound_assign_field(t: (i32, i32)) -> (i32, i32) {
+    let mut t = t;
+    if t.1 != 0 {
+        t.0 /= t.1;
+    }
+    t
+}


### PR DESCRIPTION
Fixes two encoding bugs that caused spurious insufficient-permission errors on safe code, plus related cleanup:

- **Defer terminator `PostMain` repacks to the outgoing edges.** The encoder emitted all four PCG phases' repacks before encoding a terminator, so the `PostMain` collapse (re-packing owned places for the CFG join) could fold away an aggregate whose field the terminator still had to read - e.g. the discriminant of `match (m, n) { (0, _) => .. }`, which is why `rosetta/Ackermann_function.rs` errored. `PostMain` is now emitted on each outgoing edge (statements likewise emit it after their effect), so a `SwitchInt` discriminant is read in the branch condition while still unfolded. (@zgrannan turns out that `PostMain` can have important stuff, would still be good if we could move that to the edges between blocks instead, though that doesn't seem too easy to do)
- **Capture statement operand snapshots in the operand window.** Rvalue operands were read lazily while encoding a statement's effect, after the `PreMain` weaken already exhaled the destination's predicate. This breaks compound assignments, which lower to a same-place form (`x /= y` → `x = Div(copy x, move y)`). Operands are now read between the `PreOperands` and `PostOperands` repacks, and the effect encoding must resolve every place operand to a captured snapshot.
- **Reject integer bitwise operations as unsupported.** `&`, `|`, `^` on integers were encoded with the boolean mapping (`&&`/`||`/`!=`), producing Viper consistency errors; they now report a proper unsupported-operation error at each use site. `bool` operands keep the logical semantics.
- **Clean up `TerminatorKind::Drop`**: route it through the common `Goto` arm so its successor repacks (`pcs_succ`) are emitted instead of ignored.