### PR TITLE
Verify all local closure bodies; unify MIR body retrieval

### DIFF
--- a/prusti-contracts/prusti-specs/src/lib.rs
+++ b/prusti-contracts/prusti-specs/src/lib.rs
@@ -56,6 +56,18 @@ macro_rules! result_to_tokens {
     }};
 }
 
+/// The argument of an attribute in inner position, i.e. its tokens with the
+/// surrounding parenthesis dropped. This makes them identical to the ones
+/// passed by the native procedural macro call.
+fn unwrap_argument(tokens: TokenStream) -> TokenStream {
+    let mut iter = tokens.into_iter();
+    let Some(TokenTree::Group(group)) = iter.next() else {
+        unreachable!("Unexpected shape of an attribute.")
+    };
+    assert!(iter.next().is_none(), "Unexpected shape of an attribute.");
+    group.stream()
+}
+
 fn extract_prusti_attributes(
     item: &mut untyped::AnyFnItem,
 ) -> Vec<(SpecAttributeKind, Span, TokenStream)> {
@@ -75,16 +87,10 @@ fn extract_prusti_attributes(
                     | SpecAttributeKind::Ensures
                     | SpecAttributeKind::AfterExpiry
                     | SpecAttributeKind::AssertOnExpiry
-                    | SpecAttributeKind::RefineSpec => {
-                        // We need to drop the surrounding parenthesis to make the
-                        // tokens identical to the ones passed by the native procedural
-                        // macro call.
-                        let mut iter = attr.tokens.into_iter();
-                        let TokenTree::Group(group) = iter.next().unwrap() else {
-                            unreachable!()
-                        };
-                        assert!(iter.next().is_none(), "Unexpected shape of an attribute.");
-                        group.stream()
+                    | SpecAttributeKind::RefineSpec => unwrap_argument(attr.tokens),
+                    // The argument of `terminates` is optional.
+                    SpecAttributeKind::Terminates if !attr.tokens.is_empty() => {
+                        unwrap_argument(attr.tokens)
                     }
                     // Nothing to do for attributes without arguments.
                     SpecAttributeKind::Pure

--- a/prusti-contracts/prusti-specs/src/spec_attribute_kind.rs
+++ b/prusti-contracts/prusti-specs/src/spec_attribute_kind.rs
@@ -34,6 +34,7 @@ impl TryFrom<String> for SpecAttributeKind {
             "predicate" => Ok(SpecAttributeKind::Predicate),
             "invariant" => Ok(SpecAttributeKind::Invariant),
             "refine_spec" => Ok(SpecAttributeKind::RefineSpec),
+            "terminates" => Ok(SpecAttributeKind::Terminates),
             "model" => Ok(SpecAttributeKind::Model),
             "print_counterexample" => Ok(SpecAttributeKind::PrintCounterexample),
             "verified" => Ok(SpecAttributeKind::Verified),

--- a/prusti-encoder/src/encoders/body.rs
+++ b/prusti-encoder/src/encoders/body.rs
@@ -1,0 +1,50 @@
+use pcg::pcg::BodyWithBorrowckFacts;
+use prusti_interface::environment::{EnvQuery, body::MirBody};
+use prusti_rustc_interface::{
+    middle::ty,
+    span::def_id::{DefId, LocalDefId},
+};
+
+use crate::trait_support::is_function_with_body;
+
+/// Whether the body of `def_id` is encoded, rather than only its contract.
+/// It is not if the function is trusted (we take its contract on faith), or
+/// if it has no body of its own to encode (an external function, or a trait
+/// method without a default implementation).
+pub fn encodes_body(def_id: DefId) -> bool {
+    if crate::encoders::is_function_trusted(def_id) {
+        tracing::info!("function {def_id:?} is trusted, not encoding its body");
+        return false;
+    }
+    vir::with_vcx(|vcx| {
+        is_function_with_body(vcx.tcx(), def_id) && EnvQuery::new(vcx.tcx()).has_body(def_id)
+    })
+}
+
+/// The MIR body of `def_id` to encode, or `None` if there is none (see
+/// [encodes_body]). The body is the one the compiler produced: as the
+/// encoding is generic it is not instantiated, which also keeps the regions
+/// that the PCG needs.
+pub fn impure_body<'vir>(def_id: DefId) -> Option<MirBody<'vir>> {
+    let def_id = local_to_encode(def_id)?;
+    vir::with_vcx(|vcx| Some(vcx.body_mut().get_impure_fn_body_identity(def_id)))
+}
+
+/// As [impure_body], together with the borrowck facts needed by the PCG.
+pub fn impure_body_with_facts<'vir>(def_id: DefId) -> Option<BodyWithBorrowckFacts<'vir>> {
+    let def_id = local_to_encode(def_id)?;
+    vir::with_vcx(|vcx| Some(vcx.body_mut().get_impure_fn_body_with_facts(def_id)))
+}
+
+/// The MIR body of the specification `def_id`, taken generically (i.e. with
+/// its own parameters, see [instantiated_spec_body] for the exception).
+pub fn spec_body<'vir>(def_id: DefId) -> MirBody<'vir> {
+    vir::with_vcx(|vcx| {
+        let substs = ty::GenericArgs::identity_for_item(vcx.tcx(), def_id);
+        vcx.body_mut().get_spec_body(def_id, substs, None)
+    })
+}
+
+fn local_to_encode(def_id: DefId) -> Option<LocalDefId> {
+    encodes_body(def_id).then(|| def_id.as_local()).flatten()
+}

--- a/prusti-encoder/src/encoders/body.rs
+++ b/prusti-encoder/src/encoders/body.rs
@@ -36,6 +36,19 @@ pub fn impure_body_with_facts<'vir>(def_id: DefId) -> Option<BodyWithBorrowckFac
     vir::with_vcx(|vcx| Some(vcx.body_mut().get_impure_fn_body_with_facts(def_id)))
 }
 
+/// The MIR body of the pure function `def_id`. Only the bodies of functions
+/// whose specification marks them pure are preloaded (they must be exported
+/// across crates); a local function is pure by inheritance from the trait
+/// method it implements, so its body is taken like any other local body.
+pub fn pure_body<'vir>(def_id: DefId) -> MirBody<'vir> {
+    impure_body(def_id).unwrap_or_else(|| {
+        vir::with_vcx(|vcx| {
+            let substs = ty::GenericArgs::identity_for_item(vcx.tcx(), def_id);
+            vcx.body_mut().get_pure_fn_body(def_id, substs, None)
+        })
+    })
+}
+
 /// The MIR body of the specification `def_id`, taken generically (i.e. with
 /// its own parameters, see [instantiated_spec_body] for the exception).
 pub fn spec_body<'vir>(def_id: DefId) -> MirBody<'vir> {

--- a/prusti-encoder/src/encoders/const.rs
+++ b/prusti-encoder/src/encoders/const.rs
@@ -374,10 +374,8 @@ impl TaskEncoder for ConstEnc {
                         let task = MirPureEncTask {
                             encoding_depth: encoding_depth + 1,
                             parent_def_id: uneval.def,
-                            param_env: vcx.tcx().param_env(uneval.def),
-                            substs: ty::List::identity_for_item(vcx.tcx(), uneval.def),
+                            gargs: GParams::from(uneval.def).identity_args(),
                             kind: PureKind::Constant(promoted),
-                            caller_def_id: None,
                         };
                         let expr = deps.require_dep::<MirPureEnc>(task)?.expr;
                         use vir::Reify;

--- a/prusti-encoder/src/encoders/impure/fn_wand.rs
+++ b/prusti-encoder/src/encoders/impure/fn_wand.rs
@@ -36,7 +36,7 @@ impl<'vir, E: TaskEncoder> ImpureEncVisitor<'vir, '_, E> {
     ) -> Result<Vec<vir::Stmt<'vir>>, EncodeFullError<'vir, E>> {
         let mut wand_packages = Vec::new();
         let label = self.new_label("package_post");
-        let result = self.local_defs.locals[mir::RETURN_PLACE].impure_snap;
+        let result = self.local_defs[mir::RETURN_PLACE].impure_snap;
         let result = self.vcx.mk_local_labelled_old_expr(result, label);
         let args = self
             .local_defs

--- a/prusti-encoder/src/encoders/local_def.rs
+++ b/prusti-encoder/src/encoders/local_def.rs
@@ -25,15 +25,15 @@ impl task_encoder::OutputRefAny for MirLocalDefEncOutputRef {}
 
 #[derive(Clone, Copy)]
 pub struct MirLocalDefEncOutput<'vir> {
-    /// The definitions of the locals; `None` for the hidden locals of
+    /// The definitions of the locals; `None` for the locals only serving
     /// specification-only arms, which are invisible in the encoding.
     locals: &'vir IndexVec<mir::Local, Option<LocalDef<'vir>>>,
     pub arg_count: usize,
 }
 
 impl<'vir> MirLocalDefEncOutput<'vir> {
-    /// Returns the definition of the given local, or `None` if the local is
-    /// hidden (only serves specification-only arms).
+    /// Returns the definition of the given local, or `None` if the local
+    /// only serves specification-only arms.
     pub fn get(&self, local: mir::Local) -> Option<LocalDef<'vir>> {
         self.locals[local]
     }
@@ -208,18 +208,18 @@ impl TaskEncoder for MirLocalDefEnc {
                 // Locals only serving specification-only arms are never
                 // used in the encoding; give them no definition so that
                 // their types are not encoded. Arguments and the return
-                // place are never hidden, so args-only tasks skip the
-                // analysis.
-                let hidden_locals = if task_key.all_locals() {
+                // place never serve only a spec arm, so args-only tasks skip
+                // the analysis.
+                let spec_only_locals = if task_key.all_locals() {
                     deps.require_dep::<crate::encoders::mir_fn::SpecBlocksEnc>(task_key.def_id())?
                         .spec_arms
-                        .hidden_locals
+                        .spec_only_locals
                 } else {
                     Default::default()
                 };
                 let locals = IndexVec::from_fn_n(
                     |local: mir::Local| {
-                        if hidden_locals.contains(&local) {
+                        if spec_only_locals.contains(&local) {
                             return None;
                         }
                         let rust_ty = body.local_decls[local].ty;
@@ -283,6 +283,6 @@ impl<'vir> Index<mir::Local> for MirLocalDefEncOutput<'vir> {
     fn index(&self, index: mir::Local) -> &Self::Output {
         self.locals[index]
             .as_ref()
-            .unwrap_or_else(|| panic!("hidden local {index:?} has no definition"))
+            .unwrap_or_else(|| panic!("spec-only local {index:?} has no definition"))
     }
 }

--- a/prusti-encoder/src/encoders/local_def.rs
+++ b/prusti-encoder/src/encoders/local_def.rs
@@ -10,12 +10,9 @@ use prusti_rustc_interface::{
 use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 use vir::HasType;
 
-use crate::{
-    encoders::{
-        TyUseImpureEnc,
-        ty::{RustTyDecomposition, use_impure::TyUseImpure},
-    },
-    trait_support::is_function_with_body,
+use crate::encoders::{
+    TyUseImpureEnc,
+    ty::{RustTyDecomposition, use_impure::TyUseImpure},
 };
 
 pub struct MirLocalDefEnc;
@@ -28,11 +25,19 @@ impl task_encoder::OutputRefAny for MirLocalDefEncOutputRef {}
 
 #[derive(Clone, Copy)]
 pub struct MirLocalDefEncOutput<'vir> {
-    pub locals: &'vir IndexVec<mir::Local, LocalDef<'vir>>,
+    /// The definitions of the locals; `None` for the hidden locals of
+    /// specification-only arms, which are invisible in the encoding.
+    locals: &'vir IndexVec<mir::Local, Option<LocalDef<'vir>>>,
     pub arg_count: usize,
 }
 
 impl<'vir> MirLocalDefEncOutput<'vir> {
+    /// Returns the definition of the given local, or `None` if the local is
+    /// hidden (only serves specification-only arms).
+    pub fn get(&self, local: mir::Local) -> Option<LocalDef<'vir>> {
+        self.locals[local]
+    }
+
     /// Returns the definitions for the function return value.
     pub fn ret(&self) -> LocalDef<'vir> {
         self[mir::RETURN_PLACE]
@@ -82,22 +87,6 @@ pub struct LocalDef<'vir> {
     pub impure_pred: vir::ExprBool<'vir>,
 }
 
-fn should_encode_locals<'vir>(vcx: &vir::VirCtxt<'vir>, def_id: DefId) -> bool {
-    if crate::encoders::spec::is_function_trusted(def_id) {
-        tracing::info!("function {def_id:?} is trusted, skipping local encoding");
-        return false;
-    }
-    if def_id.as_local().is_none() {
-        tracing::info!("function {def_id:?} is not a local function, skipping local encoding");
-        return false;
-    }
-    if !is_function_with_body(vcx.tcx(), def_id) {
-        tracing::info!("function {def_id:?} is not a function with body, skipping local encoding");
-        return false;
-    }
-    true
-}
-
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum MirLocalDefEncTask<'vir> {
     // TODO: is this case needed?
@@ -133,34 +122,18 @@ impl<'vir> MirLocalDefEncTask<'vir> {
         }
     }
 
-    fn body(self, vcx: &vir::VirCtxt<'vir>) -> Option<MirBody<'vir>> {
+    /// The body whose locals are encoded, or `None` if there is none to
+    /// encode, in which case the locals are derived from the signature
+    /// instead.
+    ///
+    /// The body is never instantiated: the encoding is generic, and the
+    /// callers that do pass substs only need them for the signature.
+    fn body(self) -> Option<MirBody<'vir>> {
         match self {
-            MirLocalDefEncTask::ExternSpec(def_id) => {
-                let substs = ty::GenericArgs::identity_for_item(vcx.tcx(), def_id);
-                Some(vcx.body_mut().get_spec_body(def_id, substs, None))
-            }
-            MirLocalDefEncTask::Local { def_id, .. } => {
-                if should_encode_locals(vcx, def_id) {
-                    let substs = ty::GenericArgs::identity_for_item(vcx.tcx(), def_id);
-                    Some(vcx.body_mut().get_impure_fn_body(
-                        def_id.as_local().unwrap(),
-                        substs,
-                        None,
-                    ))
-                } else {
-                    None
-                }
-            }
-            MirLocalDefEncTask::LocalSubsts { def_id, substs, .. } => {
-                if should_encode_locals(vcx, def_id) {
-                    Some(vcx.body_mut().get_impure_fn_body(
-                        def_id.as_local().unwrap(),
-                        substs,
-                        None,
-                    ))
-                } else {
-                    None
-                }
+            MirLocalDefEncTask::ExternSpec(def_id) => Some(crate::encoders::spec_body(def_id)),
+            MirLocalDefEncTask::Local { def_id, .. }
+            | MirLocalDefEncTask::LocalSubsts { def_id, .. } => {
+                crate::encoders::impure_body(def_id)
             }
         }
     }
@@ -225,19 +198,34 @@ impl TaskEncoder for MirLocalDefEnc {
         vir::with_vcx(|vcx| {
             // TODO: refactor this a bit: split into one encoder for arguments (only)
             //   and one for locals (only)
-            let data = if let Some(body) = task_key.body(vcx) {
+            let data = if let Some(body) = task_key.body() {
                 deps.emit_output_ref(
                     *task_key,
                     MirLocalDefEncOutputRef {
                         arg_count: body.arg_count,
                     },
                 )?;
+                // Locals only serving specification-only arms are never
+                // used in the encoding; give them no definition so that
+                // their types are not encoded. Arguments and the return
+                // place are never hidden, so args-only tasks skip the
+                // analysis.
+                let hidden_locals = if task_key.all_locals() {
+                    deps.require_dep::<crate::encoders::mir_fn::SpecBlocksEnc>(task_key.def_id())?
+                        .spec_arms
+                        .hidden_locals
+                } else {
+                    Default::default()
+                };
                 let locals = IndexVec::from_fn_n(
                     |local: mir::Local| {
+                        if hidden_locals.contains(&local) {
+                            return None;
+                        }
                         let rust_ty = body.local_decls[local].ty;
                         let rust_ty_task = RustTyDecomposition::from_ty(rust_ty, task_key.def_id());
                         let ty = deps.require_dep::<TyUseImpureEnc>(rust_ty_task).unwrap();
-                        mk_local_def(vcx, local, ty)
+                        Some(mk_local_def(vcx, local, ty))
                     },
                     if task_key.all_locals() {
                         body.local_decls.len()
@@ -276,7 +264,7 @@ impl TaskEncoder for MirLocalDefEnc {
                         let rust_ty_task =
                             RustTyDecomposition::from_ty(rust_ty, task_key.context_def_id());
                         let ty = deps.require_dep::<TyUseImpureEnc>(rust_ty_task)?;
-                        Ok(mk_local_def(vcx, local, ty))
+                        Ok(Some(mk_local_def(vcx, local, ty)))
                     })
                     .collect::<Result<IndexVec<_, _>, _>>()?;
 
@@ -293,6 +281,8 @@ impl TaskEncoder for MirLocalDefEnc {
 impl<'vir> Index<mir::Local> for MirLocalDefEncOutput<'vir> {
     type Output = LocalDef<'vir>;
     fn index(&self, index: mir::Local) -> &Self::Output {
-        &self.locals[index]
+        self.locals[index]
+            .as_ref()
+            .unwrap_or_else(|| panic!("hidden local {index:?} has no definition"))
     }
 }

--- a/prusti-encoder/src/encoders/mir_fn/function.rs
+++ b/prusti-encoder/src/encoders/mir_fn/function.rs
@@ -1,16 +1,13 @@
 use prusti_interface::PrustiError;
-use prusti_rustc_interface::{middle::ty, span::def_id::DefId};
+use prusti_rustc_interface::span::def_id::DefId;
 use task_encoder::{EncodeFullResult, OutputRefAny, TaskEncoder, TaskEncoderDependencies};
 use vir::{FunctionIdn, Reify};
 
-use crate::{
-    encoders::{
-        MirLocalDefEnc, MirLocalDefEncTask, MirPureEnc, MirPureEncTask, MirSpecEnc, Pure, PureKind,
-        mir_fn::{CallTaskDescription, RustSignature},
-        pure::spec::MirSpecEncMode,
-        ty::generics::{GArgCaster, GArgsCastEnc, GArgsTy, GArgsTyEnc, GParams, GenericParamsEnc},
-    },
-    trait_support::is_function_with_body,
+use crate::encoders::{
+    MirLocalDefEnc, MirLocalDefEncTask, MirPureEnc, MirPureEncTask, MirSpecEnc, Pure, PureKind,
+    mir_fn::{CallTaskDescription, RustSignature},
+    pure::spec::MirSpecEncMode,
+    ty::generics::{GArgCaster, GArgsCastEnc, GArgsTy, GArgsTyEnc, GParams, GenericParamsEnc},
 };
 
 // Function wrapper
@@ -151,7 +148,6 @@ impl TaskEncoder for FunctionEnc {
     ) -> EncodeFullResult<'vir, Self> {
         vir::with_vcx(|vcx| {
             let def_id = *task_key;
-            let trusted = crate::encoders::is_function_trusted(def_id);
             let local_defs = deps.require_dep::<MirLocalDefEnc>(MirLocalDefEncTask::Local {
                 def_id,
                 all_locals: true,
@@ -185,11 +181,10 @@ impl TaskEncoder for FunctionEnc {
                 },
             )?;
 
-            let substs = ty::GenericArgs::identity_for_item(vcx.tcx(), def_id);
             let spec =
                 deps.require_dep::<MirSpecEnc>((def_id, def_id, MirSpecEncMode::PureWithResult))?;
 
-            let expr = if trusted || !is_function_with_body(vcx.tcx(), def_id) {
+            let expr = if !crate::encoders::encodes_body(def_id) {
                 None
             } else {
                 // Encode the body of the function. If it cannot be encoded (e.g. it
@@ -200,9 +195,7 @@ impl TaskEncoder for FunctionEnc {
                     encoding_depth: 0,
                     kind: PureKind::Pure,
                     parent_def_id: def_id,
-                    param_env: vcx.tcx().param_env(def_id),
-                    substs,
-                    caller_def_id: None,
+                    gargs: params.identity_args(),
                 }) {
                     Ok(out) => {
                         let expr = out.expr.reify(vcx, (def_id, spec.pre_args));

--- a/prusti-encoder/src/encoders/mir_fn/method.rs
+++ b/prusti-encoder/src/encoders/mir_fn/method.rs
@@ -6,15 +6,11 @@ use task_encoder::{
 };
 use vir::MethodIdn;
 
-use crate::{
-    encoders::{
-        Impure, ImpureEncVisitor, MirLocalDefEnc, MirLocalDefEncTask, MirSpecEnc, WandEnc,
-        WandEncTask,
-        mir_fn::{CallTaskDescription, RustSignature, SpecBlocks},
-        pure::spec::MirSpecEncMode,
-        ty::generics::{GArgCaster, GArgsCastEnc, GArgsTy, GArgsTyEnc, GParams, GenericParamsEnc},
-    },
-    trait_support::is_function_with_body,
+use crate::encoders::{
+    Impure, ImpureEncVisitor, MirLocalDefEnc, MirLocalDefEncTask, MirSpecEnc, WandEnc, WandEncTask,
+    mir_fn::{CallTaskDescription, RustSignature, SpecBlocks, SpecBlocksEnc},
+    pure::spec::MirSpecEncMode,
+    ty::generics::{GArgCaster, GArgsCastEnc, GArgsTy, GArgsTyEnc, GParams, GenericParamsEnc},
 };
 
 // Method wrapper
@@ -148,7 +144,6 @@ impl TaskEncoder for MethodEnc {
         let def_id = *task_key;
         vir::with_vcx(|vcx| {
             let span = vcx.tcx().def_span(def_id);
-            let trusted = crate::encoders::is_function_trusted(def_id);
 
             let arg_defs = deps.require_ref_spanned::<MirLocalDefEnc>(
                 MirLocalDefEncTask::Local {
@@ -228,17 +223,16 @@ impl TaskEncoder for MethodEnc {
             posts.extend(wands.indirect_posts(vcx, &arg_defs, deps));
             posts.extend(wands.wand_posts(vcx, &arg_defs, deps));
 
-            // Do not encode the method body if it is external, trusted, just
-            // a call stub, or a trait function without a default implementation
-            let local_def_id = def_id
-                .as_local()
-                .filter(|_| !trusted && is_function_with_body(vcx.tcx(), def_id));
-            let blocks = if let Some(local_def_id) = local_def_id {
-                let body_with_facts = vcx.body_mut().get_impure_fn_body_with_facts(local_def_id);
+            // Trusted functions, call stubs, external functions and trait
+            // functions without a default implementation have no body to
+            // encode; only their contract is emitted.
+            let blocks = if let Some(body_with_facts) =
+                crate::encoders::impure_body_with_facts(def_id)
+            {
                 let body = &body_with_facts.body;
                 let local_defs = deps.require_dep_spanned::<MirLocalDefEnc>(
                     MirLocalDefEncTask::Local {
-                        def_id: local_def_id.to_def_id(),
+                        def_id,
                         all_locals: true,
                     },
                     span,
@@ -257,7 +251,11 @@ impl TaskEncoder for MethodEnc {
                 );
                 let mut start_stmts = Vec::new();
                 for local in (arg_count..body.local_decls.len()).map(mir::Local::from) {
-                    let name_p = local_defs[local].local.name;
+                    // Hidden locals have no definition.
+                    let Some(local_def) = local_defs.get(local) else {
+                        continue;
+                    };
+                    let name_p = local_def.local.name;
                     start_stmts.push(
                         vcx.mk_local_decl_stmt(vir::vir_local_decl! { vcx; [name_p] : Ref }, None),
                     )
@@ -270,8 +268,11 @@ impl TaskEncoder for MethodEnc {
                     vcx.mk_goto_stmt(&vir::CfgBlockLabelData::BasicBlock(0)),
                 ));
 
-                let spec_blocks =
-                    SpecBlocks::new(def_id, body, fpcs_analysis.analysis().loop_analysis());
+                let spec_blocks = SpecBlocks::new(
+                    deps.require_dep::<SpecBlocksEnc>(def_id)?,
+                    body,
+                    fpcs_analysis.analysis().loop_analysis(),
+                );
 
                 deps.check_cycle()?;
                 let mut visitor = ImpureEncVisitor {

--- a/prusti-encoder/src/encoders/mir_fn/method.rs
+++ b/prusti-encoder/src/encoders/mir_fn/method.rs
@@ -251,7 +251,7 @@ impl TaskEncoder for MethodEnc {
                 );
                 let mut start_stmts = Vec::new();
                 for local in (arg_count..body.local_decls.len()).map(mir::Local::from) {
-                    // Hidden locals have no definition.
+                    // Spec-only locals have no definition.
                     let Some(local_def) = local_defs.get(local) else {
                         continue;
                     };

--- a/prusti-encoder/src/encoders/mir_fn/mod.rs
+++ b/prusti-encoder/src/encoders/mir_fn/mod.rs
@@ -89,9 +89,18 @@ pub fn encode_all_in_crate<'tcx>(tcx: ty::TyCtxt<'tcx>) {
     for def_id in tcx.hir_body_owners() {
         tracing::debug!("test_entrypoint item: {def_id:?}");
         match tcx.def_kind(def_id) {
-            hir::def::DefKind::Fn | hir::def::DefKind::AssocFn => {
+            // Closure bodies are verified like `fn` bodies, whether or not
+            // they carry a `closure!` specification; only the closures of
+            // specifications themselves are exempt.
+            hir::def::DefKind::Fn | hir::def::DefKind::AssocFn | hir::def::DefKind::Closure => {
                 let def_id = def_id.to_def_id();
-                if prusti_interface::specs::is_spec_fn(tcx, def_id) {
+                if prusti_interface::specs::is_spec_item(tcx, def_id) {
+                    continue;
+                }
+                // A closure inside a trusted function is part of its
+                // (unencoded) body.
+                let root = tcx.typeck_root_def_id(def_id);
+                if root != def_id && crate::encoders::is_function_trusted(root) {
                     continue;
                 }
                 // Extern-spec stubs are macro-generated forwarding bodies whose

--- a/prusti-encoder/src/encoders/mir_fn/spec_blocks.rs
+++ b/prusti-encoder/src/encoders/mir_fn/spec_blocks.rs
@@ -82,7 +82,7 @@ impl GhostBlocks {
         );
 
         // The ghost arm's blocks (the inline ghost body).
-        dominated_region(body, arm_block, &mut self.code);
+        dominated_blocks(body, arm_block, &mut self.code);
     }
 }
 
@@ -103,11 +103,11 @@ fn get_sibling(targets: &mir::SwitchTargets, arm_block: BasicBlock) -> BasicBloc
     sibling
 }
 
-/// Collects the arm region into `out`: everything reachable from (and still
-/// dominated by) the arm entry. The dominance requirement keeps blocks
-/// shared with live code out of the region (the join both arms continue to,
-/// and cleanup blocks that calls outside the arm also unwind to).
-fn dominated_region(body: &mir::Body<'_>, arm_entry: BasicBlock, out: &mut FxHashSet<BasicBlock>) {
+/// Collects the arm's blocks into `out`: everything reachable from (and
+/// still dominated by) the arm entry. The dominance requirement keeps blocks
+/// shared with live code out (the join both arms continue to, and cleanup
+/// blocks that calls outside the arm also unwind to).
+fn dominated_blocks(body: &mir::Body<'_>, arm_entry: BasicBlock, out: &mut FxHashSet<BasicBlock>) {
     let doms = body.basic_blocks.dominators();
     let mut queue = vec![arm_entry];
     while let Some(block) = queue.pop() {
@@ -124,8 +124,8 @@ fn dominated_region(body: &mir::Body<'_>, arm_entry: BasicBlock, out: &mut FxHas
 /// The arms are invisible in the encoding: each guarding switch is encoded
 /// as an unconditional jump to the live target (the continuation, or the
 /// inline ghost body), the arm's blocks are never encoded, and neither are
-/// the [hidden locals](Self::hidden_locals) nor the (constant) assignments
-/// to them.
+/// the [spec-only locals](Self::spec_only_locals) nor the (constant)
+/// assignments to them.
 #[derive(Clone, Default)]
 pub struct SpecArms {
     /// The live target, keyed by the block whose `if false` switch guards
@@ -138,10 +138,10 @@ pub struct SpecArms {
     /// [scaffolding](Self::scaffolding), whose stores are skipped. Neither
     /// their declarations (and hence types) nor the assignments to them are
     /// encoded.
-    pub hidden_locals: FxHashSet<mir::Local>,
+    pub spec_only_locals: FxHashSet<mir::Local>,
     /// The arms' scaffolding locals, each identified by its structural
-    /// anchor: the switch discriminants (the operands of the rewired
-    /// switches; their `const false` stores are their only encodable
+    /// anchor: the switch discriminants (the operands of the switches
+    /// encoded as gotos; their `const false` stores are their only encodable
     /// mention) and the unit values of the arms' `if` statements (stored
     /// `const ()` in the live continuations, kept only when nothing else
     /// uses them: a live unit local in the same block is not scaffolding).
@@ -174,20 +174,20 @@ impl SpecArms {
         for block in &arms.blocks {
             for statement in &body[*block].statements {
                 if let mir::StatementKind::Assign(box (dest, _)) = &statement.kind {
-                    arms.hidden_locals.extend(dest.as_local());
+                    arms.spec_only_locals.extend(dest.as_local());
                 }
             }
             if let mir::TerminatorKind::Call { destination, .. } = &body[*block].terminator().kind {
-                arms.hidden_locals.extend(destination.as_local());
+                arms.spec_only_locals.extend(destination.as_local());
             }
         }
-        arms.hidden_locals.remove(&mir::RETURN_PLACE);
+        arms.spec_only_locals.remove(&mir::RETURN_PLACE);
         for ghost_block in ghost.switches.values() {
             if let mir::TerminatorKind::Call { destination, .. } =
                 &body[ghost_block.erased_block].terminator().kind
                 && let Some(local) = destination.as_local()
             {
-                arms.hidden_locals.remove(&local);
+                arms.spec_only_locals.remove(&local);
             }
         }
 
@@ -218,9 +218,11 @@ impl SpecArms {
         // Sanity check: nothing encoded outside the arms may use an
         // arm-assigned or scaffolding local.
         assert!(
-            arms.hidden_locals.is_disjoint(&used),
+            arms.spec_only_locals.is_disjoint(&used),
             "spec-only arm locals leak into encoded code: {:?}",
-            arms.hidden_locals.intersection(&used).collect::<Vec<_>>()
+            arms.spec_only_locals
+                .intersection(&used)
+                .collect::<Vec<_>>()
         );
         assert!(
             arms.scaffolding.is_disjoint(&used),
@@ -229,11 +231,11 @@ impl SpecArms {
         );
 
         // The locals without any encoded use.
-        let hidden = (body.arg_count + 1..body.local_decls.len())
+        let unused = (body.arg_count + 1..body.local_decls.len())
             .map(mir::Local::from)
             .filter(|local| !used.contains(local))
             .collect::<Vec<_>>();
-        arms.hidden_locals.extend(hidden);
+        arms.spec_only_locals.extend(unused);
         arms
     }
 
@@ -247,22 +249,18 @@ impl SpecArms {
         // Walk up the single-predecessor chain to the guarding `if false`
         // switch; the chain block below it is the arm entry.
         let mut arm_entry = marker_block;
-        let switch_block = loop {
+        let (switch_block, discr, targets) = loop {
             let pred = get_single_predecessor(&body.basic_blocks.predecessors()[arm_entry]);
-            if let mir::TerminatorKind::SwitchInt { .. } = body[pred].terminator().kind {
-                break pred;
+            if let mir::TerminatorKind::SwitchInt { discr, targets } = &body[pred].terminator().kind
+            {
+                break (pred, discr, targets);
             }
             arm_entry = pred;
-        };
-        let mir::TerminatorKind::SwitchInt { discr, targets } =
-            &body[switch_block].terminator().kind
-        else {
-            unreachable!();
         };
         let live_target = get_sibling(targets, arm_entry);
         self.switches.insert(switch_block, live_target);
 
-        // The switch discriminant is read only by the rewired switch.
+        // The switch is encoded as a goto, so its discriminant is never read.
         if let Some(local) = discr.place().and_then(|place| place.as_local()) {
             self.scaffolding.insert(local);
         }
@@ -281,7 +279,7 @@ impl SpecArms {
             }
         }
 
-        dominated_region(body, arm_entry, &mut self.blocks);
+        dominated_blocks(body, arm_entry, &mut self.blocks);
     }
 
     /// Records a `ghost!` block's runtime stand-in arm: the switch jumps
@@ -298,7 +296,7 @@ impl SpecArms {
         if let Some(local) = discr.place().and_then(|place| place.as_local()) {
             self.scaffolding.insert(local);
         }
-        dominated_region(body, ghost.erased_block, &mut self.blocks);
+        dominated_blocks(body, ghost.erased_block, &mut self.blocks);
     }
 }
 
@@ -385,7 +383,7 @@ impl SpecBlocksBase {
 }
 
 /// Memoizes [SpecBlocksBase] per `DefId`; required by both `MethodEnc` (for
-/// the full [SpecBlocks]) and `MirLocalDefEnc` (for the hidden locals).
+/// the full [SpecBlocks]) and `MirLocalDefEnc` (for the spec-only locals).
 pub struct SpecBlocksEnc;
 
 impl TaskEncoder for SpecBlocksEnc {
@@ -609,7 +607,7 @@ impl<'enc, 'vir> mir::visit::Visitor<'vir> for UsedLocals<'enc> {
     }
 
     fn visit_terminator(&mut self, terminator: &mir::Terminator<'vir>, location: mir::Location) {
-        // A rewired switch is encoded as a bare goto: its discriminant
+        // A guarding switch is encoded as a bare goto: its discriminant
         // operand is not used.
         if !self.arms.switches.contains_key(&location.block) {
             self.super_terminator(terminator, location);

--- a/prusti-encoder/src/encoders/mir_fn/spec_blocks.rs
+++ b/prusti-encoder/src/encoders/mir_fn/spec_blocks.rs
@@ -5,6 +5,7 @@ use prusti_rustc_interface::{
     middle::mir::{self, BasicBlock},
     span::{Span, def_id::DefId},
 };
+use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 
 use crate::encoders::mir_fn::RustSignature;
 
@@ -31,7 +32,7 @@ pub struct GhostBlock {
 /// The `ghost!` blocks of a MIR body (see [`GhostBlock`]). Unlike the full
 /// [`SpecBlocks`], this needs no PCG analysis, so the pure encoder can use
 /// the same detection.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct GhostBlocks {
     /// Ghost blocks, keyed by the block whose `if false` switch guards them.
     pub switches: FxHashMap<BasicBlock, GhostBlock>,
@@ -47,22 +48,20 @@ impl GhostBlocks {
     /// the ghost arm, holding the inline ghost body up to its `ghost_call`
     /// terminator.
     pub fn new<'vir>(def_id: DefId, body: &mir::Body<'vir>) -> Self {
+        let visitor = SpecVisitor::run(def_id, body);
+        Self::from_erased(body, visitor.erased_blocks)
+    }
+
+    /// Builds the ghost blocks from the blocks of the runtime `ghost_erased`
+    /// stand-in arms (as collected by [SpecVisitor]).
+    fn from_erased<'vir>(
+        body: &mir::Body<'vir>,
+        erased_blocks: impl IntoIterator<Item = BasicBlock>,
+    ) -> Self {
         let mut ghost = GhostBlocks::default();
-        vir::with_vcx(|vcx| {
-            let env_query = EnvQuery::new(vcx.tcx());
-            for (block, data) in body.basic_blocks.iter_enumerated() {
-                let mir::TerminatorKind::Call { func, .. } = &data.terminator().kind else {
-                    continue;
-                };
-                let func_ty = func.ty(body, vcx.tcx());
-                let (fn_def_id, arg_tys) = RustSignature::get_def_id_and_caller_substs(func_ty);
-                if env_query.is_function_in_crate(def_id, fn_def_id, arg_tys, "prusti_contracts")
-                    && vcx.tcx().item_name(fn_def_id).as_str() == "ghost_erased"
-                {
-                    ghost.visit_erased(body, block);
-                }
-            }
-        });
+        for block in erased_blocks {
+            ghost.visit_erased(body, block);
+        }
         ghost
     }
 
@@ -73,18 +72,7 @@ impl GhostBlocks {
         else {
             unreachable!("malformed ghost block: `ghost_erased` arm not guarded by a switch");
         };
-        let mut siblings = targets
-            .all_targets()
-            .iter()
-            .copied()
-            .filter(|target| *target != erased_block);
-        let arm_block = siblings
-            .next()
-            .expect("malformed ghost block: no sibling arm");
-        assert!(
-            siblings.next().is_none(),
-            "malformed ghost block: expected a two-armed switch"
-        );
+        let arm_block = get_sibling(targets, erased_block);
         self.switches.insert(
             switch_block,
             GhostBlock {
@@ -93,19 +81,224 @@ impl GhostBlocks {
             },
         );
 
-        // The ghost arm's blocks (the inline ghost body): everything
-        // reachable from (and still dominated by) the arm entry. The
-        // dominance requirement keeps blocks shared with live code out of
-        // the region (the join both arms continue to, and cleanup blocks
-        // that calls outside the arm also unwind to).
-        let doms = body.basic_blocks.dominators();
-        let mut queue = vec![arm_block];
-        while let Some(block) = queue.pop() {
-            if !doms.dominates(arm_block, block) || !self.code.insert(block) {
-                continue;
-            }
-            queue.extend(body.basic_blocks[block].terminator().successors());
+        // The ghost arm's blocks (the inline ghost body).
+        dominated_region(body, arm_block, &mut self.code);
+    }
+}
+
+/// Returns the other target of a two-armed switch.
+fn get_sibling(targets: &mir::SwitchTargets, arm_block: BasicBlock) -> BasicBlock {
+    let mut siblings = targets
+        .all_targets()
+        .iter()
+        .copied()
+        .filter(|target| *target != arm_block);
+    let sibling = siblings
+        .next()
+        .expect("malformed spec-only arm: no sibling arm");
+    assert!(
+        siblings.next().is_none(),
+        "malformed spec-only arm: expected a two-armed switch"
+    );
+    sibling
+}
+
+/// Collects the arm region into `out`: everything reachable from (and still
+/// dominated by) the arm entry. The dominance requirement keeps blocks
+/// shared with live code out of the region (the join both arms continue to,
+/// and cleanup blocks that calls outside the arm also unwind to).
+fn dominated_region(body: &mir::Body<'_>, arm_entry: BasicBlock, out: &mut FxHashSet<BasicBlock>) {
+    let doms = body.basic_blocks.dominators();
+    let mut queue = vec![arm_entry];
+    while let Some(block) = queue.pop() {
+        if !doms.dominates(arm_entry, block) || !out.insert(block) {
+            continue;
         }
+        queue.extend(body.basic_blocks[block].terminator().successors());
+    }
+}
+
+/// The specification-only arms of a MIR body, i.e. the `if false { .. }`
+/// expansions of our macros: the `spec_block(..)` arms of `prusti_assert!`
+/// and friends, and the runtime `ghost_erased()` stand-in arms of `ghost!`.
+/// The arms are invisible in the encoding: each guarding switch is encoded
+/// as an unconditional jump to the live target (the continuation, or the
+/// inline ghost body), the arm's blocks are never encoded, and neither are
+/// the [hidden locals](Self::hidden_locals) nor the (constant) assignments
+/// to them.
+#[derive(Clone, Default)]
+pub struct SpecArms {
+    /// The live target, keyed by the block whose `if false` switch guards
+    /// a spec-only arm.
+    pub switches: FxHashMap<BasicBlock, BasicBlock>,
+    /// The blocks of all spec-only arms.
+    pub blocks: FxHashSet<BasicBlock>,
+    /// The locals only serving the arms: those assigned within the arms,
+    /// plus those with no encoded use at all. The latter covers the
+    /// [scaffolding](Self::scaffolding), whose stores are skipped. Neither
+    /// their declarations (and hence types) nor the assignments to them are
+    /// encoded.
+    pub hidden_locals: FxHashSet<mir::Local>,
+    /// The arms' scaffolding locals, each identified by its structural
+    /// anchor: the switch discriminants (the operands of the rewired
+    /// switches; their `const false` stores are their only encodable
+    /// mention) and the unit values of the arms' `if` statements (stored
+    /// `const ()` in the live continuations, kept only when nothing else
+    /// uses them: a live unit local in the same block is not scaffolding).
+    /// Stores to these locals are not encoded.
+    scaffolding: FxHashSet<mir::Local>,
+}
+
+impl SpecArms {
+    fn new(
+        body: &mir::Body<'_>,
+        ghost: &GhostBlocks,
+        marker_blocks: impl IntoIterator<Item = BasicBlock>,
+    ) -> Self {
+        use mir::visit::Visitor;
+        let mut arms = Self::default();
+        let mut unit_candidates = FxHashSet::default();
+        for block in marker_blocks {
+            arms.visit_marker(body, block, &mut unit_candidates);
+        }
+        for (switch_block, ghost_block) in &ghost.switches {
+            arms.visit_ghost(body, *switch_block, *ghost_block);
+        }
+        if arms.switches.is_empty() {
+            return arms;
+        }
+
+        // The locals assigned within the arms. A `ghost_erased` stand-in arm
+        // writes the same destination as its (encoded) ghost arm, and the
+        // return place is of course live.
+        for block in &arms.blocks {
+            for statement in &body[*block].statements {
+                if let mir::StatementKind::Assign(box (dest, _)) = &statement.kind {
+                    arms.hidden_locals.extend(dest.as_local());
+                }
+            }
+            if let mir::TerminatorKind::Call { destination, .. } = &body[*block].terminator().kind {
+                arms.hidden_locals.extend(destination.as_local());
+            }
+        }
+        arms.hidden_locals.remove(&mir::RETURN_PLACE);
+        for ghost_block in ghost.switches.values() {
+            if let mir::TerminatorKind::Call { destination, .. } =
+                &body[ghost_block.erased_block].terminator().kind
+                && let Some(local) = destination.as_local()
+            {
+                arms.hidden_locals.remove(&local);
+            }
+        }
+
+        let mut collector = UsedLocals {
+            arms: &arms,
+            unit_candidates: &unit_candidates,
+            used: Default::default(),
+        };
+        for (block, data) in body.basic_blocks.iter_enumerated() {
+            // Cleanup blocks are emitted as dummy blocks, so their mentions
+            // (e.g. `Drop`s of arm temps) are not encoded uses.
+            if !arms.blocks.contains(&block) && !data.is_cleanup {
+                collector.visit_basic_block_data(block, data);
+            }
+        }
+        let used = collector.used;
+
+        // Unit if-temp candidates with an encoded use are real locals (e.g.
+        // a unit `result` binding stored in the same block); only the rest
+        // are scaffolding. Skipping the candidates' stores above is sound
+        // either way: a unit constant store mentions no other local.
+        arms.scaffolding.extend(
+            unit_candidates
+                .into_iter()
+                .filter(|local| !used.contains(local)),
+        );
+
+        // Sanity check: nothing encoded outside the arms may use an
+        // arm-assigned or scaffolding local.
+        assert!(
+            arms.hidden_locals.is_disjoint(&used),
+            "spec-only arm locals leak into encoded code: {:?}",
+            arms.hidden_locals.intersection(&used).collect::<Vec<_>>()
+        );
+        assert!(
+            arms.scaffolding.is_disjoint(&used),
+            "spec-only arm scaffolding locals leak into encoded code: {:?}",
+            arms.scaffolding.intersection(&used).collect::<Vec<_>>()
+        );
+
+        // The locals without any encoded use.
+        let hidden = (body.arg_count + 1..body.local_decls.len())
+            .map(mir::Local::from)
+            .filter(|local| !used.contains(local))
+            .collect::<Vec<_>>();
+        arms.hidden_locals.extend(hidden);
+        arms
+    }
+
+    /// Records the spec-only arm containing the given `spec_block` call.
+    fn visit_marker(
+        &mut self,
+        body: &mir::Body<'_>,
+        marker_block: BasicBlock,
+        unit_candidates: &mut FxHashSet<mir::Local>,
+    ) {
+        // Walk up the single-predecessor chain to the guarding `if false`
+        // switch; the chain block below it is the arm entry.
+        let mut arm_entry = marker_block;
+        let switch_block = loop {
+            let pred = get_single_predecessor(&body.basic_blocks.predecessors()[arm_entry]);
+            if let mir::TerminatorKind::SwitchInt { .. } = body[pred].terminator().kind {
+                break pred;
+            }
+            arm_entry = pred;
+        };
+        let mir::TerminatorKind::SwitchInt { discr, targets } =
+            &body[switch_block].terminator().kind
+        else {
+            unreachable!();
+        };
+        let live_target = get_sibling(targets, arm_entry);
+        self.switches.insert(switch_block, live_target);
+
+        // The switch discriminant is read only by the rewired switch.
+        if let Some(local) = discr.place().and_then(|place| place.as_local()) {
+            self.scaffolding.insert(local);
+        }
+        // The unit value the arm's `if` statement stores in the live
+        // continuation; only a candidate, since the block may also store
+        // live unit locals (e.g. a unit `result` binding).
+        for statement in &body[live_target].statements {
+            let mir::StatementKind::Assign(box (dest, rvalue)) = &statement.kind else {
+                continue;
+            };
+            let mir::Rvalue::Use(mir::Operand::Constant(constant)) = rvalue else {
+                continue;
+            };
+            if constant.ty().is_unit() {
+                unit_candidates.extend(dest.as_local());
+            }
+        }
+
+        dominated_region(body, arm_entry, &mut self.blocks);
+    }
+
+    /// Records a `ghost!` block's runtime stand-in arm: the switch jumps
+    /// into the ghost arm (the inline ghost body, which is encoded), only
+    /// the single-block `ghost_erased` arm is skipped. Unlike the `if
+    /// false` statements of the other arms, `ghost!` expands to an
+    /// `if/else` expression, so there are no unit if-temps to anchor.
+    fn visit_ghost(&mut self, body: &mir::Body<'_>, switch_block: BasicBlock, ghost: GhostBlock) {
+        self.switches.insert(switch_block, ghost.arm_block);
+        let mir::TerminatorKind::SwitchInt { discr, .. } = &body[switch_block].terminator().kind
+        else {
+            unreachable!();
+        };
+        if let Some(local) = discr.place().and_then(|place| place.as_local()) {
+            self.scaffolding.insert(local);
+        }
+        dominated_region(body, ghost.erased_block, &mut self.blocks);
     }
 }
 
@@ -138,8 +331,6 @@ pub struct SpecBlock {
 pub struct SpecBlocks {
     /// Maps specifications to basic blocks.
     pub specs_for: FxHashMap<BasicBlock, Vec<SpecBlock>>,
-    /// Set of all spec-only blocks.
-    pub spec_blocks: FxHashSet<BasicBlock>,
     /// Set of loop specifications, keyed by loop heads.
     pub loop_specs: FxHashMap<BasicBlock, LoopSpec>,
     /// Maps loop IDs (as identified by the PCG loop analysis) to their loop
@@ -147,35 +338,84 @@ pub struct SpecBlocks {
     pub loop_head_at: FxHashMap<LoopId, BasicBlock>,
     /// The `ghost!` blocks of the body.
     pub ghost: GhostBlocks,
+    /// The specification-only arms of the body.
+    pub spec_arms: SpecArms,
 }
 
-impl SpecBlocks {
+/// The body-derived part of [SpecBlocks], independent of the (PCG) loop
+/// analysis. Memoized per `DefId` by [SpecBlocksEnc] so the spec-arm
+/// analysis runs once per body.
+#[derive(Clone, Default)]
+pub struct SpecBlocksBase {
+    /// Maps specifications to basic blocks.
+    pub specs_for: FxHashMap<BasicBlock, Vec<SpecBlock>>,
+    /// The `ghost!` blocks of the body.
+    pub ghost: GhostBlocks,
+    /// The specification-only arms of the body.
+    pub spec_arms: SpecArms,
+}
+
+impl SpecBlocksBase {
     /// Determine the spec-only blocks for the given MIR body. Spec-only blocks
     /// are ones which consists of *only* a closure assignment of a closure
     /// marked with the Prusti spec-only attribute. For each spec-only block we
     /// determine which non-spec block it is attached to.
-    pub fn new<'enc, 'vir: 'enc>(
-        def_id: DefId,
-        body: &'enc mir::Body<'vir>,
-        loop_analysis: &'enc LoopAnalysis,
-    ) -> Self {
-        use mir::visit::Visitor;
-        let mut visitor = SpecVisitor {
-            def_id,
-            body,
-            specs_for: Default::default(),
-            spec_blocks: Default::default(),
+    fn new(def_id: DefId, body: &mir::Body<'_>) -> Self {
+        let mut visitor = SpecVisitor::run(def_id, body);
+
+        let ghost = GhostBlocks::from_erased(body, std::mem::take(&mut visitor.erased_blocks));
+        let spec_arms = SpecArms::new(body, &ghost, visitor.spec_blocks.iter().copied());
+
+        for specified_blocks in visitor.specs_for.values() {
+            for spec_block in specified_blocks {
+                // If this assertion ever fails, then consecutive spec blocks
+                // are actually consecutive blocks in the CFG. If this happens,
+                // we need to keep walking up the predecessors for each spec
+                // block until we find a non-spec block.
+                assert!(!visitor.spec_blocks.contains(&spec_block.attached_to));
+            }
+        }
+
+        Self {
+            specs_for: visitor.specs_for,
+            ghost,
+            spec_arms,
+        }
+    }
+}
+
+/// Memoizes [SpecBlocksBase] per `DefId`; required by both `MethodEnc` (for
+/// the full [SpecBlocks]) and `MirLocalDefEnc` (for the hidden locals).
+pub struct SpecBlocksEnc;
+
+impl TaskEncoder for SpecBlocksEnc {
+    task_encoder::encoder_cache!(SpecBlocksEnc);
+    const ENCODER_NAME: &'static str = "spec blocks encoder";
+
+    type TaskDescription<'vir> = DefId;
+    type OutputFullDependency<'vir> = SpecBlocksBase;
+
+    fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
+        *task
+    }
+
+    fn do_encode_full<'vir>(
+        task_key: &Self::TaskKey<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
+    ) -> EncodeFullResult<'vir, Self> {
+        deps.emit_output_ref(*task_key, ())?;
+        let def_id = *task_key;
+        let data = match crate::encoders::impure_body(def_id) {
+            Some(body) => SpecBlocksBase::new(def_id, &body),
+            None => SpecBlocksBase::default(),
         };
-        visitor.visit_body(body);
+        Ok(((), data))
+    }
+}
 
-        // The runtime stand-in arms of ghost blocks are skipped in the
-        // encoding (their switches are encoded as unconditional jumps into
-        // the ghost arms).
-        let ghost = GhostBlocks::new(def_id, body);
-        visitor
-            .spec_blocks
-            .extend(ghost.switches.values().map(|g| g.erased_block));
-
+impl SpecBlocks {
+    /// Associates the specs of `base` with the loops of the body.
+    pub fn new(base: SpecBlocksBase, body: &mir::Body<'_>, loop_analysis: &LoopAnalysis) -> Self {
         // Associate specs and determine loop heads (at body invariants) for loops
         let mut loop_specs: FxHashMap<LoopId, LoopSpec> = Default::default();
 
@@ -199,14 +439,8 @@ impl SpecBlocks {
             );
         }
 
-        for specified_blocks in visitor.specs_for.values() {
+        for specified_blocks in base.specs_for.values() {
             for spec_block in specified_blocks {
-                // If this assertion ever fails, then consecutive spec blocks
-                // are actually consecutive blocks in the CFG. If this happens,
-                // we need to keep walking up the predecessors for each spec
-                // block until we find a non-spec block.
-                assert!(!visitor.spec_blocks.contains(&spec_block.attached_to));
-
                 let SpecBlockKind::LoopInvariant = spec_block.kind else {
                     continue;
                 };
@@ -244,11 +478,11 @@ impl SpecBlocks {
             .map(|spec| (spec.head_block, spec))
             .collect();
         Self {
-            specs_for: visitor.specs_for,
-            spec_blocks: visitor.spec_blocks,
+            specs_for: base.specs_for,
             loop_specs,
             loop_head_at,
-            ghost,
+            ghost: base.ghost,
+            spec_arms: base.spec_arms,
         }
     }
 }
@@ -258,6 +492,22 @@ struct SpecVisitor<'enc, 'vir: 'enc> {
     body: &'enc mir::Body<'vir>,
     specs_for: FxHashMap<BasicBlock, Vec<SpecBlock>>,
     spec_blocks: FxHashSet<BasicBlock>,
+    erased_blocks: Vec<BasicBlock>,
+}
+
+impl<'enc, 'vir: 'enc> SpecVisitor<'enc, 'vir> {
+    fn run(def_id: DefId, body: &'enc mir::Body<'vir>) -> Self {
+        use mir::visit::Visitor;
+        let mut visitor = Self {
+            def_id,
+            body,
+            specs_for: Default::default(),
+            spec_blocks: Default::default(),
+            erased_blocks: Default::default(),
+        };
+        visitor.visit_body(body);
+        visitor
+    }
 }
 
 impl<'enc, 'vir: 'enc> mir::visit::Visitor<'vir> for SpecVisitor<'enc, 'vir> {
@@ -274,8 +524,15 @@ impl<'enc, 'vir: 'enc> mir::visit::Visitor<'vir> for SpecVisitor<'enc, 'vir> {
             }
 
             let item_name = vcx.tcx().item_name(def_id);
-            if item_name.as_str() != "spec_block" {
-                return;
+            match item_name.as_str() {
+                "spec_block" => (),
+                // The runtime stand-in arm of a `ghost!` block; turned into
+                // [GhostBlocks] by the callers.
+                "ghost_erased" => {
+                    self.erased_blocks.push(location.block);
+                    return;
+                }
+                _ => return,
             }
 
             let (cl_def_id, _) =
@@ -307,6 +564,56 @@ impl<'enc, 'vir: 'enc> mir::visit::Visitor<'vir> for SpecVisitor<'enc, 'vir> {
                 });
             self.spec_blocks.insert(location.block);
         });
+    }
+}
+
+/// Collects the locals used by the *encoded* parts of the visited blocks:
+/// statements that encode to nothing keep no local alive, and neither do
+/// the (skipped) stores to the arms' scaffolding locals (see
+/// [SpecArms::scaffolding]).
+struct UsedLocals<'enc> {
+    arms: &'enc SpecArms,
+    unit_candidates: &'enc FxHashSet<mir::Local>,
+    used: FxHashSet<mir::Local>,
+}
+
+impl<'enc, 'vir> mir::visit::Visitor<'vir> for UsedLocals<'enc> {
+    fn visit_local(
+        &mut self,
+        local: mir::Local,
+        _context: mir::visit::PlaceContext,
+        _location: mir::Location,
+    ) {
+        self.used.insert(local);
+    }
+
+    fn visit_statement(&mut self, statement: &mir::Statement<'vir>, location: mir::Location) {
+        match &statement.kind {
+            // Not encoded (no-ops in the impure encoder).
+            mir::StatementKind::StorageLive(..)
+            | mir::StatementKind::StorageDead(..)
+            | mir::StatementKind::FakeRead(..)
+            | mir::StatementKind::PlaceMention(..)
+            | mir::StatementKind::AscribeUserType(..)
+            | mir::StatementKind::Coverage(..)
+            | mir::StatementKind::ConstEvalCounter
+            | mir::StatementKind::Nop
+            | mir::StatementKind::BackwardIncompatibleDropHint { .. } => {}
+            // Not encoded (stores to scaffolding locals and candidates).
+            mir::StatementKind::Assign(box (dest, _))
+                if dest.as_local().is_some_and(|local| {
+                    self.arms.scaffolding.contains(&local) || self.unit_candidates.contains(&local)
+                }) => {}
+            _ => self.super_statement(statement, location),
+        }
+    }
+
+    fn visit_terminator(&mut self, terminator: &mir::Terminator<'vir>, location: mir::Location) {
+        // A rewired switch is encoded as a bare goto: its discriminant
+        // operand is not used.
+        if !self.arms.switches.contains_key(&location.block) {
+            self.super_terminator(terminator, location);
+        }
     }
 }
 

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -1543,6 +1543,11 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             self.current_block_succs = None;
 
             for successor in body.basic_blocks.successors(block) {
+                // Specification-only arms are not encoded at all; their
+                // switches are encoded as jumps to the live target.
+                if self.spec_blocks.spec_arms.blocks.contains(&successor) {
+                    continue;
+                }
                 queue.push(WorkItem {
                     rpo_idx: rpo_idx[&successor],
                     seq: next_seq.next().unwrap(),
@@ -1561,16 +1566,14 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
         let enc_output = self.deps.require_dep::<MirPureEnc>(MirPureEncTask {
             encoding_depth: 0,
             parent_def_id: self.def_id,
-            param_env: self.vcx.tcx().param_env(self.def_id),
-            substs: ty::List::identity_for_item(self.vcx.tcx(), self.def_id),
+            gargs: GParams::from(self.def_id).identity_args(),
             kind: PureKind::SpecBlock(spec_block),
-            caller_def_id: Some(self.def_id),
         })?;
         use vir::Reify;
         let locals: FxHashMap<mir::Local, _> = enc_output
             .inputs
             .iter()
-            .map(|local| (*local, self.local_defs.locals[*local].impure_snap))
+            .map(|local| (*local, self.local_defs[*local].impure_snap))
             .collect();
         let expr = enc_output
             .expr
@@ -1604,19 +1607,12 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             return Ok(());
         }
 
-        // Blocks resulting from our embedding of loop invariants etc into the
-        // program should not be emitted. Loop invariants are handled separately
-        // at the loop head instead.
-        if self.spec_blocks.spec_blocks.contains(&block) {
-            self.encoded_blocks.push(
-                self.vcx.mk_cfg_block(
-                    current_block_label,
-                    &[],
-                    &[],
-                    self.vcx
-                        .mk_dummy_stmt(vir::vir_format!(self.vcx, "spec-only block")),
-                ),
-            );
+        // Specification-only arms are unreachable after their switches are
+        // encoded as jumps to the live target; emit nothing. The specs
+        // themselves are encoded separately (assertions at the block they
+        // are attached to, loop invariants at the loop head, closure specs
+        // as the closure's contract).
+        if self.spec_blocks.spec_arms.blocks.contains(&block) {
             return Ok(());
         }
 
@@ -1777,6 +1773,16 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             self.pcg_phase_actions(location, EvalStmtPhase::PostOperands)?;
             self.pcg_phase_actions(location, EvalStmtPhase::PreMain)?;
 
+            // Assignments to the hidden locals of specification-only arms
+            // (necessarily scaffolding stores) are not encoded, since the
+            // locals are not declared.
+            if let mir::StatementKind::Assign(box (dest, _)) = &statement.kind
+                && let Some(local) = dest.as_local()
+                && self.spec_blocks.spec_arms.hidden_locals.contains(&local)
+            {
+                return Ok(());
+            }
+
             let span = statement.source_info.span;
 
             match &statement.kind {
@@ -1878,18 +1884,18 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             self.pcg_phase_actions(location, phase)?;
         }
 
-        // A `ghost!` block's `if false` switch is encoded as an unconditional
-        // jump into the ghost arm (the inline ghost body); the runtime
-        // `ghost_erased` stand-in arm is skipped.
-        let ghost_goto = self
+        // A specification-only arm's `if false` switch is encoded as an
+        // unconditional jump to the live target (the continuation, or the
+        // inline ghost body); the arm itself is not encoded.
+        let spec_goto = self
             .spec_blocks
-            .ghost
+            .spec_arms
             .switches
             .get(&location.block)
-            .map(|ghost| mir::TerminatorKind::Goto {
-                target: ghost.arm_block,
+            .map(|live_target| mir::TerminatorKind::Goto {
+                target: *live_target,
             });
-        let terminator = match ghost_goto.as_ref().unwrap_or(&terminator.kind) {
+        let terminator = match spec_goto.as_ref().unwrap_or(&terminator.kind) {
             mir::TerminatorKind::Goto { target }
             | mir::TerminatorKind::FalseUnwind {
                 real_target: target,

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -1773,12 +1773,12 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
             self.pcg_phase_actions(location, EvalStmtPhase::PostOperands)?;
             self.pcg_phase_actions(location, EvalStmtPhase::PreMain)?;
 
-            // Assignments to the hidden locals of specification-only arms
+            // Assignments to the locals only serving specification-only arms
             // (necessarily scaffolding stores) are not encoded, since the
             // locals are not declared.
             if let mir::StatementKind::Assign(box (dest, _)) = &statement.kind
                 && let Some(local) = dest.as_local()
-                && self.spec_blocks.spec_arms.hidden_locals.contains(&local)
+                && self.spec_blocks.spec_arms.spec_only_locals.contains(&local)
             {
                 return Ok(());
             }

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -130,7 +130,7 @@ impl TaskEncoder for MirPureEnc {
                     let substs = vcx.tcx().mk_args(gargs.args());
                     vcx.body_mut().get_spec_body(def_id, substs, Some(context))
                 }
-                PureKind::Pure => vcx.body_mut().get_pure_fn_body(def_id, identity, None),
+                PureKind::Pure => crate::encoders::pure_body(def_id),
                 PureKind::Constant(promoted) => {
                     vcx.body_mut().get_promoted_constant_body(def_id, promoted)
                 }

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -5,13 +5,12 @@ use crate::encoders::{
     pure::spec::MirSpecEncMode,
     ty::{
         RustTyDecomposition,
-        generics::GParams,
+        generics::{GArgs, GParams},
         use_pure::{TyUsePure, TyUsePureEnc},
     },
 };
 use itertools::Itertools;
 use pcg::utils::Place;
-use prusti_interface::specs::typed::ExternSpecKind;
 use prusti_rustc_interface::{
     abi,
     data_structures::graph::{self, Successors},
@@ -55,22 +54,20 @@ pub struct MirPureEncOutput<'vir> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum PureKind {
     Closure,
-    /// The specification of a function. The mode records how the arguments are
-    /// supplied, which decides whether their snapshots are deep (see
-    /// `Enc::impure_context`).
-    Spec(Option<ExternSpecKind>, MirSpecEncMode),
+    /// A specification, attached to the item `context` specifies. That is
+    /// not the specified item itself when an `impl` refines the
+    /// specification of a trait: there the trait's parameters (notably
+    /// `Self`) become the implementing type, and the specification body is
+    /// instantiated accordingly.
+    Spec {
+        context: DefId,
+        /// How the arguments are supplied, which decides whether their
+        /// snapshots are deep (see `Enc::impure_context`).
+        mode: MirSpecEncMode,
+    },
     Pure,
     Constant(mir::Promoted),
     SpecBlock(mir::BasicBlock),
-}
-
-impl PureKind {
-    fn extern_spec(&self) -> Option<ExternSpecKind> {
-        match self {
-            PureKind::Spec(Some(kind), _) => Some(*kind),
-            _ => None,
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -79,10 +76,10 @@ pub struct MirPureEncTask<'vir> {
     //   can we integrate the lazy context into the identifier system?
     pub encoding_depth: usize,
     pub kind: PureKind,
-    pub parent_def_id: DefId,             // ID of the function
-    pub param_env: ty::ParamEnv<'vir>,    // param environment at the usage site
-    pub substs: ty::GenericArgsRef<'vir>, // type substitutions at the usage site
-    pub caller_def_id: Option<DefId>,     // ID of the caller function, if any
+    pub parent_def_id: DefId, // ID of the function
+    /// The generic arguments the body is encoded with, together with the
+    /// context whose parameters give them meaning.
+    pub gargs: GArgs<'vir>,
 }
 
 impl TaskEncoder for MirPureEnc {
@@ -92,11 +89,10 @@ impl TaskEncoder for MirPureEnc {
     type TaskDescription<'vir> = MirPureEncTask<'vir>;
 
     type TaskKey<'vir> = (
-        usize,                    // encoding depth
-        PureKind,                 // encoding a pure function?
-        DefId,                    // ID of the function
-        ty::GenericArgsRef<'vir>, // ? this should be the "signature", after applying the env/substs
-        Option<DefId>,            // Caller/Use DefID
+        usize,       // encoding depth
+        PureKind,    // encoding a pure function?
+        DefId,       // ID of the function
+        GArgs<'vir>, // the generic arguments and their context
     );
 
     type OutputFullDependency<'vir> = MirPureEncOutput<'vir>;
@@ -109,8 +105,7 @@ impl TaskEncoder for MirPureEnc {
             task.encoding_depth,
             task.kind,
             task.parent_def_id,
-            task.substs,
-            task.caller_def_id,
+            task.gargs,
         )
     }
 
@@ -120,27 +115,30 @@ impl TaskEncoder for MirPureEnc {
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(*task_key, ())?;
 
-        let (_, kind, def_id, substs, caller_def_id) = *task_key;
+        let (_, kind, def_id, gargs) = *task_key;
 
         tracing::debug!("encoding {def_id:?}");
         let (inputs, expr) = vir::with_vcx(move |vcx| {
+            // The bodies are encoded generically, so they are fetched at the
+            // compiler's identity arguments. The one exception is a trait's
+            // specification encoded for an `impl` of that trait, which is
+            // instantiated with the arguments of the encoding.
+            let identity = ty::GenericArgs::identity_for_item(vcx.tcx(), def_id);
             let body = match kind {
-                PureKind::Closure => vcx
-                    .body_mut()
-                    .get_closure_body(def_id, substs, caller_def_id),
-                PureKind::Spec(..) => vcx.body_mut().get_spec_body(def_id, substs, caller_def_id),
-                PureKind::Pure => vcx
-                    .body_mut()
-                    .get_pure_fn_body(def_id, substs, caller_def_id),
+                PureKind::Closure => vcx.body_mut().get_closure_body(def_id, identity, None),
+                PureKind::Spec { context, .. } => {
+                    let substs = vcx.tcx().mk_args(gargs.args());
+                    vcx.body_mut().get_spec_body(def_id, substs, Some(context))
+                }
+                PureKind::Pure => vcx.body_mut().get_pure_fn_body(def_id, identity, None),
                 PureKind::Constant(promoted) => {
                     vcx.body_mut().get_promoted_constant_body(def_id, promoted)
                 }
-                PureKind::SpecBlock(_) => vcx
-                    .body_mut()
-                    .get_impure_fn_body_identity(def_id.expect_local()),
+                PureKind::SpecBlock(_) => crate::encoders::impure_body(def_id)
+                    .unwrap_or_else(|| panic!("no body to encode for {def_id:?}")),
             };
 
-            let mut enc = Enc::new(vcx, task_key.0, def_id, caller_def_id, kind, &body, deps);
+            let mut enc = Enc::new(vcx, task_key.0, def_id, kind, gargs, &body, deps);
             let expr_inner = if let PureKind::SpecBlock(block) = kind {
                 enc.encode_spec_block(block)?
             } else {
@@ -347,8 +345,8 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         vcx: &'vir vir::VirCtxt<'vir>,
         encoding_depth: usize,
         def_id: DefId,
-        caller_def_id: Option<DefId>,
         kind: PureKind,
+        gargs: GArgs<'vir>,
         body: &'enc mir::Body<'vir>,
         deps: &'enc mut TaskEncoderDependencies<'vir, MirPureEnc>,
     ) -> Self {
@@ -357,7 +355,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
             vcx,
             encoding_depth,
             def_id,
-            context: GParams::new_maybe_extern(caller_def_id.unwrap_or(def_id), kind.extern_spec()),
+            context: gargs.context(),
             body,
             rev_doms,
             ghost: GhostBlocks::new(def_id, body),
@@ -372,7 +370,13 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
             before_expiry_mode: false,
             // Only an impure method's pre/post gets shallow argument
             // snapshots; a pure function's spec is handed deep ones.
-            impure_context: matches!(kind, PureKind::Spec(_, MirSpecEncMode::Impure)),
+            impure_context: matches!(
+                kind,
+                PureKind::Spec {
+                    mode: MirSpecEncMode::Impure,
+                    ..
+                }
+            ),
         }
     }
 
@@ -1282,9 +1286,7 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
                 encoding_depth: self.encoding_depth + 1,
                 kind: PureKind::Closure,
                 parent_def_id: cl_def_id,
-                param_env: self.vcx.tcx().param_env(cl_def_id),
-                substs: ty::List::identity_for_item(self.vcx.tcx(), cl_def_id),
-                caller_def_id: Some(self.def_id),
+                gargs: GParams::from(cl_def_id).identity_args(),
             })?
             .expr
             .reify(self.vcx, (cl_def_id, self.vcx.alloc(reify_args)))

--- a/prusti-encoder/src/encoders/mod.rs
+++ b/prusti-encoder/src/encoders/mod.rs
@@ -1,3 +1,4 @@
+mod body;
 mod builtin;
 mod mir_pure;
 mod mir_impure;
@@ -14,6 +15,7 @@ pub mod mir_fn;
 pub mod custom;
 pub mod addr;
 
+pub use body::{encodes_body, impure_body, impure_body_with_facts, spec_body};
 pub use builtin::{
     MetadataCastAxiomEnc, MetadataCastEnc, MirBuiltinBinOpEnc, MirBuiltinBinOpTask,
     MirBuiltinUnOpEnc, MirBuiltinUnOpTask, MirBuiltinUseCastEnc, MirBuiltinUseCastTask, Mode,

--- a/prusti-encoder/src/encoders/mod.rs
+++ b/prusti-encoder/src/encoders/mod.rs
@@ -15,7 +15,7 @@ pub mod mir_fn;
 pub mod custom;
 pub mod addr;
 
-pub use body::{encodes_body, impure_body, impure_body_with_facts, spec_body};
+pub use body::{encodes_body, impure_body, impure_body_with_facts, pure_body, spec_body};
 pub use builtin::{
     MetadataCastAxiomEnc, MetadataCastEnc, MirBuiltinBinOpEnc, MirBuiltinBinOpTask,
     MirBuiltinUnOpEnc, MirBuiltinUnOpTask, MirBuiltinUseCastEnc, MirBuiltinUseCastTask, Mode,

--- a/prusti-encoder/src/encoders/pure/spec.rs
+++ b/prusti-encoder/src/encoders/pure/spec.rs
@@ -19,7 +19,7 @@ use vir::{CastType, HasType, Reify};
 use crate::encoders::{
     MirLocalDefEncTask, MirPureEnc,
     mir_pure::{ExprInput, MirPureEncOutput, PureKind},
-    ty::generics::GParams,
+    ty::generics::{GArgs, GParams},
 };
 pub struct MirSpecEnc;
 
@@ -330,12 +330,15 @@ impl MirSpecEnc {
         let span = vcx.tcx().def_span(def_id);
         let spec = deps.require_dep::<MirPureEnc>(crate::encoders::MirPureEncTask {
             encoding_depth: 0,
-            kind: PureKind::Spec(ctx.extern_spec, ctx.enc_mode),
+            kind: PureKind::Spec {
+                context: ctx.context_def_id,
+                mode: ctx.enc_mode,
+            },
             parent_def_id: def_id,
-            param_env: vcx.tcx().param_env(def_id),
-            substs: ctx.substs,
-            // TODO: should this be `def_id` or `caller_def_id`
-            caller_def_id: Some(ctx.context_def_id),
+            gargs: GArgs::new(
+                GParams::new_maybe_extern(ctx.context_def_id, ctx.extern_spec),
+                ctx.substs,
+            ),
         });
         spec.inspect_err(|err| {
             vcx.emit_early_error(PrustiError::unsupported(

--- a/prusti-encoder/src/encoders/ty/generics/params.rs
+++ b/prusti-encoder/src/encoders/ty/generics/params.rs
@@ -16,6 +16,20 @@ use crate::encoders::{
     },
 };
 
+/// The identity arguments of `def_id`, i.e. its own generic parameters.
+///
+/// For a closure this is *not* `identity_for_item`: the compiler gives every
+/// closure three synthetic parameters (for its kind, signature and captures)
+/// which are junk parameter defs rather than parameters the closure is
+/// generic over. The parameters of a closure are those of its parent.
+pub fn identity_params<'tcx>(tcx: ty::TyCtxt<'tcx>, def_id: DefId) -> ty::GenericArgsRef<'tcx> {
+    let params = ty::GenericArgs::identity_for_item(tcx, def_id);
+    if !tcx.is_closure_like(def_id) {
+        return params;
+    }
+    tcx.mk_args(&params[..tcx.generics_of(def_id).parent_count])
+}
+
 /// The list of defined parameters in a given context. E.g. the type parameters
 /// `T` and `U` in the body of the function `fn foo<T, U>(t: T) -> U { ... }`
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -50,7 +64,7 @@ impl<'tcx> GParams<'tcx> {
     /// `Prusti_T_Self` parameter with the `Self` that the actual trait has.
     pub fn new_maybe_extern(def_id: DefId, kind: Option<ExternSpecKind>) -> Self {
         vir::with_vcx(|vcx| {
-            let params = ty::GenericArgs::identity_for_item(vcx.tcx(), def_id);
+            let params = identity_params(vcx.tcx(), def_id);
             let env = vcx.tcx().param_env(def_id);
             let is_trait_extern_spec = matches!(kind, Some(ExternSpecKind::Trait));
             Self::new(params, env, is_trait_extern_spec)
@@ -192,6 +206,12 @@ impl<'tcx> GParams<'tcx> {
 
     pub fn rust_params(self) -> ty::GenericArgsRef<'tcx> {
         self.params
+    }
+
+    /// The identity arguments in this context, i.e. the parameters
+    /// themselves. Use when encoding an item generically.
+    pub fn identity_args(self) -> GArgs<'tcx> {
+        GArgs::new(self, self.rust_params())
     }
 
     pub fn typing_env(self) -> ty::TypingEnv<'tcx> {

--- a/prusti-interface/src/environment/query.rs
+++ b/prusti-interface/src/environment/query.rs
@@ -3,21 +3,19 @@ use std::fmt::Debug;
 use crate::data::ProcedureDefId;
 use log::debug;
 use prusti_rustc_interface::{
-    data_structures::fx::FxIndexSet,
     hir::{hir_id::HirId, Attribute},
-    infer::infer::{outlives::env::OutlivesEnvironment, InferCtxt},
+    infer::infer::InferCtxt,
     middle::ty::{
         self, GenericArgsRef, ParamEnv, PredicatePolarity, TraitPredicate, TyCtxt, TypeVisitableExt,
     },
     span::{
-        def_id::{DefId, LocalDefId, CRATE_DEF_ID},
+        def_id::{DefId, LocalDefId},
         source_map::SourceMap,
         Span,
     },
     trait_selection::{
         infer::{InferCtxtExt, TyCtxtInferExt},
         traits::{
-            outlives_bounds::InferCtxtExt as BoundsInferCtxtExt,
             query::evaluate_obligation::InferCtxtExt as QueryInferCtxtExt, ImplSource, Obligation,
             ObligationCause, SelectionContext,
         },
@@ -175,40 +173,6 @@ impl<'tcx> EnvQuery<'tcx> {
         let def_id = def_id.into_param();
         let sig = self.get_fn_sig(def_id, substs);
         self.resolve_assoc_types(sig, caller_def_id.into_param())
-    }
-
-    pub fn get_liberated_fn_sig(
-        self,
-        def_id: impl IntoParam<ProcedureDefId>,
-        substs: GenericArgsRef<'tcx>,
-    ) -> ty::FnSig<'tcx> {
-        let def_id = def_id.into_param();
-        let sig = self.get_fn_sig(def_id, substs);
-        self.tcx.liberate_late_bound_regions(def_id, sig)
-    }
-
-    pub fn assumed_wf_types(
-        self,
-        def_id: impl IntoParam<ProcedureDefId>,
-    ) -> FxIndexSet<ty::Ty<'tcx>> {
-        let def_id = def_id.into_param();
-        let liberated_sig = self.get_liberated_fn_sig(def_id, self.identity_substs(def_id));
-        // TODO: same as `ObligationCtxt::assumed_wf_types` but skips `deeply_normalize` step, is that fine?
-        liberated_sig
-            .inputs_and_output
-            .iter()
-            .collect::<FxIndexSet<_>>()
-    }
-
-    pub fn outlives_env(self, def_id: impl IntoParam<ProcedureDefId>) -> OutlivesEnvironment<'tcx> {
-        let def_id = def_id.into_param();
-        let wf_tys = self.assumed_wf_types(def_id);
-
-        let infcx = self.infer_ctxt();
-        let param_env = self.tcx.param_env(def_id);
-        // TODO: what value to use for `disable_implied_bounds_hack`?
-        let ib = infcx.implied_bounds_tys(CRATE_DEF_ID, param_env, wf_tys, true);
-        OutlivesEnvironment::from_normalized_bounds(param_env, vec![], ib, Default::default())
     }
 
     /// Returns true iff `def_id` is a closure.

--- a/prusti-interface/src/specs/mod.rs
+++ b/prusti-interface/src/specs/mod.rs
@@ -459,6 +459,25 @@ pub fn is_spec_fn(tcx: ty::TyCtxt, def_id: DefId) -> bool {
     read_prusti_attr("spec_id", attrs).is_some()
 }
 
+/// Returns true iff def_id points to a specification-only item: a spec
+/// function or closure (marked `spec_only` or carrying a `spec_id`, e.g.
+/// the spec closures of `closure!` and the checker closure of `ghost!`),
+/// or a closure nested inside one (e.g. a closure used within a
+/// specification expression).
+pub fn is_spec_item(tcx: ty::TyCtxt, def_id: DefId) -> bool {
+    let mut def_id = def_id;
+    loop {
+        let attrs = tcx.get_all_attrs(def_id);
+        if has_prusti_attr(attrs, "spec_only") || read_prusti_attr("spec_id", attrs).is_some() {
+            return true;
+        }
+        if !tcx.is_closure_like(def_id) {
+            return false;
+        }
+        def_id = tcx.parent(def_id);
+    }
+}
+
 #[tracing::instrument(level = "trace")]
 fn get_procedure_spec_ids(def_id: DefId, attrs: &[hir::Attribute]) -> Option<ProcedureSpecRefs> {
     let mut spec_id_refs = vec![];


### PR DESCRIPTION
Closure bodies are now encoded like any other local function body rather than skipped: `encode_all_in_crate` handles `DefKind::Closure` in the same arm as `Fn`/`AssocFn`, skipping only specification items (`is_spec_item`, which also covers closures nested inside a specification) and the closures of trusted functions. `GParams::identity_params` makes a closure's generic parameters those of its parent, rather than the three synthetic parameter defs the compiler gives every closure, which would otherwise show up as generic parameters of the encoded Viper method.

Body retrieval moves behind `encoders::body`: `encodes_body` is the single definition of "is there a body to encode", previously spelled out separately in `should_encode_locals`, `MethodEnc` and `FunctionEnc`, and `impure_body`/`impure_body_with_facts` derive the remaining arguments from the `DefId` they are given. The impure body is no longer monomorphised: the encoding is generic and the substitutions are the identity everywhere except a trait's specification encoded for an `impl`, so the local-def and spec-block encoders now share the region-preserving body the PCG walks.

The specification-only `if false` arms of `prusti_assert!` and friends, and the stand-in arms of `ghost!`, are invisible in the Viper output: their switches are encoded as jumps to the live target, the arms are never emitted, and the locals that only serve them are neither declared nor assigned. `SpecBlocksEnc` memoises that analysis per body.

`MirPureEncTask` loses `param_env`, which was never read, and `caller_def_id`, which only ever mattered for specifications and now lives in `PureKind::Spec`. Its `substs` become `GArgs`, pairing the arguments with the context that gives them meaning.

Also adds the missing `terminates` case to `SpecAttributeKind::try_from`, so the attribute is recognised in inner position as well.