### PR TITLE
Fix error positions of shared encodings and improve macro-call errors

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,3 @@
 imports_granularity = "Crate"
 reorder_modules = false
+error_on_unformatted = true

--- a/prusti-encoder/src/encoders/builtin/prusti.rs
+++ b/prusti-encoder/src/encoders/builtin/prusti.rs
@@ -443,6 +443,27 @@ impl TaskEncoder for PrustiBuiltinEnc {
         deps: &mut TaskEncoderDependencies<'vir, Self>,
     ) -> EncodeFullResult<'vir, Self> {
         deps.emit_output_ref(*task_key, ())?;
+        // The span of a checked operation is part of the key, so this
+        // encoding belongs to (and is reachable from) that call statement.
+        vir::with_vcx(|vcx| match task_key.span {
+            Some(span) => vcx.with_span(span, |vcx| Self::encode(task_key, deps, vcx)),
+            None => Self::encode(task_key, deps, vcx),
+        })
+    }
+
+    fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
+        CollectionOpsEnc::emit_outputs(program);
+    }
+}
+
+impl PrustiBuiltinEnc {
+    /// Encodes the operation of `task_key`, with its span (if it is a
+    /// checked operation) on the span stack.
+    fn encode<'vir>(
+        task_key: &PrustiBuiltinTask<'vir>,
+        deps: &mut TaskEncoderDependencies<'vir, Self>,
+        vcx: &'vir vir::VirCtxt<'vir>,
+    ) -> EncodeFullResult<'vir, Self> {
         let PrustiBuiltinTask {
             builtin,
             def_id,
@@ -451,85 +472,79 @@ impl TaskEncoder for PrustiBuiltinEnc {
             span,
         } = *task_key;
         assert_eq!(is_pure, span.is_none());
-        vir::with_vcx(|vcx| {
-            let tcx = vcx.tcx();
-            let sig = tcx
-                .fn_sig(def_id)
-                .instantiate(tcx, args.args())
-                .skip_binder();
+        let tcx = vcx.tcx();
+        let sig = tcx
+            .fn_sig(def_id)
+            .instantiate(tcx, args.args())
+            .skip_binder();
 
-            // One hole per operand, typed with the operand's snapshot type.
-            let operands = (0..sig.inputs().len())
-                .map(|i| {
-                    let ty = RustTyDecomposition::from_ty(sig.inputs()[i], args.context());
-                    let snap_ty = deps.require_ref::<TyUsePureEnc>(ty)?.snapshot;
-                    Ok(vcx.mk_lazy_expr(
-                        vir::vir_format!(vcx, "prusti_builtin_operand_{i}"),
-                        snap_ty,
-                        Box::new(move |_vcx, lctx: PrustiBuiltinOperands<'vir>| {
-                            assert_eq!(lctx.len(), sig.inputs().len());
-                            lctx[i].kind
-                        }),
-                    ))
-                })
-                .collect::<EncResult<'vir, Vec<ExprRet<'vir, vir::Snap>>>>()?;
-            let operands = &operands;
+        // One hole per operand, typed with the operand's snapshot type.
+        let operands = (0..sig.inputs().len())
+            .map(|i| {
+                let ty = RustTyDecomposition::from_ty(sig.inputs()[i], args.context());
+                let snap_ty = deps.require_ref::<TyUsePureEnc>(ty)?.snapshot;
+                Ok(vcx.mk_lazy_expr(
+                    vir::vir_format!(vcx, "prusti_builtin_operand_{i}"),
+                    snap_ty,
+                    Box::new(move |_vcx, lctx: PrustiBuiltinOperands<'vir>| {
+                        assert_eq!(lctx.len(), sig.inputs().len());
+                        lctx[i].kind
+                    }),
+                ))
+            })
+            .collect::<EncResult<'vir, Vec<ExprRet<'vir, vir::Snap>>>>()?;
+        let operands = &operands;
 
-            let mut ctxt = BuiltinCtxt {
-                vcx,
-                deps,
-                sig,
-                args,
-                operands,
-                span,
-            };
-            let res: ExprRet<'vir, vir::Snap> = match builtin {
-                PrustiBuiltin::Spec(_) => {
-                    unreachable!("pure-only builtin in `PrustiBuiltinEnc`: {builtin:?}")
+        let mut ctxt = BuiltinCtxt {
+            vcx,
+            deps,
+            sig,
+            args,
+            operands,
+            span,
+        };
+        let res: ExprRet<'vir, vir::Snap> = match builtin {
+            PrustiBuiltin::Spec(_) => {
+                unreachable!("pure-only builtin in `PrustiBuiltinEnc`: {builtin:?}")
+            }
+            PrustiBuiltin::Ghost(op) => ctxt.encode_ghost(op)?,
+            PrustiBuiltin::SnapEq | PrustiBuiltin::SnapNe => {
+                let bin_op = match builtin {
+                    PrustiBuiltin::SnapEq => vir::BinOpKind::CmpEq,
+                    PrustiBuiltin::SnapNe => vir::BinOpKind::CmpNe,
+                    _ => unreachable!(),
+                };
+                let (lhs, rhs) = ctxt.deref_operands::<vir::Snap>()?;
+                ctxt.native_cmp(bin_op, lhs, rhs).upcast_ty()
+            }
+            PrustiBuiltin::SnapClone => ctxt.deref_operand(0)?,
+            PrustiBuiltin::Seq(op) => ctxt.encode_seq(op)?,
+            PrustiBuiltin::AnySet { multiset, op } => ctxt.encode_any_set(multiset, op)?,
+            PrustiBuiltin::Map(op) => ctxt.encode_map(op)?,
+            // `From` differs structurally between the numeric types; the
+            // shared operations are handled by `encode_num`.
+            PrustiBuiltin::Int(NumOp::From) => {
+                let prim = *ctxt.e_input(0)?.expect_primitive();
+                let val = prim.snap_to_prim(ctxt.operands[0].downcast_ty());
+                val.downcast_ty::<vir::Int>().upcast_ty()
+            }
+            PrustiBuiltin::Int(op) => ctxt.encode_num::<vir::Int>(op, false)?,
+            PrustiBuiltin::Real(NumOp::From) => {
+                let fp_to_real = ctxt.e_input(0)?.expect_float().fp_to_real;
+                fp_to_real.call()(ctxt.operands[0].downcast_ty()).upcast_ty()
+            }
+            PrustiBuiltin::Real(op) => ctxt.encode_num::<vir::Perm>(op, true)?,
+            PrustiBuiltin::Float(op, fl) => {
+                let domain = ctxt.float_domain(fl)?;
+                let operand = ctxt.operands[0].downcast_ty();
+                match op {
+                    FloatOp::IsNan => domain.fp_is_nan.call()(operand).upcast_ty(),
+                    FloatOp::IsInfinite => domain.fp_is_infinite.call()(operand).upcast_ty(),
+                    FloatOp::Abs => domain.fp_abs.call()(operand).upcast_ty(),
                 }
-                PrustiBuiltin::Ghost(op) => ctxt.encode_ghost(op)?,
-                PrustiBuiltin::SnapEq | PrustiBuiltin::SnapNe => {
-                    let bin_op = match builtin {
-                        PrustiBuiltin::SnapEq => vir::BinOpKind::CmpEq,
-                        PrustiBuiltin::SnapNe => vir::BinOpKind::CmpNe,
-                        _ => unreachable!(),
-                    };
-                    let (lhs, rhs) = ctxt.deref_operands::<vir::Snap>()?;
-                    ctxt.native_cmp(bin_op, lhs, rhs).upcast_ty()
-                }
-                PrustiBuiltin::SnapClone => ctxt.deref_operand(0)?,
-                PrustiBuiltin::Seq(op) => ctxt.encode_seq(op)?,
-                PrustiBuiltin::AnySet { multiset, op } => ctxt.encode_any_set(multiset, op)?,
-                PrustiBuiltin::Map(op) => ctxt.encode_map(op)?,
-                // `From` differs structurally between the numeric types; the
-                // shared operations are handled by `encode_num`.
-                PrustiBuiltin::Int(NumOp::From) => {
-                    let prim = *ctxt.e_input(0)?.expect_primitive();
-                    let val = prim.snap_to_prim(ctxt.operands[0].downcast_ty());
-                    val.downcast_ty::<vir::Int>().upcast_ty()
-                }
-                PrustiBuiltin::Int(op) => ctxt.encode_num::<vir::Int>(op, false)?,
-                PrustiBuiltin::Real(NumOp::From) => {
-                    let fp_to_real = ctxt.e_input(0)?.expect_float().fp_to_real;
-                    fp_to_real.call()(ctxt.operands[0].downcast_ty()).upcast_ty()
-                }
-                PrustiBuiltin::Real(op) => ctxt.encode_num::<vir::Perm>(op, true)?,
-                PrustiBuiltin::Float(op, fl) => {
-                    let domain = ctxt.float_domain(fl)?;
-                    let operand = ctxt.operands[0].downcast_ty();
-                    match op {
-                        FloatOp::IsNan => domain.fp_is_nan.call()(operand).upcast_ty(),
-                        FloatOp::IsInfinite => domain.fp_is_infinite.call()(operand).upcast_ty(),
-                        FloatOp::Abs => domain.fp_abs.call()(operand).upcast_ty(),
-                    }
-                }
-            };
-            Ok(((), PrustiBuiltinExpr(res)))
-        })
-    }
-
-    fn emit_outputs<'vir>(program: &mut task_encoder::Program<'vir>) {
-        CollectionOpsEnc::emit_outputs(program);
+            }
+        };
+        Ok(((), PrustiBuiltinExpr(res)))
     }
 }
 
