### PR TITLE
Implement ptr-to-ptr casts and impure place encoding for raw pointers

### DIFF
--- a/prusti-encoder/src/encoders/builtin/cast.rs
+++ b/prusti-encoder/src/encoders/builtin/cast.rs
@@ -93,7 +93,7 @@ impl TaskEncoder for MirBuiltinCastEnc {
         let name = match kind {
             mir::CastKind::PointerCoercion(ty::adjustment::PointerCoercion::Unsize, ..) => "unsize",
             mir::CastKind::IntToInt => "i2i",
-            mir::CastKind::PtrToPtr => "ptr2ptr",
+            mir::CastKind::PtrToPtr => "p2p",
             other => todo!("cast kind {other:?}"),
         };
         // The unsize cast/methods don't depend on the pointee type (the methods
@@ -154,7 +154,6 @@ impl TaskEncoder for MirBuiltinCastEnc {
                     };
                     let expr = e_res_ty.prim_to_snap(wrapped);
 
-                    // A value-level (thin) cast: no generic parameters, no precondition.
                     let fn_idn = FunctionIdn::new(name, op_ty_snap, res_ty_snap);
                     let function = vcx.mk_function(fn_idn, (arg_decl,), &[], &[], None, Some(expr));
                     (
@@ -174,7 +173,6 @@ impl TaskEncoder for MirBuiltinCastEnc {
                         e_op_ty.metadata_access(arg_ex),
                     );
 
-                    // A value-level (thin) cast: no generic parameters, no precondition.
                     let fn_idn = FunctionIdn::new(name, op_ty_snap, res_ty_snap);
                     let function = vcx.mk_function(fn_idn, (arg_decl,), &[], &[], None, Some(expr));
                     (

--- a/prusti-encoder/src/encoders/builtin/cast.rs
+++ b/prusti-encoder/src/encoders/builtin/cast.rs
@@ -93,6 +93,7 @@ impl TaskEncoder for MirBuiltinCastEnc {
         let name = match kind {
             mir::CastKind::PointerCoercion(ty::adjustment::PointerCoercion::Unsize, ..) => "unsize",
             mir::CastKind::IntToInt => "i2i",
+            mir::CastKind::PtrToPtr => "ptr2ptr",
             other => todo!("cast kind {other:?}"),
         };
         // The unsize cast/methods don't depend on the pointee type (the methods
@@ -152,6 +153,26 @@ impl TaskEncoder for MirBuiltinCastEnc {
                         }
                     };
                     let expr = e_res_ty.prim_to_snap(wrapped);
+
+                    // A value-level (thin) cast: no generic parameters, no precondition.
+                    let fn_idn = FunctionIdn::new(name, op_ty_snap, res_ty_snap);
+                    let function = vcx.mk_function(fn_idn, (arg_decl,), &[], &[], None, Some(expr));
+                    (
+                        MirBuiltinCastLocal {
+                            cast: function,
+                            unsize: None,
+                            undo: None,
+                        },
+                        MirBuiltinCastOutput::Simple(fn_idn),
+                    )
+                }
+                mir::CastKind::PtrToPtr => {
+                    let e_op_ty = op_ty.expect_raw();
+                    let e_res_ty = res_ty.expect_raw();
+                    let expr = e_res_ty.prim_to_snap(
+                        e_op_ty.address_access(arg_ex),
+                        e_op_ty.metadata_access(arg_ex),
+                    );
 
                     // A value-level (thin) cast: no generic parameters, no precondition.
                     let fn_idn = FunctionIdn::new(name, op_ty_snap, res_ty_snap);

--- a/prusti-encoder/src/encoders/builtin/use_cast.rs
+++ b/prusti-encoder/src/encoders/builtin/use_cast.rs
@@ -1,5 +1,5 @@
 use prusti_rustc_interface::middle::mir;
-use task_encoder::{EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
+use task_encoder::{EncodeFullError, EncodeFullResult, TaskEncoder, TaskEncoderDependencies};
 use vir::FunctionIdn;
 
 use crate::encoders::{
@@ -53,6 +53,11 @@ impl<'vir> MirBuiltinUseCastTask<'vir> {
 pub enum MirBuiltinUseCastOutput<'vir> {
     Simple(FunctionIdn<'vir, vir::CSnap, vir::CSnap>),
     Unsize(MirBuiltinUnsize<'vir>),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum MirBuiltinUseCastError {
+    UnsupportedTransmute,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -112,6 +117,7 @@ impl TaskEncoder for MirBuiltinUseCastEnc {
 
     type TaskDescription<'vir> = MirBuiltinUseCastTask<'vir>;
 
+    type EncodingError = MirBuiltinUseCastError;
     type OutputFullDependency<'vir> = MirBuiltinUseCastOutput<'vir>;
 
     fn task_to_key<'vir>(task: &Self::TaskDescription<'vir>) -> Self::TaskKey<'vir> {
@@ -133,6 +139,20 @@ impl TaskEncoder for MirBuiltinUseCastEnc {
             kind,
             operand_ty: operand_ty.ty,
         };
+
+        // a mismatch of the referent type when performing a raw pointer cast
+        // is essentially a transmute, which we don't support yet; we have to
+        // report the error here because we still have the generic parameters
+        // for the raw pointers here
+        if kind == mir::CastKind::PtrToPtr
+            && result_ty.args.args()[0].as_type() != operand_ty.args.args()[0].as_type()
+        {
+            return Err(EncodeFullError::EncodingError(
+                MirBuiltinUseCastError::UnsupportedTransmute,
+                None,
+            ));
+        }
+
         let cast = deps.require_dep::<MirBuiltinCastEnc>(task)?;
         match cast {
             MirBuiltinCastOutput::Simple(fn_idn) => {

--- a/prusti-encoder/src/encoders/mir_impure.rs
+++ b/prusti-encoder/src/encoders/mir_impure.rs
@@ -1270,6 +1270,15 @@ impl<'vir, 'enc, E: TaskEncoder> ImpureEncVisitor<'vir, 'enc, E> {
                             snap: None,
                         }
                     }
+                    ty::TyKind::RawPtr(..) => {
+                        let ref_snap = e_ty.ref_to_snap(expr.address).downcast_ty();
+                        let p_ty = self.ty_use_pure(place_ty.ty).expect_raw();
+                        PlaceExpr {
+                            address: p_ty.address_access(ref_snap),
+                            metadata: Some(p_ty.metadata_access(ref_snap)),
+                            snap: None,
+                        }
+                    }
                     _ => unreachable!(),
                 }
             }

--- a/prusti-tests/tests/verify/fail/unsafe/ptr_ty_cast.rs
+++ b/prusti-tests/tests/verify/fail/unsafe/ptr_ty_cast.rs
@@ -2,8 +2,8 @@ use prusti_contracts::*;
 
 fn main() {
     let mut x = 5;
-    let p_x = &raw const x;
-    let p_x = p_x as *mut i32;
+    let p_x = &raw mut x;
+    let p_x = p_x as *mut i8;
     unsafe { *p_x = 6 };
     prusti_assert!(x == 6);
 }

--- a/prusti-tests/tests/verify/fail/unsafe/ptr_ty_cast.rs
+++ b/prusti-tests/tests/verify/fail/unsafe/ptr_ty_cast.rs
@@ -1,9 +1,0 @@
-use prusti_contracts::*;
-
-fn main() {
-    let mut x = 5;
-    let p_x = &raw mut x;
-    let p_x = p_x as *mut i8;
-    unsafe { *p_x = 6 };
-    prusti_assert!(x == 6);
-}

--- a/prusti-tests/tests/verify/fail/unsupported/rawptr_cast.rs
+++ b/prusti-tests/tests/verify/fail/unsupported/rawptr_cast.rs
@@ -1,0 +1,10 @@
+use prusti_contracts::*;
+
+fn main() {
+    let mut x = 5i32;
+    let p_x = &raw mut x;
+    let p_x = p_x as *mut i8; //~ERROR: unsupported rvalue
+    unsafe {
+        *p_x = 6;
+    }
+}

--- a/prusti-tests/tests/verify/pass/casts/ptr_to_ptr.rs
+++ b/prusti-tests/tests/verify/pass/casts/ptr_to_ptr.rs
@@ -1,0 +1,9 @@
+use prusti_contracts::*;
+
+fn main() {
+    let mut x = 5;
+    let p_x = &raw const x;
+    let p_x = p_x as *mut i32;
+    unsafe {*p_x = 6};
+    prusti_assert!(x == 6);
+}

--- a/prusti-tests/tests/verify/pass/casts/ptr_to_ptr.rs
+++ b/prusti-tests/tests/verify/pass/casts/ptr_to_ptr.rs
@@ -4,6 +4,8 @@ fn main() {
     let mut x = 5;
     let p_x = &raw const x;
     let p_x = p_x as *mut i32;
-    unsafe { *p_x = 6 };
+    unsafe {
+        *p_x = 6;
+    }
     prusti_assert!(x == 6);
 }


### PR DESCRIPTION
This PR implements ptr-to-ptr casts and the impure place encoding for raw pointers. Without proper support for raw pointers, many cases will still fail verification. However, some of the stdlib doctests work with raw pointers and this PR fixes crashing on such cases (it was easier to implement this rather than to find some workaround to fail gracefully). 