@@ -1045,8 +1060,8 @@ impl<'enc, 'vir> BuiltinCtxt<'enc, 'vir> {
 
     /// Registers a backtranslation handler for the well-definedness
     /// obligation of a checked (impure-code) partial collection operation.
-    /// The handler attaches to the caller's current span - the call
-    /// statement, where Viper anchors these error positions.
+    /// The handler attaches to this encoding's span - the call statement,
+    /// which is part of the task key.
     fn handle_partial_op_error(&self, error_kind: &'static str, message: &'static str, span: Span) {
         self.vcx.handle_error(error_kind, move |_| {
             Some(vec![PrustiError::verification(message, span.into())])

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -1905,10 +1905,10 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 real_target: target,
                 ..
             }
-            // A `Drop`'s semantics (releasing the dropped place's permission
-            // via a weaken exhale) are carried by the PCG statements, so only
-            // its goto remains to be encoded here.
             | mir::TerminatorKind::Drop { target, .. } => {
+                // A `Drop`'s semantics (releasing the dropped place's
+                // permission via a weaken exhale) are carried by the PCG
+                // statements, so only its goto remains to be encoded here.
                 self.pcs_succ_to(*target)?;
                 let set_flag = self.set_from_to_flag(location.block, *target);
                 self.stmt(set_flag);
@@ -1943,8 +1943,11 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                     self.collect_pcs_succ_at(otherwise_succ_idx, targets.otherwise())?;
                 otherwise_stmts.push(self.set_from_to_flag(location.block, targets.otherwise()));
 
-                let discr_ex = discr_ty
-                    .snap_to_prim(self.encode_operand_snap(discr, &None).unwrap().downcast_ty());
+                let discr_ex = discr_ty.snap_to_prim(
+                    self.encode_operand_snap(discr, &None)
+                        .unwrap()
+                        .downcast_ty(),
+                );
                 self.vcx.mk_goto_if_stmt(
                     discr_ex.as_dyn(), // self.vcx.mk_local_ex(discr_name),
                     goto_targets,
@@ -1988,6 +1991,21 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                 );
 
                 let (func_def_id, caller_substs, is_pure) = self.get_call_data(func);
+                // A call whose span comes from a macro expansion (e.g. the
+                // `core::panicking::panic` call inside a failing `assert!`)
+                // was not written by the user, so reporting "precondition
+                // might not hold" at the expanded fragment is confusing: no
+                // visible call exists there. Report at the macro invocation
+                // that produced the call, naming the actually-called function.
+                let verification_error = if span.from_expansion() {
+                    let name = self.vcx.tcx().def_path_str(func_def_id);
+                    let message = format!(
+                        "precondition of `{name}` (called by this macro expansion) might not hold"
+                    );
+                    PrustiError::verification(message, span.source_callsite().into())
+                } else {
+                    PrustiError::verification("precondition might not hold", span.into())
+                };
 
                 let dest = self
                     .encode_place(Place::from(*destination))
@@ -2006,10 +2024,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                             vcx.handle_error(
                                 "application.precondition:assertion.false",
                                 move |reason_span_opt| {
-                                    let mut error = PrustiError::verification(
-                                        "precondition might not hold",
-                                        span.into(),
-                                    );
+                                    let mut error = verification_error.clone();
                                     if let Some(reason_span) = reason_span_opt {
                                         error.add_note_mut(
                                             "the failing precondition is here",
@@ -2043,10 +2058,7 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                         vcx.handle_error(
                             "call.precondition:assertion.false",
                             move |reason_span_opt| {
-                                let mut error = PrustiError::verification(
-                                    "precondition might not hold",
-                                    span.into(),
-                                );
+                                let mut error = verification_error.clone();
                                 if let Some(reason_span) = reason_span_opt {
                                     error.add_note_mut(
                                         "the failing precondition is here",

--- a/prusti-encoder/src/encoders/mir_pure.rs
+++ b/prusti-encoder/src/encoders/mir_pure.rs
@@ -138,12 +138,26 @@ impl TaskEncoder for MirPureEnc {
                     .unwrap_or_else(|| panic!("no body to encode for {def_id:?}")),
             };
 
-            let mut enc = Enc::new(vcx, task_key.0, def_id, kind, gargs, &body, deps);
-            let expr_inner = if let PureKind::SpecBlock(block) = kind {
-                enc.encode_spec_block(block)?
+            // Encode under the body's span: expression nodes pick up the
+            // ambient span at creation, so everything in a pure/spec body
+            // defaults to the body's source (e.g. the spec attribute for a
+            // spec closure), refined per statement in `encode_stmt`. This is
+            // what error positions inside the body backtranslate to. The MIR
+            // span of a body deserialized from another crate is dummy; the
+            // definition's span survives in the crate metadata.
+            let body_span = if body.span.is_dummy() {
+                vcx.tcx().def_span(def_id)
             } else {
-                enc.encode_body()?
+                body.span
             };
+            let mut enc = Enc::new(vcx, task_key.0, def_id, kind, gargs, &body, deps);
+            let expr_inner = vcx.with_span(body_span, |_| {
+                if let PureKind::SpecBlock(block) = kind {
+                    enc.encode_spec_block(block)
+                } else {
+                    enc.encode_body()
+                }
+            })?;
             let inputs = std::mem::take(&mut enc.versions_used)
                 .into_iter()
                 .filter(|(l, v)| *l != mir::RETURN_PLACE && *v == 0)
@@ -162,23 +176,30 @@ impl TaskEncoder for MirPureEnc {
                 let ret = RustTyDecomposition::from_ty(body.return_ty(), enc.context);
                 deps.require_ref::<TyUsePureEnc>(ret)?.snapshot
             };
-            let expr = vcx.mk_lazy_expr(
-                vir::vir_format!(vcx, "pure body {def_id:?}"),
-                snapshot,
-                Box::new(move |vcx, lctx: ExprInput<'_>| {
-                    // check: are we actually providing inputs for the
-                    //   correct `DefId`?
-                    assert_eq!(lctx.0, def_id);
+            // Created under the body's span: this wrapper is the node whose
+            // span survives reification as the top of the expression (`span`
+            // is passed through by `reify`), so it is what error positions
+            // pointing at the whole body (e.g. a failing precondition
+            // conjunct) backtranslate to.
+            let expr = vcx.with_span(body_span, |vcx| {
+                vcx.mk_lazy_expr(
+                    vir::vir_format!(vcx, "pure body {def_id:?}"),
+                    snapshot,
+                    Box::new(move |vcx, lctx: ExprInput<'_>| {
+                        // check: are we actually providing inputs for the
+                        //   correct `DefId`?
+                        assert_eq!(lctx.0, def_id);
 
-                    // check: are we providing the expected number of inputs?
-                    // TODO: check that the expected inputs are present; this
-                    //   check is not precise
-                    assert!(lctx.1.len() >= inputs_expected);
+                        // check: are we providing the expected number of inputs?
+                        // TODO: check that the expected inputs are present; this
+                        //   check is not precise
+                        assert!(lctx.1.len() >= inputs_expected);
 
-                    use vir::Reify;
-                    expr_inner.kind.reify(vcx, lctx)
-                }),
-            );
+                        use vir::Reify;
+                        expr_inner.kind.reify(vcx, lctx)
+                    }),
+                )
+            });
             add_debug_note!(expr.debug_info, "Inner expr: {}", expr_inner.debug_info);
             Ok((inputs, expr))
         })?;
@@ -934,25 +955,31 @@ impl<'vir: 'enc, 'enc> Enc<'vir, 'enc> {
         stmt: &mir::Statement<'vir>,
         location: mir::Location,
     ) -> Result<Update<'vir>, EncodeFullError<'vir, MirPureEnc>> {
-        let mut update = Update::new();
-        match &stmt.kind {
-            &mir::StatementKind::StorageLive(local) => {
-                let new_version = self.bump_version_no_assign(local, location);
-                update.versions.insert(local, new_version);
+        // Encoded under the statement's span: expressions pick up the ambient
+        // span at creation, which makes error positions inside pure/spec
+        // bodies point at the originating source (e.g. the failing conjunct
+        // of a spec).
+        self.vcx.with_span(stmt.source_info.span, |_| {
+            let mut update = Update::new();
+            match &stmt.kind {
+                &mir::StatementKind::StorageLive(local) => {
+                    let new_version = self.bump_version_no_assign(local, location);
+                    update.versions.insert(local, new_version);
+                }
+                mir::StatementKind::StorageDead(..)
+                | mir::StatementKind::FakeRead(..)
+                | mir::StatementKind::AscribeUserType(..)
+                | mir::StatementKind::PlaceMention(..) => {} // nop
+                mir::StatementKind::Assign(box (dest, rvalue)) => {
+                    //assert!(dest.projection.is_empty());
+                    let span = stmt.source_info.span;
+                    let expr = self.encode_rvalue(curr_ver, rvalue, span)?;
+                    self.bump_version(&mut update, dest.local, expr, location);
+                }
+                k => todo!("statement kind {k:?}"),
             }
-            mir::StatementKind::StorageDead(..)
-            | mir::StatementKind::FakeRead(..)
-            | mir::StatementKind::AscribeUserType(..)
-            | mir::StatementKind::PlaceMention(..) => {} // nop
-            mir::StatementKind::Assign(box (dest, rvalue)) => {
-                //assert!(dest.projection.is_empty());
-                let span = stmt.source_info.span;
-                let expr = self.encode_rvalue(curr_ver, rvalue, span)?;
-                self.bump_version(&mut update, dest.local, expr, location);
-            }
-            k => todo!("statement kind {k:?}"),
-        }
-        Ok(update)
+            Ok(update)
+        })
     }
 
     fn encode_rvalue(

--- a/prusti-encoder/src/encoders/pure/spec.rs
+++ b/prusti-encoder/src/encoders/pure/spec.rs
@@ -227,9 +227,12 @@ impl TaskEncoder for MirSpecEnc {
                 .filter_map(|spec_def_id| {
                     let spec = Self::encode_pure(vcx, deps, ctx, *spec_def_id, "precondition")?;
                     let expr = spec.expr.downcast_ty::<vir::Bool>();
-                    let expr = expr.reify(vcx, (*spec_def_id, pre_args));
                     let span = vcx.tcx().def_span(*spec_def_id);
-                    Some((vcx.with_span(span, |_| expr), span))
+                    // Reify *inside* the span scope: the nodes created by the
+                    // reification pick up the ambient span, which makes error
+                    // positions inside this precondition point at the spec.
+                    let expr = vcx.with_span(span, |vcx| expr.reify(vcx, (*spec_def_id, pre_args)));
+                    Some((expr, span))
                 })
                 .collect();
 

--- a/scripts/helper_functions.py
+++ b/scripts/helper_functions.py
@@ -164,7 +164,8 @@ def get_var_or(name, default):
         return default
 
 
-def run_command(args, env=None, cwd=None, on_exit=None, report_time=False):
+def run_command(args, env=None, cwd=None, on_exit=None, report_time=False,
+                capture_output=False):
     """Run a command with the given arguments.
 
     +   ``env`` – an environment in which to run.
@@ -172,17 +173,25 @@ def run_command(args, env=None, cwd=None, on_exit=None, report_time=False):
     +   ``on_exit`` – function to be executed on exit.
     +   ``report_time`` – whether to report how long it took to execute
         the command.
+    +   ``capture_output`` – whether to capture the output of the command
+        instead of letting it through to the terminal. The caller gets it
+        as bytes from the returned `CompletedProcess`.
     """
     if env is None:
         env = get_env()
     start_time = datetime.datetime.now()
-    completed = subprocess.run(args, env=env, cwd=cwd, shell=(os.name == 'nt'))
+    completed = subprocess.run(args, env=env, cwd=cwd, shell=(os.name == 'nt'),
+                               capture_output=capture_output)
     if report_time:
         print(datetime.datetime.now() - start_time)
     if on_exit is not None:
         on_exit()
     if completed.returncode != 0:
+        if capture_output:
+            sys.stdout.write(completed.stdout.decode())
+            sys.stderr.write(completed.stderr.decode())
         sys.exit(completed.returncode)
+    return completed
 
 
 def extract_test_compile_flags(test_path):

--- a/task-encoder/src/lib.rs
+++ b/task-encoder/src/lib.rs
@@ -346,11 +346,18 @@ pub trait TaskEncoder {
         }
 
         let value = task_key.clone();
-        let catch_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-            let mut deps = TaskEncoderDependencies::new();
-            let encode_result = Self::do_encode_full(&value, &mut deps);
-            (encode_result, deps)
-        }));
+        // The span stack is isolated across the encoder-context boundary: the
+        // encoding is demand-driven and cached, so its spans must not chain
+        // up to whatever span is ambient at the (first) demand site.
+        let catch_result = vir::with_vcx(|vcx| {
+            vcx.with_span_stack_isolated(|| {
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+                    let mut deps = TaskEncoderDependencies::new();
+                    let encode_result = Self::do_encode_full(&value, &mut deps);
+                    (encode_result, deps)
+                }))
+            })
+        });
 
         let (encode_result, deps) = catch_result.map_err(|panic_payload| {
             // There was a panic within the encoder. We want to report it

--- a/viper/tests/invalid_programs.rs
+++ b/viper/tests/invalid_programs.rs
@@ -27,13 +27,9 @@ fn consistency_error() {
             ast.seqn(&[ast.assert(ast.false_lit(), ast.no_position())], &[]),
         );
 
-        ast.seqn(
-            &[assignment, if_stmt],
-            &[
-                // consistency error: we omit the declaration of the local variable x
-                // ast.local_var_decl("x", ast.bool_type())
-            ],
-        )
+        // consistency error: we omit the declaration of the local variable x, i.e.
+        // `ast.local_var_decl("x", ast.bool_type())`
+        ast.seqn(&[assignment, if_stmt], &[])
     });
 }
 

--- a/vir/src/spans.rs
+++ b/vir/src/spans.rs
@@ -115,6 +115,24 @@ impl<'tcx> VirCtxt<'tcx> {
         res
     }
 
+    /// Execute the given function with an empty span stack, restoring the
+    /// current stack afterwards. Used when crossing an encoder-context
+    /// boundary (a task encoder starting to encode a new task): encodings are
+    /// demand-driven and cached, so without this the encoded item's spans
+    /// would be linked to whatever span happens to be ambient at the *first*
+    /// demand site, and error positions inside the shared encoding would
+    /// forever backtranslate to that first caller (e.g. every failing
+    /// `assert!` in a crate reporting its "failing precondition" note at the
+    /// first `assert!` encoded).
+    pub fn with_span_stack_isolated<T>(&'tcx self, f: impl FnOnce() -> T) -> T {
+        let saved = std::mem::take(&mut self.spans.borrow_mut().stack);
+        let res = f();
+        // Overwrite rather than assert emptiness: a panicking encoder (the
+        // panic is caught by the task encoder) leaves its pushed spans behind.
+        self.spans.borrow_mut().stack = saved;
+        res
+    }
+
     /// Add an error handler to the span currently on top of the stack.
     /// `error_kind` is the machine-readable identifier of an error, as
     /// defined by Viper. The handler function should construct one or more
@@ -124,7 +142,10 @@ impl<'tcx> VirCtxt<'tcx> {
         error_kind: &'static str,
         handler: impl Fn(Option<Span>) -> Option<Vec<PrustiError>> + 'tcx,
     ) {
-        let top_span_id = self.top_span().unwrap().id;
+        let top_span_id = self
+            .top_span()
+            .expect("an error handler must be registered under a span")
+            .id;
         let mut manager = self.spans.borrow_mut();
         let previous = manager.handlers.remove(&top_span_id);
         manager.handlers.insert(
@@ -163,18 +184,26 @@ impl<'tcx> VirCtxt<'tcx> {
         let reason_span_opt = reason_pos_id
             .and_then(|id| manager.all.get(id))
             .map(|vir_span| vir_span.span);
-        let mut span_opt = manager.all.get(offending_pos_id);
-        while let Some(span) = span_opt {
-            let mut handler_opt = manager.handlers.get(&span.id);
-            while let Some(handler) = handler_opt {
-                if handler.error_kind == error_kind {
-                    if let Some(errors) = (handler.handler)(reason_span_opt) {
-                        return errors;
+        // TODO: the `reason_pos_id` fallback works around Viper blaming the
+        //   *enclosing* node (e.g. method call statement) for a failed
+        //   well-definedness check of a native partial operation expression
+        //   (e.g. a sequence index), which leaves the expression that actually
+        //   failed in the `reason` rather than in the `offending` position.
+        //   See https://github.com/viperproject/silver/issues/928
+        for pos_id in [Some(offending_pos_id), reason_pos_id] {
+            let mut span_opt = pos_id.and_then(|id| manager.all.get(id));
+            while let Some(span) = span_opt {
+                let mut handler_opt = manager.handlers.get(&span.id);
+                while let Some(handler) = handler_opt {
+                    if handler.error_kind == error_kind {
+                        if let Some(errors) = (handler.handler)(reason_span_opt) {
+                            return errors;
+                        }
                     }
+                    handler_opt = handler.next.as_deref();
                 }
-                handler_opt = handler.next.as_deref();
+                span_opt = span.parent.as_ref();
             }
-            span_opt = span.parent.as_ref();
         }
         // No handler found for the error, this must be a bug. We'll try to provide a span at least.
         let span = manager

--- a/x.py
+++ b/x.py
@@ -206,8 +206,21 @@ def fmt_all():
         fmt_in(crate)
 
 def fmt_check_in(cwd):
-    """Run cargo fmt check in the given subproject."""
-    run_command(['cargo', 'fmt', '--', '--check'], cwd=cwd)
+    """Run cargo fmt check in the given subproject, failing on any error.
+
+    Errors which rustfmt reports without failing itself are how it says that
+    it could not format something, e.g. that formatting a construct would drop
+    one of its comments and that it therefore left the entire enclosing
+    expression (and thus all of the code within it) exactly as it found it.
+    """
+    completed = run_command(['cargo', 'fmt', '--', '--check'], cwd=cwd,
+                            capture_output=True)
+    stderr = completed.stderr.decode()
+    sys.stdout.write(completed.stdout.decode())
+    sys.stderr.write(stderr)
+    # e.g. `error[internal]: not formatted because a comment would be lost`
+    if any(line.startswith('error') for line in stderr.splitlines()):
+        error('rustfmt reported errors in {}, see above.', cwd)
 
 def fmt_check_all():
     """Run rustfmt check on all formatted files."""


### PR DESCRIPTION
Error positions inside demand-driven, cached encodings (e.g. an extern spec's contract) were linked to whatever span was ambient at the first demand site, so e.g. every failing `assert!` in a crate reported its "failing precondition" note at the first `assert!` encoded. Fixed by:

- isolating the span stack when a task encoder starts a new task (the sentinel anticipated by the TODO in vir/src/spans.rs)
- reifying precondition expressions inside their spec's span scope (postconditions already did this)
- encoding pure/spec bodies under the body's span (falling back to the definition's span for cross-crate bodies, whose deserialized MIR has no spans), refined per statement, and creating the outer "pure body" lazy wrapper in that scope: reify passes `span` through, so the wrapper's span is the top-level position of every reified contract

A failing precondition of a call the user did not write (e.g. the `core::panicking::panic` call inside a failing `assert!`) is now reported at the macro invocation that produced it, naming the called function, instead of pointing "precondition might not hold" at an invisible call. Calls written by the user (including in macro arguments, which keep their own spans) are reported as before.

Also, set `error_on_unformatted` to `true` to report any blocks of code that `fmt` skips and if there are some changed the CI to fail.